### PR TITLE
Memory ordering

### DIFF
--- a/include/mscclpp/fifo_device.hpp
+++ b/include/mscclpp/fifo_device.hpp
@@ -68,11 +68,11 @@ struct FifoDeviceHandle {
     // There is a Write-After-Read hazard for the triggerPtr->fst. So the st instruction will not be executed
     // before the loop.
 #if defined(MSCCLPP_DEVICE_CUDA)
-    asm volatile("st.global.relaxed.sys.v2.u64 [%0], {%1,%2};" ::"l"(triggerPtr), "l"(trigger.fst), "l"(trigger.snd));
+    asm volatile("st.global.release.sys.v2.u64 [%0], {%1,%2};" ::"l"(triggerPtr), "l"(trigger.fst), "l"(trigger.snd));
 #else   // !defined(MSCCLPP_DEVICE_CUDA)
     // store snd no later than fst.
     atomicStore(&(triggerPtr->snd), trigger.snd, memoryOrderRelaxed);
-    atomicStore(&(triggerPtr->fst), trigger.fst, memoryOrderRelaxed);
+    atomicStore(&(triggerPtr->fst), trigger.fst, memoryOrderRelease);
 #endif  // !defined(MSCCLPP_DEVICE_CUDA)
 
     return curFifoHead;


### PR DESCRIPTION
There appear to be two locations where the memory ordering is not guaranteed.
- In `DeviceSyncer`, the atomic load and store are in relaxed order. There seems to be no memory ordering guarantee across threadblocks. For example:
```
TB0                     | TB1
write global memory     |
DeviceSyncer.sync(...)  | DeviceSyncer.sync(...)
                        | read global memory
```
There appears to be no guarantee that TB1 sees the TB0's modification at the time of read. There is a fence before the spin loop in DeviceSyncer.sync to establish a release pattern, but no fence after the wait to establish an acquire pattern. The fence_acq_rel_gpu() may also be replaced by stronger __threadfence(), or possibly by weaker release fence plus acquire fence.
- In `FifoDeviceHandle`, the memory ordering of writing the trigger should be release? to match the acquire in
https://github.com/microsoft/mscclpp/blob/adc9ee56840a520289781fe8ac22673fe14fad19/src/fifo.cc#L46