### PR TITLE
Type bug fix

### DIFF
--- a/src/include/mscclpp.h
+++ b/src/include/mscclpp.h
@@ -17,9 +17,9 @@
 extern "C" {
 #endif
 
-typedef enum { mscclppData = 0x1,
-               mscclppFlag = 0x2,
-               mscclppSync = 0x4} mscclppTriggerType_t;
+typedef enum : uint64_t { mscclppData = 0x1,
+                          mscclppFlag = 0x2,
+                          mscclppSync = 0x4} mscclppTriggerType_t;
 
 #define MSCCLPP_SIZE_BITS 30
 #define MSCCLPP_OFFSET_BITS 31


### PR DESCRIPTION
Need to force `mscclppTriggerType_t` type as `uint64_t` so that it doesn't become singed integer by the compiler.