### PR TITLE
Scratch buffer copy-based implementation of ncclBcast / ncclBroadcast

### DIFF
--- a/apps/nccl/src/broadcast.hpp
+++ b/apps/nccl/src/broadcast.hpp
@@ -24,7 +24,6 @@ __global__ void __launch_bounds__(1024, 1)
   const size_t nWarp = nThread / WARP_SIZE;
   const size_t nPeer = nRanksPerNode - 1;
   const size_t chanOffset = nPeer * blockIdx.x;
-  //auto smChans = smChannels + chanOffset;
   
   __shared__ mscclpp::DeviceHandle<mscclpp::SmChannel> smChans[NRANKS_PER_NODE - 1];
   if(threadIdx.x < nPeer) {
@@ -34,45 +33,34 @@ __global__ void __launch_bounds__(1024, 1)
   }
   __syncthreads();
 
-  //const size_t peerIdx = blockIdx.x;
   const size_t peerRootIdx = (root == rank) ? nPeer : ((root < rank) ? root : (root - 1));
 
   const size_t bytesPerGPU = nelemsPerGPU * sizeof(int);
-  //const size_t bytes = bytesPerGPU * nPeer;
   const size_t bytes = bytesPerGPU;
-  size_t unitBytesPerThread = 16;
-  //if (bytes >= nThread * 64) {
-  //  unitBytesPerThread = 64;
-  //} else {
-  //  unitBytesPerThread = 16;
-  //}
-  //const size_t unitBytesPerWarp = unitBytesPerThread * WARP_SIZE;
-  //const size_t unitBytes = unitBytesPerWarp * nWarp;
+  size_t unitBytesPerThread;
+  if (bytes*nPeer >= nThread * 64) {
+    unitBytesPerThread = 64;
+  } else {
+    unitBytesPerThread = 16;
+  }
   const size_t unitBytesPerBlock = unitBytesPerThread * blockDim.x;
   const size_t unitBytes = unitBytesPerBlock * gridDim.x;
   const size_t nLoop = bytes / unitBytes;
-  //printf("nLoop = %ld, bytes = %ld, unitBytes = %ld\n", nLoop, bytes, unitBytes);
 
   if (nLoop > 0) {
     // First loop unrolling
-    //const size_t peerIdx = wid % nPeer;
-    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
-    const size_t offset = blockIdx.x * unitBytesPerBlock ; //(wid / nPeer) * unitBytesPerWarp;
+    const size_t offset = blockIdx.x * unitBytesPerBlock;
     if(rank == root) {
       if constexpr (IsOutOfPlace) {
       } else {
 	  for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
             char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
             char* send_ = reinterpret_cast<char*>(sendbuff);
-            //char *recv_ = reinterpret_cast<char*>(recvbuff);
-            //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
-            //                                 WARP_SIZE);
             smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
                                              blockDim.x);
             __syncthreads();
 	    if(threadIdx.x == peerIdx)
               smChans[peerIdx].signal();
-            //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
           }
       }
     } else { // rank != root.
@@ -81,37 +69,27 @@ __global__ void __launch_bounds__(1024, 1)
 	if(threadIdx.x == peerRootIdx)
           smChans[peerRootIdx].wait();
 	__syncthreads();
-        //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
-        //char* send_ = reinterpret_cast<char*>(sendbuff);
         char *recv_ = reinterpret_cast<char*>(recvbuff);
 	char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
         smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
                                          blockDim.x);
-        //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
-        //                                 WARP_SIZE);
       } 
     }
   }
 
   for (size_t i = 1; i < nLoop ; ++i) {
-    //const size_t peerIdx = wid % nPeer;
-    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
-    const size_t offset = blockIdx.x * unitBytesPerBlock + i * unitBytes; //(wid / nPeer) * unitBytesPerWarp;
+    const size_t offset = blockIdx.x * unitBytesPerBlock + i * unitBytes;
     if(rank == root) {
       if constexpr (IsOutOfPlace) {
       } else {
 	  for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
             char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
             char* send_ = reinterpret_cast<char*>(sendbuff);
-            //char *recv_ = reinterpret_cast<char*>(recvbuff);
-            //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
-            //                                 WARP_SIZE);
             smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
                                              blockDim.x);
             __syncthreads();
 	    if(threadIdx.x == peerIdx)
               smChans[peerIdx].signal();
-            //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
           }
       }
     } else { // rank != root.
@@ -120,21 +98,15 @@ __global__ void __launch_bounds__(1024, 1)
 	if(threadIdx.x == peerRootIdx)
           smChans[peerRootIdx].wait();
 	__syncthreads();
-        //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
-        //char* send_ = reinterpret_cast<char*>(sendbuff);
         char *recv_ = reinterpret_cast<char*>(recvbuff);
 	char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
         smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
                                          blockDim.x);
