### PR TITLE
Fix synchronization in allreduce8 kernel

### DIFF
--- a/apps/nccl/src/allreduce.hpp
+++ b/apps/nccl/src/allreduce.hpp
@@ -363,8 +363,8 @@ __global__ void __launch_bounds__(512, 1)
   // we can use double buffering to hide synchronization overhead
   for (size_t itr = 0; itr < nItrs; itr++) {
     if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
-      channels[threadIdx.x].signal();
-      channels[threadIdx.x].wait();
+      outChannels[threadIdx.x].signal();
+      outChannels[threadIdx.x].wait();
     }
     __syncthreads();
     // Starts allgather
@@ -381,8 +381,8 @@ __global__ void __launch_bounds__(512, 1)
     // Ensure that all writes of this block have been issued before issuing the signal
     __syncthreads();
     if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
-      channels[threadIdx.x].signal();
-      channels[threadIdx.x].wait();
+      outChannels[threadIdx.x].signal();
+      outChannels[threadIdx.x].wait();
     }
     __syncthreads();
 
@@ -405,8 +405,8 @@ __global__ void __launch_bounds__(512, 1)
   }
   if (restNInt4 > 0) {
     if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
-      channels[threadIdx.x].signal();
-      channels[threadIdx.x].wait();
+      outChannels[threadIdx.x].signal();
+      outChannels[threadIdx.x].wait();
     }
     __syncthreads();
     for (size_t idx = threadIdx.x; idx < restNInt4; idx += blockDim.x) {
@@ -421,8 +421,8 @@ __global__ void __launch_bounds__(512, 1)
     // Ensure that all writes of this block have been issued before issuing the signal
     __syncthreads();
     if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
-      channels[threadIdx.x].signal();
-      channels[threadIdx.x].wait();
+      outChannels[threadIdx.x].signal();
+      outChannels[threadIdx.x].wait();
     }
     __syncthreads();
 


### PR DESCRIPTION
Running kernel allreduce8 across 64 vGPUs (in CPX mode) revealed a synchronization bug. The PR addresses it by ensuring that signals are only issued after all threads in the block have issued their writes to guarantee correct ordering between data writes and signal writes.