### PR TITLE
Update allgather fallback algo

### DIFF
--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -212,7 +212,7 @@ cudaError_t allgather(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
                       size_t channelInOffset, size_t channelOutOffset, int rank, int nRanksPerNode, int worldSize,
                       size_t nelems, cudaStream_t stream) {
   int nBlocks = 28;
-  if (nelems * sizeof(T) <= 64 * (1 << 20)) {
+  if (nelems * sizeof(T) <= 32 * (1 << 20)) {
     if (nelems <= 4096) {
       nBlocks = 7;
     } else if (nelems <= 32768) {

--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -126,8 +126,8 @@ __global__ void __launch_bounds__(1024, 1)
   int4* scratch4 = reinterpret_cast<int4*>(scratch);
   int4* resultBuff4 = reinterpret_cast<int4*>(resultBuff);
 
-  const size_t unitNInt4 = blockDim.x * gridDim.x; // The number of int4 transfers at once
-  const size_t nInt4PerChunk = unitNInt4 * 4; // 4 instructions per thread to make it more efficient
+  const size_t unitNInt4 = blockDim.x * gridDim.x;  // The number of int4 transfers at once
+  const size_t nInt4PerChunk = unitNInt4 * 4;       // 4 instructions per thread to make it more efficient
   const size_t nItrs = nInt4 / nInt4PerChunk;
   const size_t restNInt4 = nInt4 % nInt4PerChunk;
   const size_t scratchChunkRankOffset = nInt4PerChunk * rank;

--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -126,7 +126,7 @@ __global__ void __launch_bounds__(1024, 1)
   int4* resultBuff4 = reinterpret_cast<int4*>(resultBuff);
 
   const size_t unitNInt4 = blockDim.x * gridDim.x; // The number of int4 transfers at once
-  const size_t nInt4PerChunk = unitNInt4 * 8; // 16 instructions per thread to transfer data per chunk
+  const size_t nInt4PerChunk = unitNInt4 * 4; // 4 instructions per thread to make it more efficient
   const size_t nItrs = nInt4 / nInt4PerChunk;
   const size_t restNInt4 = nInt4 % nInt4PerChunk;
   const size_t scratchChunkRankOffset = nInt4PerChunk * rank;

--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -113,8 +113,9 @@ __global__ void __launch_bounds__(1024, 1)
 
 template <bool IsOutOfPlace>
 __global__ void __launch_bounds__(1024, 1)
-    allgather8(void* buff, void* scratch, void* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
-               size_t channelInputOffset, int rank, int nRanksPerNode, int worldSize, size_t nelems) {
+    allgather8(void* buff, void* scratch, void* resultBuff,
+               mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels, int rank, int nRanksPerNode,
+               [[maybe_unused]] int worldSize, size_t nelems) {
   const int nPeer = nRanksPerNode - 1;
   const size_t chanOffset = nPeer * blockIdx.x;
   // assume (nelems * sizeof(T)) is divisible by 16
@@ -208,9 +209,9 @@ __global__ void __launch_bounds__(1024, 1)
 }
 
 template <bool IsOutOfPlace, typename T>
-cudaError_t allgather(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
-                      size_t channelInOffset, size_t channelOutOffset, int rank, int nRanksPerNode, int worldSize,
-                      size_t nelems, cudaStream_t stream) {
+cudaError_t allgather(T* buff, [[maybe_unused]] T* scratch, [[maybe_unused]] T* resultBuff,
+                      mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels, size_t channelOutOffset, int rank,
+                      int nRanksPerNode, [[maybe_unused]] int worldSize, size_t nelems, cudaStream_t stream) {
   int nBlocks = 28;
   if (nelems * sizeof(T) <= 32 * (1 << 20)) {
     if (nelems <= 4096) {
@@ -230,8 +231,8 @@ cudaError_t allgather(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
 #else
     nBlocks = 56;
     allgather8<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void*)scratch, (void*)resultBuff,
-                                                           memoryChannels, channelInOffset, rank, nRanksPerNode,
-                                                           worldSize, nelems * sizeof(T) / sizeof(int));
+                                                           memoryChannels, rank, nRanksPerNode, worldSize,
+                                                           nelems * sizeof(T) / sizeof(int));
 #endif
   }
   return cudaGetLastError();

--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -111,20 +111,136 @@ __global__ void __launch_bounds__(1024, 1)
   }
 }
 
-template <bool IsOutOfPlace, typename T>
-cudaError_t allgather(T* buff, [[maybe_unused]] T* scratch, [[maybe_unused]] T* resultBuff,
-                      mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels, size_t channelOutOffset, int rank,
-                      int nRanksPerNode, int worldSize, size_t nelems, cudaStream_t stream) {
-  int nBlocks = 28;
-  if (nelems <= 4096) {
-    nBlocks = 7;
-  } else if (nelems <= 32768) {
-    nBlocks = 14;
-  } else if (nelems >= 2097152) {
-    nBlocks = 35;
+template <bool IsOutOfPlace>
+__global__ void __launch_bounds__(1024, 1)
+    allgather8(void* buff, void* scratch, void* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
+               size_t channelInputOffset, int rank, int nRanksPerNode, int worldSize, size_t nelems) {
+  const int nPeer = nRanksPerNode - 1;
+  const size_t chanOffset = nPeer * blockIdx.x;
+  // assume (nelems * sizeof(T)) is divisible by 16
+  const size_t nInt4 = nelems * sizeof(int) / sizeof(int4);
+  auto memoryChans = memoryChannels + chanOffset;
+
+  int4* buff4 = reinterpret_cast<int4*>(buff);
+  int4* scratch4 = reinterpret_cast<int4*>(scratch);
+  int4* resultBuff4 = reinterpret_cast<int4*>(resultBuff);
+
+
+  // Distribute `nInt4` across all blocks with the unit size `unitNInt4`
+  constexpr size_t unitNInt4 = 1024;
+  const size_t maxNInt4PerBlock = (((nInt4 + gridDim.x - 1) / gridDim.x) + unitNInt4 - 1) / unitNInt4 * unitNInt4;
+  size_t offsetOfThisBlock = maxNInt4PerBlock * blockIdx.x;
+  size_t nInt4OfThisBlock = maxNInt4PerBlock;
+  size_t nNeededBlocks = (nInt4 + maxNInt4PerBlock - 1) / maxNInt4PerBlock;
+  constexpr size_t nInt4PerChunk = 1024 * 256 / sizeof(int4);  // 256KB
+  if (blockIdx.x >= nNeededBlocks) {
+    nInt4OfThisBlock = 0;
+  } else if (blockIdx.x == nNeededBlocks - 1) {
+    nInt4OfThisBlock = nInt4 - maxNInt4PerBlock * (nNeededBlocks - 1);
   }
-  allgather6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, memoryChannels, channelOutOffset, rank, worldSize,
-                                                         nRanksPerNode, nelems * sizeof(T) / sizeof(int));
+  const size_t nItrs = nInt4OfThisBlock / nInt4PerChunk;
+  const size_t restNInt4 = nInt4OfThisBlock % nInt4PerChunk;
+  const size_t chunkSizePerRank = nNeededBlocks * nInt4PerChunk;
+  const size_t blockOffset = nInt4PerChunk * blockIdx.x;
+  const size_t scratchChunkRankOffset = chunkSizePerRank * rank;
+
+  __shared__ mscclpp::DeviceHandle<mscclpp::MemoryChannel> channels[NRANKS_PER_NODE - 1];
+  const int lid = threadIdx.x % WARP_SIZE;
+  if (lid < nPeer) {
+    channels[lid] = memoryChans[lid];
+  }
+  __syncwarp();
+  // we can use double buffering to hide synchronization overhead
+  for (size_t itr = 0; itr < nItrs; itr++) {
+    if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
+      channels[threadIdx.x].signal();
+      channels[threadIdx.x].wait();
+    }
+    __syncthreads();
+    // Starts allgather
+    for (int i = 0; i < NPEERS; i++) {
+    for (size_t idx = threadIdx.x; idx < nInt4PerChunk; idx += blockDim.x) {
+      int4 val = buff4[idx + offsetOfThisBlock];
+        const int peerIdx = (i + rank) % nPeer;
+        const int remoteRank = (peerIdx < rank) ? peerIdx : peerIdx + 1;
+        channels[peerIdx].write(scratchChunkRankOffset + blockOffset + idx, val);
+      }
+    }
+    // Ensure that all writes of this block have been issued before issuing the signal
+    __syncthreads();
+    if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
+      channels[threadIdx.x].signal();
+      channels[threadIdx.x].wait();
+    }
+    __syncthreads();
+    for (int peerIdx = 0; peerIdx < NPEERS; peerIdx++) {
+      const int remoteRank = (peerIdx < rank) ? peerIdx : peerIdx + 1;
+      for (size_t idx = threadIdx.x; idx < nInt4PerChunk; idx += blockDim.x) {
+        int4 val = scratch4[chunkSizePerRank * remoteRank + blockOffset + idx];
+        resultBuff4[nInt4 * remoteRank + idx + offsetOfThisBlock] = val;
+      }
+    }
+  }
+
+  // if (restNInt4 > 0) {
+  //   if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
+  //     channels[threadIdx.x].signal();
+  //     channels[threadIdx.x].wait();
+  //   }
+  //   __syncthreads();
+  //   for (size_t idx = threadIdx.x; idx < restNInt4; idx += blockDim.x) {
+  //     for (int i = 0; i < NPEERS; i++) {
+  //       const int peerIdx = (i + blockIdx.x) % nPeer;
+  //       const int remoteRank = (peerIdx < rank) ? peerIdx : peerIdx + 1;
+  //       int4 val = buff4[nInt4PerRank * remoteRank + idx + offsetOfThisBlock];
+  //       channels[peerIdx].write(scratchBaseOffsetInt4 + scratchChunkRankOffset + blockOffset + idx, val);
+  //     }
+  //   }
+
+  //   // Ensure that all writes of this block have been issued before issuing the signal
+  //   __syncthreads();
+  //   if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
+  //     channels[threadIdx.x].signal();
+  //     channels[threadIdx.x].wait();
+  //   }
+  //   __syncthreads();
+
+  //   for (size_t idx = threadIdx.x; idx < restNInt4; idx += blockDim.x) {
+  //     int4 data = buff4[nInt4PerRank * rank + idx + offsetOfThisBlock];
+  //     resultBuff4[nInt4PerRank * rank + idx + offsetOfThisBlock] = data;
+  //   }
+  //   // Ensure all threads have issued writes to outChannel
+  //   __syncthreads();
+  // }
+  // // Threads are already synchronized
+  // // So all writes to outChannel have been issued before signal is being issued
+  // if (threadIdx.x < static_cast<uint32_t>(nPeer)) {
+  //   channels[threadIdx.x].signal();
+  //   channels[threadIdx.x].wait();
+  // }
+}
+
+template <bool IsOutOfPlace, typename T>
+cudaError_t allgather(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
+                      size_t channelInOffset, size_t channelOutOffset, int rank, int nRanksPerNode, int worldSize,
+                      size_t nelems, cudaStream_t stream) {
+  int nBlocks = 28;
+  if (nelems * sizeof(T) <= 64 * (1 << 20)) {
+    if (nelems <= 4096) {
+      nBlocks = 7;
+    } else if (nelems <= 32768) {
+      nBlocks = 14;
+    } else if (nelems >= 2097152) {
+      nBlocks = 35;
+    }
+    allgather6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, memoryChannels, channelOutOffset, rank,
+                                                           worldSize, nRanksPerNode, nelems * sizeof(T) / sizeof(int));
+  } else {
+    nBlocks = 64;
+    allgather8<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void*)scratch, (void*)resultBuff,
+                                                           memoryChannels, channelInOffset, rank, nRanksPerNode,
+                                                           worldSize, nelems * sizeof(T) / sizeof(int));
+  }
   return cudaGetLastError();
 }
 