-        //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
-        //                                 WARP_SIZE);
       } 
     }
   }
 
   if (bytes % unitBytes > 0) { // remainder.
-    //const size_t peerIdx = wid % nPeer;
-    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
     const size_t offset = blockIdx.x * unitBytesPerBlock + nLoop * unitBytes;
     const size_t remainBytes = (offset < bytes ) ?  (bytes - offset) : 0;
     if(remainBytes > 0) {	  
@@ -144,15 +116,11 @@ __global__ void __launch_bounds__(1024, 1)
             for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
               char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
               char* send_ = reinterpret_cast<char*>(sendbuff);
-              //char *recv_ = reinterpret_cast<char*>(recvbuff);
-              //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
-              //                                 WARP_SIZE);
               smChans[peerIdx].copy<16, true>(dst + offset, send_ + offset, remainBytes, threadIdx.x,
                                                blockDim.x);
               __syncthreads();
               if(threadIdx.x == peerIdx)
                 smChans[peerIdx].signal();
-              //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
             }
         }
       } else { // rank != root.
@@ -161,64 +129,14 @@ __global__ void __launch_bounds__(1024, 1)
           if(threadIdx.x == peerRootIdx)
             smChans[peerRootIdx].wait();
           __syncthreads();
-          //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
-          //char* send_ = reinterpret_cast<char*>(sendbuff);
           char *recv_ = reinterpret_cast<char*>(recvbuff);
           char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
           smChans[peerRootIdx].copy<16, true>(recv_ + offset, scratch_ + offset, remainBytes, threadIdx.x,
                                            blockDim.x);
-          //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
-          //                                 WARP_SIZE);
         } 
       }
     } // remainBytes > 0.
   }
-
-
-
-//  if(rank == root) {
-//  for (size_t i = 1; i < nLoop; ++i) {
-//    const size_t gWid = wid + i * nWarp;
-//    const size_t peerIdx = gWid % nPeer;
-//    const size_t offset = (gWid / nPeer) * unitBytesPerWarp;
-//    if constexpr (IsOutOfPlace) {
-//        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
-//        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
-//        char* buff = reinterpret_cast<char*>(sendbuff);
-//        smChans[peerIdx].copy<16, false>(src + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-//                                         WARP_SIZE);
-//        smChans[peerIdx].copy<16, false>(dst + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-//                                         WARP_SIZE);
-//    } else {
-//         smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
-//    }
-//  }
-//  }
-//
-//  if(rank == root) {
-//  if (bytes % unitBytes > 0) {
-//    const size_t gWid = wid + nLoop * nWarp;
-//    const size_t peerIdx = gWid % nPeer;
-//    const size_t offsetWithinRank = (gWid / nPeer) * unitBytesPerWarp;
-//    const size_t offset = offsetWithinRank;
-//    const size_t remainBytes = (offsetWithinRank + unitBytesPerWarp > bytesPerGPU)
-//                                   ? ((bytesPerGPU > offsetWithinRank) ? (bytesPerGPU - offsetWithinRank) : 0)
-//                                   : unitBytesPerWarp;
-//    if (remainBytes > 0) {
-//      if constexpr (IsOutOfPlace) {
-//        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
-//        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
-//        char* buff = reinterpret_cast<char*>(sendbuff);
-//        smChans[peerIdx].copy<16, true>(src + offset + channelOutOffset, buff + offset, remainBytes, lid,
-//                                        WARP_SIZE);
-//        smChans[peerIdx].copy<16, true>(dst + offset + channelOutOffset, buff + offset, remainBytes, lid,
-//                                        WARP_SIZE);
-//      } else {
-//        smChans[peerIdx].put<16, true>(offset + channelOutOffset, remainBytes, lid, WARP_SIZE);
-//      }
-//    }
-//  }
-//  }
 
   deviceSyncer.sync(gridDim.x);
 
@@ -233,12 +151,11 @@ cudaError_t broadcast(T* buff, T* scratch, T* resultBuff,
                       mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset, int rank,
                       int nRanksPerNode, int root, int worldSize, size_t nelems, cudaStream_t stream) {
   int nBlocks = 7;
-  //int nBlocks = 28;
-  //if (nelems*nRanksPerNode <= 4096) {
+  //if (nelems <= 4096) {
   //  nBlocks = 7;
-  //} else if (nelems*nRanksPerNode <= 32768) {
+  //} else if (nelems <= 32768) {
   //  nBlocks = 14;
-  //} else if (nelems*nRanksPerNode >= 2097152) {
+  //} else if (nelems >= 2097152) {
   //  nBlocks = 35;
   //}
   broadcast6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void *)scratch, (void *)resultBuff, smChannels, channelOutOffset, rank, worldSize,

