### PR TITLE
Fix reduceMin failed issue

### DIFF
--- a/apps/nccl/src/nccl.cu
+++ b/apps/nccl/src/nccl.cu
@@ -318,11 +318,6 @@ static ncclResult_t ncclAllReduceFallback(const void* sendbuff, void* recvbuff, 
     return ncclInvalidArgument;
   }
 
-  if (op != ncclSum) {
-    WARN("Only ncclSum is supported in the fallback path");
-    return ncclInvalidArgument;
-  }
-
   // Declarating variables
   size_t sendBytes, recvBytes;
   CUdeviceptr sendBasePtr, recvBasePtr;


### PR DESCRIPTION
Remote the reduceOp check, as this already done at `getReduceOp` method