--- a/apps/nccl/src/allgather.hpp
+++ b/apps/nccl/src/allgather.hpp
@@ -223,10 +223,16 @@ cudaError_t allgather(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
     allgather6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, memoryChannels, channelOutOffset, rank,
                                                            worldSize, nRanksPerNode, nelems * sizeof(T) / sizeof(int));
   } else {
+#if defined(__HIP_PLATFORM_AMD__)
+    nBlocks = 35;
+    allgather6<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, memoryChannels, channelOutOffset, rank,
+                                                           worldSize, nRanksPerNode, nelems * sizeof(T) / sizeof(int));
+#else
     nBlocks = 56;
     allgather8<IsOutOfPlace><<<nBlocks, 1024, 0, stream>>>((void*)buff, (void*)scratch, (void*)resultBuff,
                                                            memoryChannels, channelInOffset, rank, nRanksPerNode,
                                                            worldSize, nelems * sizeof(T) / sizeof(int));
+#endif
   }
   return cudaGetLastError();
 }

--- a/apps/nccl/src/nccl.cu
+++ b/apps/nccl/src/nccl.cu
@@ -321,7 +321,7 @@ static ncclResult_t ncclAllGatherFallback(const void* sendbuff, void* recvbuff, 
   mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels = nullptr;
   std::vector<mscclpp::RegisteredMemory> remoteMemories;
 
-  if (bytes <= 64 * (1 << 20)) {
+  if (bytes <= 32 * (1 << 20)) {
     auto it = comm->channelOutInfos.find(recvKey);
     if (mscclppDisableChannelCache == true || it == comm->channelOutInfos.end()) {
       if (mscclppDisableChannelCache == true) {

--- a/apps/nccl/src/nccl.cu
+++ b/apps/nccl/src/nccl.cu
@@ -308,40 +308,55 @@ static ncclResult_t ncclAllGatherFallback(const void* sendbuff, void* recvbuff, 
     return ncclInvalidArgument;
   }
 
-  size_t recvBytes;
-  CUdeviceptr recvBasePtr;
+  size_t sendBytes, recvBytes;
+  CUdeviceptr sendBasePtr, recvBasePtr;
   MSCCLPP_CUTHROW(cuMemGetAddressRange(&recvBasePtr, &recvBytes, (CUdeviceptr)recvbuff));
+  MSCCLPP_CUTHROW(cuMemGetAddressRange(&sendBasePtr, &sendBytes, (CUdeviceptr)sendbuff));
   size_t offsetOut = (char*)recvbuff - (char*)recvBasePtr;
+  size_t offsetIn = (char*)sendbuff - (char*)sendBasePtr;
   channelKey recvKey{(void*)recvBasePtr, recvBytes};
+  channelKey sendKey{(void*)sendBasePtr, sendBytes};
   int rank = comm->comm->bootstrap()->getRank();
   int nRank = comm->comm->bootstrap()->getNranks();
   mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels = nullptr;
+  std::vector<mscclpp::RegisteredMemory> remoteMemories;
 
-  auto it = comm->channelOutInfos.find(recvKey);
-  if (mscclppDisableChannelCache == true || it == comm->channelOutInfos.end()) {
-    if (mscclppDisableChannelCache == true) {
-      recvBytes = bytes;
-      recvBasePtr = (CUdeviceptr)recvbuff;
-      offsetOut = 0;
+  if (bytes <= 64 * (1 << 20)) {
+    auto it = comm->channelOutInfos.find(recvKey);
+    if (mscclppDisableChannelCache == true || it == comm->channelOutInfos.end()) {
+      if (mscclppDisableChannelCache == true) {
+        recvBytes = bytes;
+        recvBasePtr = (CUdeviceptr)recvbuff;
+        offsetOut = 0;
+      }
+      std::vector<mscclpp::RegisteredMemory> remoteMemories = setupRemoteMemories(
+          comm->comm, rank, const_cast<void*>((void*)recvBasePtr), recvBytes, mscclpp::Transport::CudaIpc);
+      std::vector<mscclpp::MemoryChannel> channels =
+          setupMemoryChannels(comm, remoteMemories, const_cast<void*>((void*)recvBasePtr));
+      std::vector<mscclpp::DeviceHandle<mscclpp::MemoryChannel>> memoryChannelDeviceHandles;
+      std::transform(channels.begin(), channels.end(), std::back_inserter(memoryChannelDeviceHandles),
+                     [](const mscclpp::MemoryChannel& memoryChannel) { return mscclpp::deviceHandle(memoryChannel); });
+      ChannelInfo channelInfo{channels, setupMemoryChannelDeviceHandles(channels)};
+      it = comm->channelOutInfos.emplace(recvKey, channelInfo).first;
     }
-    std::vector<mscclpp::RegisteredMemory> remoteMemories = setupRemoteMemories(
-        comm->comm, rank, const_cast<void*>((void*)recvBasePtr), recvBytes, mscclpp::Transport::CudaIpc);
-    std::vector<mscclpp::MemoryChannel> channels =
-        setupMemoryChannels(comm, remoteMemories, const_cast<void*>((void*)recvBasePtr));
-    std::vector<mscclpp::DeviceHandle<mscclpp::MemoryChannel>> memoryChannelDeviceHandles;
-    std::transform(channels.begin(), channels.end(), std::back_inserter(memoryChannelDeviceHandles),
-                   [](const mscclpp::MemoryChannel& memoryChannel) { return mscclpp::deviceHandle(memoryChannel); });
-    ChannelInfo channelInfo{channels, setupMemoryChannelDeviceHandles(channels)};
-    it = comm->channelOutInfos.emplace(recvKey, channelInfo).first;
+    memoryChannels = it->second.memoryChannelDeviceHandles.get();
+  } else {
+    auto sendIt = comm->channelInInfos.find(sendKey);
+    if (sendIt == comm->channelInInfos.end()) {
+      std::vector<mscclpp::MemoryChannel> channels =
+          setupMemoryChannels(comm, comm->remoteScratchRegMemories, const_cast<void*>((void*)sendBasePtr));
+      ChannelInfo channelInfo{channels, setupMemoryChannelDeviceHandles(channels)};
+      sendIt = comm->channelInInfos.emplace(sendKey, channelInfo).first;
+    }
+    memoryChannels = sendIt->second.memoryChannelDeviceHandles.get();
   }
 
-  memoryChannels = it->second.memoryChannelDeviceHandles.get();
   if ((char*)sendbuff == (char*)recvbuff + rank * sendcount) {
-    CUDACHECK(allgather<false>((int*)sendbuff, (int*)nullptr, (int*)recvbuff, memoryChannels, offsetOut, rank,
-                               NRANKS_PER_NODE, nRank, bytes / sizeof(int), stream));
+    CUDACHECK(allgather<false>((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, memoryChannels, offsetIn,
+                               offsetOut, rank, NRANKS_PER_NODE, nRank, bytes / sizeof(int), stream));
   } else {
-    CUDACHECK(allgather<true>((int*)sendbuff, (int*)nullptr, (int*)recvbuff, memoryChannels, offsetOut, rank,
-                              NRANKS_PER_NODE, nRank, bytes / sizeof(int), stream));
+    CUDACHECK(allgather<true>((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, memoryChannels, offsetIn,
+                              offsetOut, rank, NRANKS_PER_NODE, nRank, bytes / sizeof(int), stream));
   }
 
   return ncclSuccess;

--- a/include/mscclpp/env.hpp
+++ b/include/mscclpp/env.hpp
@@ -30,6 +30,7 @@ class Env {
   const std::string executionPlanDir;
   const std::string npkitDumpDir;
   const bool cudaIpcUseDefaultStream;
+  const bool disableChannelCache;
 
  private:
   Env();

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -15,7 +15,6 @@
 #include <string>
 
 int mscclppDebugLevel = -1;
-bool mscclppDisableChannelCache = false;
 static int pid = -1;
 static std::string hostname;
 thread_local int mscclppDebugNoWarn = 0;
@@ -50,15 +49,6 @@ void mscclppDebugInit() {
     tempNcclDebugLevel = MSCCLPP_LOG_ABORT;
   } else if (strcasecmp(mscclpp_debug, "TRACE") == 0) {
     tempNcclDebugLevel = MSCCLPP_LOG_TRACE;
-  }
-
-  const char* disable_channel_cache = getenv("MSCCLPP_DISABLE_CHANNEL_CACHE");
-  if (disable_channel_cache == NULL) {
-    mscclppDisableChannelCache = false;
-  } else if (strcasecmp(disable_channel_cache, "TRUE") == 0) {
-    mscclppDisableChannelCache = true;
-  } else {
-    mscclppDisableChannelCache = false;
   }
 
   /* Parse the MSCCLPP_DEBUG_SUBSYS env var
@@ -98,6 +88,8 @@ void mscclppDebugInit() {
         mask = MSCCLPP_ALLOC;
       } else if (strcasecmp(subsys, "CALL") == 0) {
         mask = MSCCLPP_CALL;
+      } else if (strcasecmp(subsys, "MSCCLPP_EXECUTOR") == 0) {
+        mask = MSCCLPP_EXECUTOR;
       } else if (strcasecmp(subsys, "ALL") == 0) {
         mask = MSCCLPP_ALL;
       }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -61,7 +61,8 @@ Env::Env()
       commId(readEnv<std::string>("MSCCLPP_COMM_ID", "")),
       executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
       npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
-      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)) {}
+      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
+      disableChannelCache(readEnv<bool>("MSCCLPP_DISABLE_CHANNEL_CACHE", false)) {}
 
 std::shared_ptr<Env> env() {
   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
@@ -80,6 +81,7 @@ std::shared_ptr<Env> env() {
     logEnv("MSCCLPP_EXECUTION_PLAN_DIR", globalEnv->executionPlanDir);
     logEnv("MSCCLPP_NPKIT_DUMP_DIR", globalEnv->npkitDumpDir);
     logEnv("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", globalEnv->cudaIpcUseDefaultStream);
+    logEnv("MSCCLPP_DISABLE_CHANNEL_CACHE", globalEnv->disableChannelCache);
   }
   return globalEnv;
 }

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -91,7 +91,6 @@ typedef enum {
 } mscclppDebugLogSubSys;
 
 extern int mscclppDebugLevel;
-extern bool mscclppDisableChannelCache;
 extern uint64_t mscclppDebugMask;
 extern pthread_mutex_t mscclppDebugLock;
 extern FILE* mscclppDebugFile;


### PR DESCRIPTION
Enhancements to all-gather operation, a temporary solution to fix the memory overhead when integrating msccl++ with pytorch.
This solution will not register input/output buffer to msccl++, so the temp output buffer for allgather could be reused by torch automatically.

* Introduced a new `allgather8` kernel function in `apps/nccl/src/allgather.hpp` to handle larger data sizes more efficiently. This includes double buffering to hide synchronization overhead and support for both in-place and out-of-place operations.
* Modified the `allgather` function to decide between `allgather6` and `allgather8` based on data size and platform, improving performance for large data sizes.

Configuration and environment improvements:

* Added a new environment variable `MSCCLPP_DISABLE_CHANNEL_CACHE` to control whether the channel cache is disabled, enhancing configurability. This variable is now part of the `Env` class and is logged during environment initialization.
* Removed the redundant global variable `mscclppDisableChannelCache` from `src/debug.cc` and updated its usage to refer to the new environment variable. 