--- a/apps/nccl/src/broadcast.hpp
+++ b/apps/nccl/src/broadcast.hpp
@@ -14,7 +14,7 @@
 
 template <bool IsOutOfPlace>
 __global__ void __launch_bounds__(1024, 1)
-    broadcast6(void* sendbuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset,
+    broadcast6(void* sendbuff, void* scratchbuff, void *recvbuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset,
                size_t rank, [[maybe_unused]] size_t worldSize, size_t root, size_t nRanksPerNode, size_t nelemsPerGPU) {
   const size_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t lid = tid % WARP_SIZE;
@@ -34,81 +34,191 @@ __global__ void __launch_bounds__(1024, 1)
   }
   __syncthreads();
 
+  //const size_t peerIdx = blockIdx.x;
+  const size_t peerRootIdx = (root == rank) ? nPeer : ((root < rank) ? root : (root - 1));
+
   const size_t bytesPerGPU = nelemsPerGPU * sizeof(int);
-  const size_t bytes = bytesPerGPU * nPeer;
-  size_t unitBytesPerThread;
-  if (bytes >= nThread * 64) {
-    unitBytesPerThread = 64;
-  } else {
-    unitBytesPerThread = 16;
-  }
-  const size_t unitBytesPerWarp = unitBytesPerThread * WARP_SIZE;
-  const size_t unitBytes = unitBytesPerWarp * nWarp;
+  //const size_t bytes = bytesPerGPU * nPeer;
+  const size_t bytes = bytesPerGPU;
+  size_t unitBytesPerThread = 16;
+  //if (bytes >= nThread * 64) {
+  //  unitBytesPerThread = 64;
+  //} else {
+  //  unitBytesPerThread = 16;
+  //}
+  //const size_t unitBytesPerWarp = unitBytesPerThread * WARP_SIZE;
+  //const size_t unitBytes = unitBytesPerWarp * nWarp;
+  const size_t unitBytesPerBlock = unitBytesPerThread * blockDim.x;
+  const size_t unitBytes = unitBytesPerBlock * gridDim.x;
   const size_t nLoop = bytes / unitBytes;
+  //printf("nLoop = %ld, bytes = %ld, unitBytes = %ld\n", nLoop, bytes, unitBytes);
 
-
-  if(rank == root) {
   if (nLoop > 0) {
     // First loop unrolling
-    const size_t peerIdx = wid % nPeer;
-    const size_t offset = (wid / nPeer) * unitBytesPerWarp;
-    if constexpr (IsOutOfPlace) {
-        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
-        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
-        char* buff = reinterpret_cast<char*>(sendbuff);
-        smChans[peerIdx].copy<16, false>(src + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-                                         WARP_SIZE);
-        smChans[peerIdx].copy<16, false>(dst + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-                                         WARP_SIZE);
-    } else {
-          smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
-    }
-  }
-  }
-
-  if(rank == root) {
-  for (size_t i = 1; i < nLoop; ++i) {
-    const size_t gWid = wid + i * nWarp;
-    const size_t peerIdx = gWid % nPeer;
-    const size_t offset = (gWid / nPeer) * unitBytesPerWarp;
-    if constexpr (IsOutOfPlace) {
-        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
-        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
-        char* buff = reinterpret_cast<char*>(sendbuff);
-        smChans[peerIdx].copy<16, false>(src + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-                                         WARP_SIZE);
-        smChans[peerIdx].copy<16, false>(dst + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
-                                         WARP_SIZE);
-    } else {
-         smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
-    }
-  }
-  }
-
-  if(rank == root) {
-  if (bytes % unitBytes > 0) {
-    const size_t gWid = wid + nLoop * nWarp;
-    const size_t peerIdx = gWid % nPeer;
-    const size_t offsetWithinRank = (gWid / nPeer) * unitBytesPerWarp;
-    const size_t offset = offsetWithinRank;
-    const size_t remainBytes = (offsetWithinRank + unitBytesPerWarp > bytesPerGPU)
-                                   ? ((bytesPerGPU > offsetWithinRank) ? (bytesPerGPU - offsetWithinRank) : 0)
-                                   : unitBytesPerWarp;
-    if (remainBytes > 0) {
+    //const size_t peerIdx = wid % nPeer;
+    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
+    const size_t offset = blockIdx.x * unitBytesPerBlock ; //(wid / nPeer) * unitBytesPerWarp;
+    if(rank == root) {
       if constexpr (IsOutOfPlace) {
-        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
-        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
-        char* buff = reinterpret_cast<char*>(sendbuff);
-        smChans[peerIdx].copy<16, true>(src + offset + channelOutOffset, buff + offset, remainBytes, lid,
-                                        WARP_SIZE);
-        smChans[peerIdx].copy<16, true>(dst + offset + channelOutOffset, buff + offset, remainBytes, lid,
-                                        WARP_SIZE);
       } else {
-        smChans[peerIdx].put<16, true>(offset + channelOutOffset, remainBytes, lid, WARP_SIZE);
+	  for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
+            char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+            char* send_ = reinterpret_cast<char*>(sendbuff);
+            //char *recv_ = reinterpret_cast<char*>(recvbuff);
+            //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
+            //                                 WARP_SIZE);
+            smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
+                                             blockDim.x);
+            __syncthreads();
+	    if(threadIdx.x == peerIdx)
+              smChans[peerIdx].signal();
+            //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
+          }
       }
+    } else { // rank != root.
+      if constexpr (IsOutOfPlace) {
+      } else {
+	if(threadIdx.x == peerRootIdx)
+          smChans[peerRootIdx].wait();
+	__syncthreads();
+        //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+        //char* send_ = reinterpret_cast<char*>(sendbuff);
+        char *recv_ = reinterpret_cast<char*>(recvbuff);
+	char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
+        smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
+                                         blockDim.x);
+        //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
+        //                                 WARP_SIZE);
+      } 
     }
   }
