### PR TITLE
IB inline send for flags

### DIFF
--- a/src/include/ib.h
+++ b/src/include/ib.h
@@ -8,9 +8,10 @@
 #include <string>
 
 #define MSCCLPP_IB_CQ_SIZE 1024
-#define MSCCLPP_IB_CQ_POLL_NUM 4
+#define MSCCLPP_IB_CQ_POLL_NUM 1
 #define MSCCLPP_IB_MAX_SENDS 64
 #define MSCCLPP_IB_MAX_DEVS 8
+#define MSCCLPP_IB_MAX_INLINE_DATA 8
 
 // MR info to be shared with the remote peer
 struct mscclppIbMrInfo
@@ -52,9 +53,10 @@ struct mscclppIbQp
   int rtr(const mscclppIbQpInfo* info);
   int rts();
   int stageSend(struct mscclppIbMr* ibMr, const mscclppIbMrInfo* info, uint32_t size, uint64_t wrId, uint64_t srcOffset,
-                uint64_t dstOffset, bool signaled);
+                uint64_t dstOffset, bool signaledFlag, bool inlineFlag);
   int stageSendWithImm(struct mscclppIbMr* ibMr, const mscclppIbMrInfo* info, uint32_t size, uint64_t wrId,
-                       uint64_t srcOffset, uint64_t dstOffset, bool signaled, unsigned int immData);
+                       uint64_t srcOffset, uint64_t dstOffset, bool signaledFlag, bool inlineFlag,
+                       unsigned int immData);
   int postSend();
   int postRecv(uint64_t wrId);
   int pollCq();

--- a/src/init.cc
+++ b/src/init.cc
@@ -180,7 +180,7 @@ mscclppResult_t mscclppCommDestroy(mscclppComm_t comm)
   for (int i = 0; i < comm->nConns; i++) {
     struct mscclppConn* conn = &comm->conns[i];
     if (conn) {
-      MSCCLPPCHECK(mscclppCudaFree(conn->devConn->sendEpochId));
+      MSCCLPPCHECK(mscclppCudaHostFree(conn->devConn->sendEpochId));
       MSCCLPPCHECK(mscclppCudaFree(conn->devConn->recvEpochId));
     }
   }
@@ -374,7 +374,7 @@ mscclppResult_t mscclppConnect(mscclppComm_t comm, int remoteRank, int tag, void
 
   conn->devConn = devConn;
   conn->devConn->localBuff = localBuff;
-  MSCCLPPCHECK(mscclppCudaCalloc(&conn->devConn->sendEpochId, 1));
+  MSCCLPPCHECK(mscclppCudaHostCalloc(&conn->devConn->sendEpochId, 1));
   MSCCLPPCHECK(mscclppCudaCalloc(&conn->devConn->recvEpochId, 1));
   conn->devConn->remoteRank = remoteRank;
   conn->devConn->tag = tag;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -106,7 +106,7 @@ void* mscclppProxyService(void* _args)
         conn->ibQp->stageSend(conn->ibBuffMr, &conn->ibBuffMrInfo, (uint32_t)trigger.fields.dataSize,
                               /*wrId=*/0, /*srcOffset=*/trigger.fields.srcDataOffset,
                               /*dstOffset=*/trigger.fields.dstDataOffset,
-                              /*signaled=*/false);
+                              /*signaled=*/false, /*inlineFlag=*/false);
         if ((ret = conn->ibQp->postSend()) != 0) {
           // Return value is errno.
           WARN("data postSend failed: errno %d", ret);
@@ -121,7 +121,7 @@ void* mscclppProxyService(void* _args)
       } else {
         // My local flag is copied to the peer's proxy flag
         conn->ibQp->stageSend(conn->ibLocalFlagMr, &conn->ibProxyFlagMrInfo, sizeof(uint64_t),
-                              /*wrId=*/0, /*srcOffset=*/0, /*dstOffset=*/0, /*signaled=*/true);
+                              /*wrId=*/0, /*srcOffset=*/0, /*dstOffset=*/0, /*signaledFlag=*/true, /*inlineFlag=*/true);
         if ((ret = conn->ibQp->postSend()) != 0) {
           WARN("flag postSend failed: errno %d", ret);
         }


### PR DESCRIPTION
* Use `IBV_SEND_INLINE` for sending flags
* To achieve above, alloc `sendEpochId` on host memory
* Other minor changes