### PR TITLE
Seperate headers for GPU data types 

### DIFF
--- a/include/mscclpp/gpu.hpp
+++ b/include/mscclpp/gpu.hpp
@@ -7,9 +7,10 @@
 #if defined(__HIP_PLATFORM_AMD__)
 
 // Temporal fix for rocm-6.0.0-12969
-#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
+#include <hip/hip_version.h>
+#if (HIP_VERSION > 60012969)
 #include <hip/hip_bf16.h>
-#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
+#endif  // (HIP_VERSION > 60012969)
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 

--- a/include/mscclpp/gpu.hpp
+++ b/include/mscclpp/gpu.hpp
@@ -6,7 +6,10 @@
 
 #if defined(__HIP_PLATFORM_AMD__)
 
+// Temporal fix for rocm-6.0.0-12969
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
 #include <hip/hip_bf16.h>
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 

--- a/include/mscclpp/gpu.hpp
+++ b/include/mscclpp/gpu.hpp
@@ -6,12 +6,6 @@
 
 #if defined(__HIP_PLATFORM_AMD__)
 
-// Temporal fix for rocm-6.0.0-12969
-#include <hip/hip_version.h>
-#if (HIP_VERSION > 60012969)
-#include <hip/hip_bf16.h>
-#endif  // (HIP_VERSION > 60012969)
-#include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 
 using cudaError_t = hipError_t;
@@ -96,14 +90,7 @@ constexpr auto CU_MEM_ACCESS_FLAGS_PROT_READWRITE = hipMemAccessFlagsProtReadWri
 #else
 
 #include <cuda.h>
-#include <cuda_fp16.h>
 #include <cuda_runtime.h>
-#if (CUDART_VERSION >= 11000)
-#include <cuda_bf16.h>
-#endif
-#if (CUDART_VERSION >= 11080)
-#include <cuda_fp8.h>
-#endif
 
 #endif
 

--- a/include/mscclpp/gpu_data_types.hpp
+++ b/include/mscclpp/gpu_data_types.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#ifndef MSCCLPP_GPU_DATA_TYPES_HPP_
+#define MSCCLPP_GPU_DATA_TYPES_HPP_
+
+#if defined(__HIP_PLATFORM_AMD__)
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+
+#else
+
+#include <cuda_fp16.h>
+#if (CUDART_VERSION >= 11000)
+#include <cuda_bf16.h>
+#endif
+#if (CUDART_VERSION >= 11080)
+#include <cuda_fp8.h>
+#endif
+
+#endif
+
+#endif  // MSCCLPP_GPU_DATA_TYPES_HPP_

--- a/include/mscclpp/nvls_device.hpp
+++ b/include/mscclpp/nvls_device.hpp
@@ -5,6 +5,7 @@
 #define MSCCLPP_NVLS_DEVICE_HPP_
 
 #include <mscclpp/gpu.hpp>
+#include <mscclpp/gpu_data_types.hpp>
 #include <type_traits>
 
 #include "device.hpp"

--- a/src/include/execution_kernel.hpp
+++ b/src/include/execution_kernel.hpp
@@ -8,6 +8,7 @@
 #include <mscclpp/packet_device.hpp>
 #include <mscclpp/proxy_channel.hpp>
 #include <mscclpp/sm_channel.hpp>
+#include <mscclpp/gpu_data_types.hpp>
 
 #include "execution_common.hpp"
 

--- a/src/include/execution_kernel.hpp
+++ b/src/include/execution_kernel.hpp
@@ -5,10 +5,10 @@
 #define MSCCLPP_EXECUTION_KERNEL_HPP_
 
 #include <mscclpp/executor.hpp>
+#include <mscclpp/gpu_data_types.hpp>
 #include <mscclpp/packet_device.hpp>
 #include <mscclpp/proxy_channel.hpp>
 #include <mscclpp/sm_channel.hpp>
-#include <mscclpp/gpu_data_types.hpp>
 
 #include "execution_common.hpp"
 


### PR DESCRIPTION
Prevent unnecessarily including data type headers in everywhere.