+
+  for (size_t i = 1; i < nLoop ; ++i) {
+    //const size_t peerIdx = wid % nPeer;
+    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
+    const size_t offset = blockIdx.x * unitBytesPerBlock + i * unitBytes; //(wid / nPeer) * unitBytesPerWarp;
+    if(rank == root) {
+      if constexpr (IsOutOfPlace) {
+      } else {
+	  for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
+            char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+            char* send_ = reinterpret_cast<char*>(sendbuff);
+            //char *recv_ = reinterpret_cast<char*>(recvbuff);
+            //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
+            //                                 WARP_SIZE);
+            smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
+                                             blockDim.x);
+            __syncthreads();
+	    if(threadIdx.x == peerIdx)
+              smChans[peerIdx].signal();
+            //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
+          }
+      }
+    } else { // rank != root.
+      if constexpr (IsOutOfPlace) {
+      } else {
+	if(threadIdx.x == peerRootIdx)
+          smChans[peerRootIdx].wait();
+	__syncthreads();
+        //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+        //char* send_ = reinterpret_cast<char*>(sendbuff);
+        char *recv_ = reinterpret_cast<char*>(recvbuff);
+	char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
+        smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
+                                         blockDim.x);
+        //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
+        //                                 WARP_SIZE);
+      } 
+    }
   }
