### PR TITLE
Fix mscclpp_benchmark

### DIFF
--- a/python/mscclpp/comm.py
+++ b/python/mscclpp/comm.py
@@ -99,7 +99,7 @@ class CommGroup:
             else:
                 endpoint = endpoints
             if endpoint.transport == Transport.Nvls:
-                return connect_nvls_collective(self.communicator, all_ranks)
+                return connect_nvls_collective(self.communicator, all_ranks, 2**30)
             else:
                 connections[rank] = self.communicator.connect_on_setup(rank, 0, endpoint)
         self.communicator.setup()

--- a/python/mscclpp_benchmark/allreduce_bench.py
+++ b/python/mscclpp_benchmark/allreduce_bench.py
@@ -289,7 +289,7 @@ if __name__ == "__main__":
     mscclpp_algbw = []
     nccl_algbw = []
     speed_ups = []
-    end_range = 28 if is_nvls_supported() else 29
+    end_range = 29
     for i in range(10, end_range):
         if MPI.COMM_WORLD.size // N_GPUS_PER_NODE == 1:
             nelems = 2**i


### PR DESCRIPTION
Enable 1GB message size for NVLS transport in mscclpp_benchmark