### PR TITLE
Increase MSCCLPP_BITS_REGMEM_HANDLE to 9

### DIFF
--- a/include/mscclpp/proxy_channel_device.hpp
+++ b/include/mscclpp/proxy_channel_device.hpp
@@ -22,7 +22,7 @@ const TriggerType TriggerSync = 0x4;  // Trigger a flush.
 
 #define MSCCLPP_BITS_SIZE 32
 #define MSCCLPP_BITS_OFFSET 32
-#define MSCCLPP_BITS_REGMEM_HANDLE 8
+#define MSCCLPP_BITS_REGMEM_HANDLE 9
 #define MSCCLPP_BITS_TYPE 3
 #define MSCCLPP_BITS_CONNID 10
 #define MSCCLPP_BITS_FIFO_RESERVED 1


### PR DESCRIPTION
MSCCLPP_BITS_REGMEM_HANDLE=8 limits the number registered memories for a ProxyService to 256. Many use cases, such as KV cache transfer, require registering more tensors.

This change allows registering up-to 512 memories. Note that this change uses up the slack bits remaining in the ChannelTrigger struct.