+
+  if (bytes % unitBytes > 0) { // remainder.
+    //const size_t peerIdx = wid % nPeer;
+    //const size_t offset = (wid / nPeer) * unitBytesPerWarp;
+    const size_t offset = blockIdx.x * unitBytesPerBlock + nLoop * unitBytes;
+    const size_t remainBytes = (offset < bytes ) ?  (bytes - offset) : 0;
+    if(remainBytes > 0) {	  
+      if(rank == root) {
+        if constexpr (IsOutOfPlace) {
+        } else {
+            for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
+              char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+              char* send_ = reinterpret_cast<char*>(sendbuff);
+              //char *recv_ = reinterpret_cast<char*>(recvbuff);
+              //smChans[peerIdx].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerWarp, lid,
+              //                                 WARP_SIZE);
+              smChans[peerIdx].copy<16, true>(dst + offset, send_ + offset, remainBytes, threadIdx.x,
+                                               blockDim.x);
+              __syncthreads();
+              if(threadIdx.x == peerIdx)
+                smChans[peerIdx].signal();
+              //  smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
+            }
+        }
+      } else { // rank != root.
+        if constexpr (IsOutOfPlace) {
+        } else {
+          if(threadIdx.x == peerRootIdx)
+            smChans[peerRootIdx].wait();
+          __syncthreads();
+          //char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+          //char* send_ = reinterpret_cast<char*>(sendbuff);
+          char *recv_ = reinterpret_cast<char*>(recvbuff);
+          char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
+          smChans[peerRootIdx].copy<16, true>(recv_ + offset, scratch_ + offset, remainBytes, threadIdx.x,
+                                           blockDim.x);
+          //smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerWarp, lid,
+          //                                 WARP_SIZE);
+        } 
+      }
+    } // remainBytes > 0.
+  }
+
+
+
+//  if(rank == root) {
+//  for (size_t i = 1; i < nLoop; ++i) {
+//    const size_t gWid = wid + i * nWarp;
+//    const size_t peerIdx = gWid % nPeer;
+//    const size_t offset = (gWid / nPeer) * unitBytesPerWarp;
+//    if constexpr (IsOutOfPlace) {
+//        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
+//        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
+//        char* buff = reinterpret_cast<char*>(sendbuff);
+//        smChans[peerIdx].copy<16, false>(src + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
+//                                         WARP_SIZE);
+//        smChans[peerIdx].copy<16, false>(dst + offset + channelOutOffset, buff + offset, unitBytesPerWarp, lid,
+//                                         WARP_SIZE);
+//    } else {
+//         smChans[peerIdx].put<16, false>(offset + channelOutOffset, unitBytesPerWarp, lid, WARP_SIZE);
+//    }
+//  }
+//  }
+//
+//  if(rank == root) {
+//  if (bytes % unitBytes > 0) {
+//    const size_t gWid = wid + nLoop * nWarp;
+//    const size_t peerIdx = gWid % nPeer;
+//    const size_t offsetWithinRank = (gWid / nPeer) * unitBytesPerWarp;
+//    const size_t offset = offsetWithinRank;
+//    const size_t remainBytes = (offsetWithinRank + unitBytesPerWarp > bytesPerGPU)
+//                                   ? ((bytesPerGPU > offsetWithinRank) ? (bytesPerGPU - offsetWithinRank) : 0)
+//                                   : unitBytesPerWarp;
+//    if (remainBytes > 0) {
+//      if constexpr (IsOutOfPlace) {
+//        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);
+//        char* src = reinterpret_cast<char*>(smChans[peerIdx].src_);
+//        char* buff = reinterpret_cast<char*>(sendbuff);
+//        smChans[peerIdx].copy<16, true>(src + offset + channelOutOffset, buff + offset, remainBytes, lid,
+//                                        WARP_SIZE);
+//        smChans[peerIdx].copy<16, true>(dst + offset + channelOutOffset, buff + offset, remainBytes, lid,
+//                                        WARP_SIZE);
+//      } else {
+//        smChans[peerIdx].put<16, true>(offset + channelOutOffset, remainBytes, lid, WARP_SIZE);
+//      }
+//    }
+//  }
+//  }
 
   deviceSyncer.sync(gridDim.x);
 
@@ -119,18 +229,19 @@ __global__ void __launch_bounds__(1024, 1)
 }
 
 template <bool IsOutOfPlace, typename T>
-cudaError_t broadcast(T* buff, [[maybe_unused]] T* scratch, [[maybe_unused]] T* resultBuff,
+cudaError_t broadcast(T* buff, T* scratch, T* resultBuff,
                       mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset, int rank,
                       int nRanksPerNode, int root, int worldSize, size_t nelems, cudaStream_t stream) {
-  int nBlocks = 28;
-  if (nelems*nRanksPerNode <= 4096) {
-    nBlocks = 7;
-  } else if (nelems*nRanksPerNode <= 32768) {
-    nBlocks = 14;
-  } else if (nelems*nRanksPerNode >= 2097152) {
-    nBlocks = 35;
-  }
-  broadcast6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, smChannels, channelOutOffset, rank, worldSize,
+  int nBlocks = 7;
+  //int nBlocks = 28;
+  //if (nelems*nRanksPerNode <= 4096) {
+  //  nBlocks = 7;
+  //} else if (nelems*nRanksPerNode <= 32768) {
+  //  nBlocks = 14;
+  //} else if (nelems*nRanksPerNode >= 2097152) {
+  //  nBlocks = 35;
+  //}
+  broadcast6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void *)scratch, (void *)resultBuff, smChannels, channelOutOffset, rank, worldSize,
                                                          root, nRanksPerNode, nelems * sizeof(T) / sizeof(int));
   return cudaGetLastError();
 }

--- a/apps/nccl/src/broadcast.hpp
+++ b/apps/nccl/src/broadcast.hpp
@@ -14,8 +14,9 @@
 
 template <bool IsOutOfPlace>
 __global__ void __launch_bounds__(1024, 1)
