### PR TITLE
signal/poll optimization

### DIFF
--- a/include/mscclpp/proxy_channel_device.hpp
+++ b/include/mscclpp/proxy_channel_device.hpp
@@ -114,6 +114,11 @@ struct ProxyChannelDeviceHandle {
 
   /// Push a @ref TriggerFlag to the FIFO.
   MSCCLPP_DEVICE_INLINE void signal() { fifo_.push(ChannelTrigger(TriggerFlag, 0, 0, 0, 0, 1, semaphoreId_).value); }
+  
+  MSCCLPP_DEVICE_INLINE void signal(const uint64_t count) {
+    for (uint64_t i = 0; i < count; ++i)
+      fifo_.push(ChannelTrigger(TriggerFlag, 0, 0, 0, 0, 1, semaphoreId_).value); 
+  }
 
   /// Push a @ref TriggerData and a @ref TriggerFlag at the same time to the FIFO.
   /// @param dst The destination memory region.
@@ -165,8 +170,9 @@ struct ProxyChannelDeviceHandle {
   }
 
   /// Check if the proxy channel has been signaled.
+  /// @param max_poll The max number of signals to poll.
   /// @return true if the proxy channel has been signaled.
-  MSCCLPP_DEVICE_INLINE bool poll() { return semaphore_.poll(); }
+  MSCCLPP_DEVICE_INLINE uint64_t poll(const int64_t max_poll = 1) { return semaphore_.poll(max_poll); }
 
   /// Wait for the proxy channel to be signaled.
   /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
@@ -195,7 +201,7 @@ struct SimpleProxyChannelDeviceHandle {
   MSCCLPP_DEVICE_INLINE void put(uint64_t offset, uint64_t size) { put(offset, offset, size); }
 
   /// Push a @ref TriggerFlag to the FIFO.
-  MSCCLPP_DEVICE_INLINE void signal() { proxyChan_.signal(); }
+  MSCCLPP_DEVICE_INLINE void signal(const uint64_t count = 1) { proxyChan_.signal(count); }
 
   /// Push a @ref TriggerData and a @ref TriggerFlag at the same time to the FIFO.
   /// @param dstOffset The offset into the destination memory region.
@@ -229,8 +235,9 @@ struct SimpleProxyChannelDeviceHandle {
   MSCCLPP_DEVICE_INLINE void flush() { proxyChan_.flush(); }
 
   /// Check if the proxy channel has been signaled.
+  /// @param max_poll The max number of signals to poll.
   /// @return true if the proxy channel has been signaled.
-  MSCCLPP_DEVICE_INLINE bool poll() { return proxyChan_.poll(); }
+  MSCCLPP_DEVICE_INLINE uint64_t poll(const int64_t max_poll = 1) { return proxyChan_.poll(max_poll); }
 
   /// Wait for the proxy channel to be signaled.
   /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.

--- a/include/mscclpp/sm_channel_device.hpp
+++ b/include/mscclpp/sm_channel_device.hpp
@@ -243,7 +243,7 @@ struct SmChannelDeviceHandle {
   /// This function guarantees that all the memory operation before this function is completed before the remote
   /// semaphore is signaled.
   ///
-  MSCCLPP_DEVICE_INLINE void signal() { semaphore_.signal(); }
+  MSCCLPP_DEVICE_INLINE void signal(uint64_t count = 1) { semaphore_.signal(count); }
 
   /// Signal the remote semaphore.
   ///
@@ -267,8 +267,9 @@ struct SmChannelDeviceHandle {
   MSCCLPP_DEVICE_INLINE uint64_t semaphoreGetLocal() const { return semaphore_.semaphoreGetLocal(); }
 
   /// Check if the remote semaphore has signaled.
+  /// @param max_poll The max number of signals to poll.
   /// @return true if the remote semaphore has signaled.
-  MSCCLPP_DEVICE_INLINE bool poll() { return semaphore_.poll(); }
+  MSCCLPP_DEVICE_INLINE uint64_t poll(const int64_t max_poll = 1) { return semaphore_.poll(max_poll); }
 
   /// Wait for the remote semaphore to send a signal.
   /// @param maxSpinCount The maximum number of spins before asserting. Never assert if negative.


### PR DESCRIPTION
Hi, it would be great if the sm/proxy channel can support signal/poll multiple times in one function call. The code changes in this PR supports the functionality without disrupting existing usage, i.e., `signal()` and `poll()` work as before.
- `signal(n)` sends n signals down the channel. For sm channel, this avoids doing `atomicLoad` multiple times on the semaphore.
- `x = poll(n)` polls up to n signals from the channel and returns the actual number of signals polled. It returns 0 if n<=0.
- `signal()` and `poll()` are equivalent to `signal(1)` and `poll(1)`, which are the default arguments.