### PR TITLE
Fixing Bug Const Offset in Execution Plan

### DIFF
--- a/src/executor/execution_plan.cc
+++ b/src/executor/execution_plan.cc
@@ -291,11 +291,11 @@ void ExecutionPlan::Impl::setupChannels(const json& gpus) {
   }
 }
 
-void ExecutionPlan::Impl::setupOperations(const json& gpus, size_t contsSrcOffset, size_t constDstOffset) {
+void ExecutionPlan::Impl::setupOperations(const json& gpus, size_t constSrcOffset, size_t constDstOffset) {
   auto getConstOffset = [&](BufferType type) -> size_t {
     switch (type) {
       case BufferType::INPUT:
-        return contsSrcOffset;
+        return constSrcOffset;
       case BufferType::OUTPUT:
         return constDstOffset;
       case BufferType::SCRATCH:


### PR DESCRIPTION
The offset was not differentiating between the buffer types, causing the offset to be incorrect when the buffer type was not `SCRATCH`.