-    broadcast6(void* sendbuff, void* scratchbuff, void *recvbuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset,
-               size_t rank, [[maybe_unused]] size_t worldSize, size_t root, size_t nRanksPerNode, size_t nelemsPerGPU) {
+    broadcast6(void* sendbuff, void* scratchbuff, void* recvbuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels,
+               size_t channelOutOffset, size_t rank, [[maybe_unused]] size_t worldSize, size_t root,
+               size_t nRanksPerNode, size_t nelemsPerGPU) {
   const size_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t lid = tid % WARP_SIZE;
   const size_t wid = tid / WARP_SIZE;
@@ -24,10 +25,10 @@ __global__ void __launch_bounds__(1024, 1)
   const size_t nWarp = nThread / WARP_SIZE;
   const size_t nPeer = nRanksPerNode - 1;
   const size_t chanOffset = nPeer * blockIdx.x;
-  
+
   __shared__ mscclpp::DeviceHandle<mscclpp::SmChannel> smChans[NRANKS_PER_NODE - 1];
-  if(threadIdx.x < nPeer) {
-    smChans[threadIdx.x] = smChannels[chanOffset+threadIdx.x];
+  if (threadIdx.x < nPeer) {
+    smChans[threadIdx.x] = smChannels[chanOffset + threadIdx.x];
     smChans[threadIdx.x].relaxedSignal();
     smChans[threadIdx.x].wait();
   }
@@ -38,7 +39,7 @@ __global__ void __launch_bounds__(1024, 1)
   const size_t bytesPerGPU = nelemsPerGPU * sizeof(int);
   const size_t bytes = bytesPerGPU;
   size_t unitBytesPerThread;
-  if (bytes*nPeer >= nThread * 64) {
+  if (bytes * nPeer >= nThread * 64) {
     unitBytesPerThread = 64;
   } else {
     unitBytesPerThread = 16;
@@ -56,99 +57,89 @@ __global__ void __launch_bounds__(1024, 1)
   if (nLoop > 0) {
     // First loop unrolling
     const size_t offset = blockIdx.x * unitBytesPerBlock;
-    if(rank == root) {
+    if (rank == root) {
       char* send_ = reinterpret_cast<char*>(sendbuff);
       for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
-        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
-        smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
-                                         blockDim.x);
+        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);  // Peer's scratchbuff.
+        smChans[peerIdx].copy<16, false>(dst + offset, send_ + offset, unitBytesPerBlock, threadIdx.x, blockDim.x);
         __syncthreads();
-        if(threadIdx.x == peerIdx)
-           smChans[peerIdx].signal();
+        if (threadIdx.x == peerIdx) smChans[peerIdx].signal();
       }
       if constexpr (IsOutOfPlace) {
-        char *recv_ = reinterpret_cast<char*>(recvbuff);
-        smChans[0].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
-                                       blockDim.x);
+        char* recv_ = reinterpret_cast<char*>(recvbuff);
+        smChans[0].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerBlock, threadIdx.x, blockDim.x);
       }
 
-    } else { // rank != root.
-	if(threadIdx.x == peerRootIdx)
-          smChans[peerRootIdx].wait();
-	__syncthreads();
-        char *recv_ = reinterpret_cast<char*>(recvbuff);
-	char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
-        smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
-                                         blockDim.x);
+    } else {  // rank != root.
+      if (threadIdx.x == peerRootIdx) smChans[peerRootIdx].wait();
+      __syncthreads();
+      char* recv_ = reinterpret_cast<char*>(recvbuff);
+      char* scratch_ = reinterpret_cast<char*>(scratchbuff);  // My scratchbuff.
+      smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset, unitBytesPerBlock, threadIdx.x,
+                                           blockDim.x);
     }
   }
 
-  for (size_t i = 1; i < nLoop ; ++i) {
+  for (size_t i = 1; i < nLoop; ++i) {
     const size_t offset = blockIdx.x * unitBytesPerBlock + i * unitBytes;
-    if (i % nLoopToSync == 0) { // Sync to reuse scratch buff
-      scratchSub = -i*unitBytes;
+    if (i % nLoopToSync == 0) {  // Sync to reuse scratch buff
+      scratchSub = -i * unitBytes;
       deviceSyncer.sync(gridDim.x);
       if (threadIdx.x < nPeer) {
         smChans[threadIdx.x].relaxedSignal();
         smChans[threadIdx.x].wait();
       }
     }
-    if(rank == root) {
+    if (rank == root) {
       char* send_ = reinterpret_cast<char*>(sendbuff);
       for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
-        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+        char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);  // Peer's scratchbuff.
         smChans[peerIdx].copy<16, false>(dst + offset + scratchSub, send_ + offset, unitBytesPerBlock, threadIdx.x,
                                          blockDim.x);
         __syncthreads();
-	if(threadIdx.x == peerIdx)
-          smChans[peerIdx].signal();
+        if (threadIdx.x == peerIdx) smChans[peerIdx].signal();
       }
       if constexpr (IsOutOfPlace) {
-        char *recv_ = reinterpret_cast<char*>(recvbuff);
-        smChans[0].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerBlock, threadIdx.x,
-                                       blockDim.x);
+        char* recv_ = reinterpret_cast<char*>(recvbuff);
+        smChans[0].copy<16, false>(recv_ + offset, send_ + offset, unitBytesPerBlock, threadIdx.x, blockDim.x);
       }
-    } else { // rank != root.
-      if(threadIdx.x == peerRootIdx)
-          smChans[peerRootIdx].wait();
+    } else {  // rank != root.
+      if (threadIdx.x == peerRootIdx) smChans[peerRootIdx].wait();
       __syncthreads();
-      char *recv_ = reinterpret_cast<char*>(recvbuff);
-      char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
-      smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset + scratchSub, unitBytesPerBlock, threadIdx.x,
-                                         blockDim.x);
-    } 
+      char* recv_ = reinterpret_cast<char*>(recvbuff);
+      char* scratch_ = reinterpret_cast<char*>(scratchbuff);  // My scratchbuff.
+      smChans[peerRootIdx].copy<16, false>(recv_ + offset, scratch_ + offset + scratchSub, unitBytesPerBlock,
+                                           threadIdx.x, blockDim.x);
+    }
   }
 
   // Remainder loop will also fit the scratch buff since we subtract unitBytes from SCRATCH_SIZE.
