### PR TITLE
Fix crash in static variable deconstructor

### DIFF
--- a/src/utils_internal.cc
+++ b/src/utils_internal.cc
@@ -95,6 +95,7 @@ uint64_t computeHostHash(void) {
 
 uint64_t getHostHash(void) {
   thread_local std::unique_ptr<uint64_t> hostHash = std::make_unique<uint64_t>(computeHostHash());
+  // avoid crash on static destruction
   if (hostHash == nullptr) {
     hostHash = std::make_unique<uint64_t>(computeHostHash());
   }
@@ -123,6 +124,7 @@ uint64_t computePidHash(void) {
 
 uint64_t getPidHash(void) {
   thread_local std::unique_ptr<uint64_t> pidHash = std::make_unique<uint64_t>(computePidHash());
+  // avoid crash on static destruction
   if (pidHash == nullptr) {
     pidHash = std::make_unique<uint64_t>(computePidHash());
   }

--- a/src/utils_internal.cc
+++ b/src/utils_internal.cc
@@ -95,6 +95,9 @@ uint64_t computeHostHash(void) {
 
 uint64_t getHostHash(void) {
   thread_local std::unique_ptr<uint64_t> hostHash = std::make_unique<uint64_t>(computeHostHash());
+  if (hostHash == nullptr) {
+    hostHash = std::make_unique<uint64_t>(computeHostHash());
+  }
   return *hostHash;
 }
 
@@ -120,6 +123,9 @@ uint64_t computePidHash(void) {
 
 uint64_t getPidHash(void) {
   thread_local std::unique_ptr<uint64_t> pidHash = std::make_unique<uint64_t>(computePidHash());
+  if (pidHash == nullptr) {
+    pidHash = std::make_unique<uint64_t>(computePidHash());
+  }
   return *pidHash;
 }
 


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/utility/program/exit
`The last destructor for thread-local objects is [sequenced-before](https://en.cppreference.com/w/cpp/language/eval_order) the first destructor for a static object.`
Change the code to avoid this case.