-  if (bytes % unitBytes > 0) { // remainder.
+  if (bytes % unitBytes > 0) {  // remainder.
     const size_t offset = blockIdx.x * unitBytesPerBlock + nLoop * unitBytes;
-    const size_t remainBytes = (offset < bytes ) ?  (bytes - offset) : 0;
-    if(remainBytes > 0) {	  
-      if(rank == root) {
+    const size_t remainBytes = (offset < bytes) ? (bytes - offset) : 0;
+    if (remainBytes > 0) {
+      if (rank == root) {
         char* send_ = reinterpret_cast<char*>(sendbuff);
         for (size_t peerIdx = 0; peerIdx < nPeer; peerIdx++) {
-          char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_); // Peer's scratchbuff.
+          char* dst = reinterpret_cast<char*>(smChans[peerIdx].dst_);  // Peer's scratchbuff.
           smChans[peerIdx].copy<16, true>(dst + offset + scratchSub, send_ + offset, remainBytes, threadIdx.x,
-                                           blockDim.x);
+                                          blockDim.x);
           __syncthreads();
-          if(threadIdx.x == peerIdx)
-            smChans[peerIdx].signal();
+          if (threadIdx.x == peerIdx) smChans[peerIdx].signal();
         }
         if constexpr (IsOutOfPlace) {
-          char *recv_ = reinterpret_cast<char*>(recvbuff);
-          smChans[0].copy<16, true>(recv_ + offset, send_ + offset, remainBytes, threadIdx.x,
-                                               blockDim.x);
+          char* recv_ = reinterpret_cast<char*>(recvbuff);
+          smChans[0].copy<16, true>(recv_ + offset, send_ + offset, remainBytes, threadIdx.x, blockDim.x);
         }
-      } else { // rank != root.
-        if(threadIdx.x == peerRootIdx)
-          smChans[peerRootIdx].wait();
+      } else {  // rank != root.
+        if (threadIdx.x == peerRootIdx) smChans[peerRootIdx].wait();
         __syncthreads();
-        char *recv_ = reinterpret_cast<char*>(recvbuff);
-        char *scratch_ = reinterpret_cast<char*>(scratchbuff); // My scratchbuff.
+        char* recv_ = reinterpret_cast<char*>(recvbuff);
+        char* scratch_ = reinterpret_cast<char*>(scratchbuff);  // My scratchbuff.
         smChans[peerRootIdx].copy<16, true>(recv_ + offset, scratch_ + offset + scratchSub, remainBytes, threadIdx.x,
-                                         blockDim.x);
+                                            blockDim.x);
       }
-    } // remainBytes > 0.
+    }  // remainBytes > 0.
   }
 
   deviceSyncer.sync(gridDim.x);
@@ -160,19 +151,20 @@ __global__ void __launch_bounds__(1024, 1)
 }
 
 template <bool IsOutOfPlace, typename T>
-cudaError_t broadcast(T* buff, T* scratch, T* resultBuff,
-                      mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels, size_t channelOutOffset, int rank,
-                      int nRanksPerNode, int root, int worldSize, size_t nelems, cudaStream_t stream) {
+cudaError_t broadcast(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels,
+                      size_t channelOutOffset, int rank, int nRanksPerNode, int root, int worldSize, size_t nelems,
+                      cudaStream_t stream) {
   int nBlocks = 7;
-  //if (nelems <= 4096) {
-  //  nBlocks = 7;
-  //} else if (nelems <= 32768) {
-  //  nBlocks = 14;
-  //} else if (nelems >= 2097152) {
-  //  nBlocks = 35;
-  //}
-  broadcast6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void *)scratch, (void *)resultBuff, smChannels, channelOutOffset, rank, worldSize,
-                                                         root, nRanksPerNode, nelems * sizeof(T) / sizeof(int));
+  // if (nelems <= 4096) {
+  //   nBlocks = 7;
+  // } else if (nelems <= 32768) {
+  //   nBlocks = 14;
+  // } else if (nelems >= 2097152) {
+  //   nBlocks = 35;
+  // }
+  broadcast6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void*)scratch, (void*)resultBuff, smChannels,
+                                                         channelOutOffset, rank, worldSize, root, nRanksPerNode,
+                                                         nelems * sizeof(T) / sizeof(int));
   return cudaGetLastError();
 }
 

--- a/apps/nccl/src/nccl.cu
+++ b/apps/nccl/src/nccl.cu
@@ -478,18 +478,22 @@ NCCL_API ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t
   size_t recvBytes;
   CUdeviceptr recvBasePtr;
   MSCCLPP_CUTHROW(cuMemGetAddressRange(&recvBasePtr, &recvBytes, (CUdeviceptr)recvbuff));
-  size_t offsetOut = (char*)recvbuff - (char*)recvBasePtr;
-  channelKey recvKey{(void*)recvBasePtr, recvBytes};
+  //size_t offsetOut = (char*)recvbuff - (char*)recvBasePtr;
+  size_t offsetOut = 0;
+  //channelKey recvKey{(void*)recvBasePtr, recvBytes};
+  channelKey recvKey{(void*)0x0, 0}; // Just create the channel once.
   int rank = comm->comm->bootstrap()->getRank();
   int nRank = comm->comm->bootstrap()->getNranks();
   mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels = nullptr;
 
   auto it = comm->channelOutInfos.find(recvKey);
   if (it == comm->channelOutInfos.end()) {
-    std::vector<mscclpp::RegisteredMemory> remoteMemories = setupRemoteMemories(
-        comm->comm, rank, const_cast<void*>((void*)recvBasePtr), recvBytes, mscclpp::Transport::CudaIpc);
+    //std::vector<mscclpp::RegisteredMemory> remoteMemories = setupRemoteMemories(
+    //    comm->comm, rank, const_cast<void*>((void*)recvBasePtr), recvBytes, mscclpp::Transport::CudaIpc);
+    //std::vector<mscclpp::SmChannel> channels =
+    //    setupSmChannels(comm, remoteMemories, const_cast<void*>((void*)recvBasePtr));
     std::vector<mscclpp::SmChannel> channels =
-        setupSmChannels(comm, remoteMemories, const_cast<void*>((void*)recvBasePtr));
+        setupSmChannels(comm, comm->remoteScratchRegMemories, const_cast<void*>((void*)recvBasePtr));
     std::vector<mscclpp::DeviceHandle<mscclpp::SmChannel>> smChannelDeviceHandles;
     std::transform(channels.begin(), channels.end(), std::back_inserter(smChannelDeviceHandles),
                    [](const mscclpp::SmChannel& smChannel) { return mscclpp::deviceHandle(smChannel); });
@@ -499,10 +503,10 @@ NCCL_API ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t
 
   smChannels = it->second.smChannelDeviceHandles.get();
   if ((char*)sendbuff == (char*)recvbuff) {
-    CUDACHECK(broadcast<false>((int*)sendbuff, (int*)nullptr, (int*)recvbuff, smChannels, offsetOut, rank,
+    CUDACHECK(broadcast<false>((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, smChannels, offsetOut, rank,
                                NRANKS_PER_NODE, root, nRank, bytes / sizeof(int), stream));
   } else {
-    CUDACHECK(broadcast<true>((int*)sendbuff, (int*)nullptr, (int*)recvbuff, smChannels, offsetOut, rank,
+    CUDACHECK(broadcast<true>((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, smChannels, offsetOut, rank,
                               NRANKS_PER_NODE, root, nRank, bytes / sizeof(int), stream));
   }
 


### PR DESCRIPTION
Encountered a hang with rccl-test's ncclBcast runs. In rccl-test with ncclBcast, the buffer changes only for the root-gpu b/w test runs. So, the channel key changes only for the root gpu and remains the same for the other gpus. So, the root gpu starts to create a new sm channel while the other gpus do not create new sm channels. Hence, a hang occurs.

To fix this, we have to use copy-based implementation. This is the simplest copy-based implementation. Uses a static channel key with sm channels created using scratch buffer as the remote memories.