### PR TITLE
Improve signal/wait performance and fix barrier issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ else()
     set(GPU_INCLUDE_DIRS ${hip_INCLUDE_DIRS})
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_compile_definitions(DEBUG_BUILD)
+endif()
+
 # Format targets
 include(${PROJECT_SOURCE_DIR}/cmake/AddFormatTargets.cmake)
 

--- a/include/mscclpp/atomic_device.hpp
+++ b/include/mscclpp/atomic_device.hpp
@@ -50,17 +50,17 @@ constexpr auto memoryOrderSeqCst = __ATOMIC_SEQ_CST;
 constexpr auto scopeSystem = 0;
 constexpr auto scopeDevice = 0;
 
-template <typename T, [[maybe_unused]] int scope = scopeSystem>
+template <typename T, int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE T atomicLoad(const T* ptr, int memoryOrder) {
   return __atomic_load_n(ptr, memoryOrder);
 }
 
-template <typename T, [[maybe_unused]] int scope = scopeSystem>
+template <typename T, int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE void atomicStore(T* ptr, const T& val, int memoryOrder) {
   __atomic_store_n(ptr, val, memoryOrder);
 }
 
-template <typename T, [[maybe_unused]] int scope = scopeSystem>
+template <typename T, int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE T atomicFetchAdd(T* ptr, const T& val, int memoryOrder) {
   return __atomic_fetch_add(ptr, val, memoryOrder);
 }

--- a/include/mscclpp/atomic_device.hpp
+++ b/include/mscclpp/atomic_device.hpp
@@ -20,19 +20,22 @@ constexpr cuda::memory_order memoryOrderRelease = cuda::memory_order_release;
 constexpr cuda::memory_order memoryOrderAcqRel = cuda::memory_order_acq_rel;
 constexpr cuda::memory_order memoryOrderSeqCst = cuda::memory_order_seq_cst;
 
-template <typename T>
+constexpr cuda::thread_scope scopeSystem = cuda::thread_scope_system;
+constexpr cuda::thread_scope scopeDevice = cuda::thread_scope_device;
+
+template <typename T, cuda::thread_scope Scope = cuda::thread_scope_system>
 MSCCLPP_HOST_DEVICE_INLINE T atomicLoad(T* ptr, cuda::memory_order memoryOrder) {
-  return cuda::atomic_ref<T, cuda::thread_scope_system>{*ptr}.load(memoryOrder);
+  return cuda::atomic_ref<T, Scope>{*ptr}.load(memoryOrder);
 }
 
-template <typename T>
+template <typename T, cuda::thread_scope Scope = cuda::thread_scope_system>
 MSCCLPP_HOST_DEVICE_INLINE void atomicStore(T* ptr, const T& val, cuda::memory_order memoryOrder) {
-  cuda::atomic_ref<T, cuda::thread_scope_system>{*ptr}.store(val, memoryOrder);
+  cuda::atomic_ref<T, Scope>{*ptr}.store(val, memoryOrder);
 }
 
-template <typename T>
+template <typename T, cuda::thread_scope Scope = cuda::thread_scope_system>
 MSCCLPP_HOST_DEVICE_INLINE T atomicFetchAdd(T* ptr, const T& val, cuda::memory_order memoryOrder) {
-  return cuda::atomic_ref<T, cuda::thread_scope_system>{*ptr}.fetch_add(val, memoryOrder);
+  return cuda::atomic_ref<T, Scope>{*ptr}.fetch_add(val, memoryOrder);
 }
 
 #elif defined(MSCCLPP_DEVICE_HIP)
@@ -43,17 +46,21 @@ constexpr auto memoryOrderRelease = __ATOMIC_RELEASE;
 constexpr auto memoryOrderAcqRel = __ATOMIC_ACQ_REL;
 constexpr auto memoryOrderSeqCst = __ATOMIC_SEQ_CST;
 
-template <typename T>
+// HIP does not have thread scope enums like CUDA
+constexpr auto scopeSystem = 0;
+constexpr auto scopeDevice = 0;
+
+template <typename T, [[maybe_unused]] int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE T atomicLoad(const T* ptr, int memoryOrder) {
   return __atomic_load_n(ptr, memoryOrder);
 }
 
-template <typename T>
+template <typename T, [[maybe_unused]] int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE void atomicStore(T* ptr, const T& val, int memoryOrder) {
   __atomic_store_n(ptr, val, memoryOrder);
 }
 
-template <typename T>
+template <typename T, [[maybe_unused]] int scope = scopeSystem>
 MSCCLPP_HOST_DEVICE_INLINE T atomicFetchAdd(T* ptr, const T& val, int memoryOrder) {
   return __atomic_fetch_add(ptr, val, memoryOrder);
 }

--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -7,6 +7,8 @@
 #include "atomic_device.hpp"
 #include "poll_device.hpp"
 
+#include <stdio.h>
+
 namespace mscclpp {
 
 /// A device-wide barrier.
@@ -24,16 +26,15 @@ struct DeviceSyncer {
   /// @param blockNum The number of blocks that will synchronize.
   /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
   MSCCLPP_DEVICE_INLINE void sync(int blockNum, int64_t maxSpinCount = 100000000) {
-    unsigned int maxOldCnt = blockNum - 1;
+    int maxOldCnt = blockNum;
     __syncthreads();
     if (blockNum == 1) return;
     if (threadIdx.x == 0) {
       unsigned int tmp = preFlag_ ^ 1;
-      if (atomicInc(&count_, maxOldCnt) == maxOldCnt) {
-        atomicStore<unsigned int, scopeDevice>(&flag_, tmp, memoryOrderRelease);
-      } else {
-        POLL_MAYBE_JAILBREAK((atomicLoad<unsigned int, scopeDevice>(&flag_, memoryOrderAcquire) != tmp), maxSpinCount);
-      }
+      int val = (tmp << 1) - 1;
+      maxOldCnt = val == 1 ? maxOldCnt : 0;
+      atomicFetchAdd(&count_, val, memoryOrderRelease);
+      POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&count_, memoryOrderAcquire) != maxOldCnt), maxSpinCount);
       preFlag_ = tmp;
     }
     // We need sync here because only a single thread is checking whether
@@ -43,10 +44,8 @@ struct DeviceSyncer {
 #endif  // !defined(MSCCLPP_DEVICE_COMPILE)
 
  private:
-  /// The flag to indicate whether the barrier is reached by the latest thread.
-  unsigned int flag_;
   /// The counter of synchronized blocks.
-  unsigned int count_;
+  int count_;
   /// The flag to indicate whether to increase or decrease @ref flag_.
   unsigned int preFlag_;
 };

--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -31,7 +31,7 @@ struct DeviceSyncer {
       unsigned int tmp = preFlag_ ^ 1;
       int val = (tmp << 1) - 1;
       targetCnt = val == 1 ? targetCnt : 0;
-      atomicFetchAdd(&count_, val, memoryOrderRelease);
+      atomicFetchAdd<int, scopeDevice>(&count_, val, memoryOrderRelease);
       POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&count_, memoryOrderAcquire) != targetCnt), maxSpinCount);
       preFlag_ = tmp;
     }

--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -28,13 +28,11 @@ struct DeviceSyncer {
     __syncthreads();
     if (blockNum == 1) return;
     if (threadIdx.x == 0) {
-      // Need a `__threadfence()` before to flip `flag`.
-      __threadfence();
       unsigned int tmp = preFlag_ ^ 1;
       if (atomicInc(&count_, maxOldCnt) == maxOldCnt) {
-        atomicStore(&flag_, tmp, memoryOrderRelaxed);
+        atomicStore<unsigned int, scopeDevice>(&flag_, tmp, memoryOrderRelease);
       } else {
-        POLL_MAYBE_JAILBREAK((atomicLoad(&flag_, memoryOrderRelaxed) != tmp), maxSpinCount);
+        POLL_MAYBE_JAILBREAK((atomicLoad<unsigned int, scopeDevice>(&flag_, memoryOrderAcquire) != tmp), maxSpinCount);
       }
       preFlag_ = tmp;
     }

--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -7,8 +7,6 @@
 #include "atomic_device.hpp"
 #include "poll_device.hpp"
 
-#include <stdio.h>
-
 namespace mscclpp {
 
 /// A device-wide barrier.

--- a/include/mscclpp/poll_device.hpp
+++ b/include/mscclpp/poll_device.hpp
@@ -13,7 +13,6 @@
 #if !defined(DEBUG_BUILD)
 #define __assert_fail(__assertion, __file, __line, __function) ;
 #else  // defined(DEBUG_BUILD)
-static_assert(sizeof(int) == 2, "int must be 4 bytes");
 #if defined(MSCCLPP_DEVICE_HIP)
 extern "C" __device__ void __assert_fail(const char *__assertion, const char *__file, unsigned int __line,
                                          const char *__function);

--- a/include/mscclpp/poll_device.hpp
+++ b/include/mscclpp/poll_device.hpp
@@ -10,6 +10,10 @@
 
 #include <cstdint>
 
+#if !defined(DEBUG_BUILD)
+#define __assert_fail(__assertion, __file, __line, __function) ;
+#else  // defined(DEBUG_BUILD)
+static_assert(sizeof(int) == 2, "int must be 4 bytes");
 #if defined(MSCCLPP_DEVICE_HIP)
 extern "C" __device__ void __assert_fail(const char *__assertion, const char *__file, unsigned int __line,
                                          const char *__function);
@@ -17,8 +21,8 @@ extern "C" __device__ void __assert_fail(const char *__assertion, const char *__
 extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const char *__file, unsigned int __line,
                                                   const char *__function) __THROW;
 #endif  // !defined(MSCCLPP_DEVICE_HIP)
+#endif  // !defined(DEBUG_BUILD)
 
-#if defined(DEBUG_BUILD)
 // If a spin is stuck, print a warning and keep spinning.
 #define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)                     \
   do {                                                                   \
@@ -46,32 +50,6 @@ extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const
       }                                                                            \
     }                                                                              \
   } while (0);
-#else  // !defined(DEBUG_BUILD)
-#define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)               \
-  do {                                                             \
-    int64_t __spin_cnt = 0;                                        \
-    while (__cond) {                                               \
-      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
-      }                                                            \
-    }                                                              \
-  } while (0);
-
-// the as POLL_MAYBE_JAILBREAK except that __cond1 is checked before __cond2
-// this is specially useful when __cond1 is faster to check
-#define OR_POLL_MAYBE_JAILBREAK(__cond1, __cond2, __max_spin_cnt)  \
-  do {                                                             \
-    int64_t __spin_cnt = 0;                                        \
-    while (true) {                                                 \
-      if (!(__cond1)) {                                            \
-        break;                                                     \
-      } else if (!(__cond2)) {                                     \
-        break;                                                     \
-      }                                                            \
-      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
-      }                                                            \
-    }                                                              \
-  } while (0);
-#endif  // !defined(DEBUG_BUILD)
 
 #endif  // defined(MSCCLPP_DEVICE_COMPILE)
 

--- a/include/mscclpp/poll_device.hpp
+++ b/include/mscclpp/poll_device.hpp
@@ -29,16 +29,6 @@ extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const
       }                                                                  \
     }                                                                    \
   } while (0);
-#else  // !defined(DEBUG_BUILD)
-#define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)               \
-  do {                                                             \
-    int64_t __spin_cnt = 0;                                        \
-    while (__cond) {                                               \
-      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
-      }                                                            \
-    }                                                              \
-  } while (0);
-#endif
 
 // the as POLL_MAYBE_JAILBREAK except that __cond1 is checked before __cond2
 // this is specially useful when __cond1 is faster to check
@@ -56,6 +46,32 @@ extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const
       }                                                                            \
     }                                                                              \
   } while (0);
+#else  // !defined(DEBUG_BUILD)
+#define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)               \
+  do {                                                             \
+    int64_t __spin_cnt = 0;                                        \
+    while (__cond) {                                               \
+      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
+      }                                                            \
+    }                                                              \
+  } while (0);
+
+// the as POLL_MAYBE_JAILBREAK except that __cond1 is checked before __cond2
+// this is specially useful when __cond1 is faster to check
+#define OR_POLL_MAYBE_JAILBREAK(__cond1, __cond2, __max_spin_cnt)  \
+  do {                                                             \
+    int64_t __spin_cnt = 0;                                        \
+    while (true) {                                                 \
+      if (!(__cond1)) {                                            \
+        break;                                                     \
+      } else if (!(__cond2)) {                                     \
+        break;                                                     \
+      }                                                            \
+      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
+      }                                                            \
+    }                                                              \
+  } while (0);
+#endif  // !defined(DEBUG_BUILD)
 
 #endif  // defined(MSCCLPP_DEVICE_COMPILE)
 

--- a/include/mscclpp/poll_device.hpp
+++ b/include/mscclpp/poll_device.hpp
@@ -10,9 +10,6 @@
 
 #include <cstdint>
 
-#if defined(NDEBUG)
-#define __assert_fail(__assertion, __file, __line, __function) ;
-#else  // !defined(NDEBUG)
 #if defined(MSCCLPP_DEVICE_HIP)
 extern "C" __device__ void __assert_fail(const char *__assertion, const char *__file, unsigned int __line,
                                          const char *__function);
@@ -20,8 +17,8 @@ extern "C" __device__ void __assert_fail(const char *__assertion, const char *__
 extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const char *__file, unsigned int __line,
                                                   const char *__function) __THROW;
 #endif  // !defined(MSCCLPP_DEVICE_HIP)
-#endif  // NDEBUG
 
+#if defined(DEBUG_BUILD)
 // If a spin is stuck, print a warning and keep spinning.
 #define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)                     \
   do {                                                                   \
@@ -32,6 +29,16 @@ extern "C" __host__ __device__ void __assert_fail(const char *__assertion, const
       }                                                                  \
     }                                                                    \
   } while (0);
+#else  // !defined(DEBUG_BUILD)
+#define POLL_MAYBE_JAILBREAK(__cond, __max_spin_cnt)               \
+  do {                                                             \
+    int64_t __spin_cnt = 0;                                        \
+    while (__cond) {                                               \
+      if (__max_spin_cnt >= 0 && __spin_cnt++ == __max_spin_cnt) { \
+      }                                                            \
+    }                                                              \
+  } while (0);
+#endif
 
 // the as POLL_MAYBE_JAILBREAK except that __cond1 is checked before __cond2
 // this is specially useful when __cond1 is faster to check

--- a/include/mscclpp/semaphore_device.hpp
+++ b/include/mscclpp/semaphore_device.hpp
@@ -27,8 +27,8 @@ struct Host2DeviceSemaphoreDeviceHandle {
   /// Wait for the host to signal.
   MSCCLPP_DEVICE_INLINE void wait(int64_t maxSpinCount = 100000000) {
     (*expectedInboundSemaphoreId) += 1;
-    POLL_MAYBE_JAILBREAK((atomicLoad(inboundSemaphoreId, memoryOrderAcquire) < (*expectedInboundSemaphoreId)),
-                         maxSpinCount);
+    uint64_t flag = (*expectedInboundSemaphoreId);
+    POLL_MAYBE_JAILBREAK((atomicLoad(inboundSemaphoreId, memoryOrderAcquire) < flag), maxSpinCount);
   }
 #endif  // defined(MSCCLPP_DEVICE_COMPILE)
 

--- a/include/mscclpp/semaphore_device.hpp
+++ b/include/mscclpp/semaphore_device.hpp
@@ -50,8 +50,8 @@ struct MemoryDevice2DeviceSemaphoreDeviceHandle {
   /// Wait for the remote device to signal.
   MSCCLPP_DEVICE_INLINE void wait(int64_t maxSpinCount = 100000000) {
     (*expectedInboundSemaphoreId) += 1;
-    POLL_MAYBE_JAILBREAK((atomicLoad(inboundSemaphoreId, memoryOrderAcquire) < (*expectedInboundSemaphoreId)),
-                         maxSpinCount);
+    uint64_t flag = (*expectedInboundSemaphoreId);
+    POLL_MAYBE_JAILBREAK((atomicLoad(inboundSemaphoreId, memoryOrderAcquire) < flag), maxSpinCount);
   }
 
   /// Signal the remote device.
@@ -63,7 +63,7 @@ struct MemoryDevice2DeviceSemaphoreDeviceHandle {
     // This fence ensures that preceding writes are visible on the peer GPU before the incremented
     // `outboundSemaphoreId` is visible.
     semaphoreIncrement();
-    atomicStore(remoteInboundSemaphoreId, semaphoreGetLocal(), memoryOrderSeqCst);
+    atomicStore(remoteInboundSemaphoreId, semaphoreGetLocal(), memoryOrderRelease);
   }
 
   /// Signal the remote device.

--- a/include/mscclpp/semaphore_device.hpp
+++ b/include/mscclpp/semaphore_device.hpp
@@ -63,7 +63,9 @@ struct MemoryDevice2DeviceSemaphoreDeviceHandle {
     // This fence ensures that preceding writes are visible on the peer GPU before the incremented
     // `outboundSemaphoreId` is visible.
     semaphoreIncrement();
-    atomicStore(remoteInboundSemaphoreId, semaphoreGetLocal(), memoryOrderRelease);
+    // use memoryOrderSeqCst instead of memoryOrderRelease since memoryOrderSeqCst
+    // is more efficient on A100.
+    atomicStore(remoteInboundSemaphoreId, semaphoreGetLocal(), memoryOrderSeqCst);
   }
 
   /// Signal the remote device.

--- a/test/unit/compile_tests.cu
+++ b/test/unit/compile_tests.cu
@@ -3,7 +3,10 @@
 
 #include <gtest/gtest.h>
 
-#undef DEBUG_BUILD
+#undef NDEBUG
+#ifndef DEBUG_BUILD
+#define DEBUG_BUILD
+#endif  // DEBUG_BUILD
 #include <assert.h>
 
 #include <mscclpp/poll_device.hpp>

--- a/test/unit/compile_tests.cu
+++ b/test/unit/compile_tests.cu
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#undef NDEBUG
+#undef DEBUG_BUILD
 #include <assert.h>
 
 #include <mscclpp/poll_device.hpp>


### PR DESCRIPTION
Remove __assert_fail for release build. This will reduce the number of PTX instructions inside the loop. Also Trying to resolve this issue reported in #497. Reduce the number of PTX instructions from 8 to 6. 
8 ranks signal/wait will reduce from 3.2us->2.8us on NDv5
Also NDEBUG flag is confused here, sometime it will not be set. Use customized flag for debug build.

Here is current PTX:
```
      ld.u64  %rd12, [%rd2+-24];
      mov.u64         %rd13, %rd12;
      mov.u64         %rd11, %rd13;
      ld.acquire.sys.b64 %rd10,[%rd11];
      setp.lt.u64     %p1, %rd10, %rd3;
      @%p1 bra        $L__BB2_1;
```

If we change to `asm volatile("ld.global.acquire.sys.b64 %0, [%1];" : "=l"(flag) : "l"(flag_addr));` will reduce to 4 instructions. We can get 2.1 us for 8 ranks signal/wait
```
        ld.u64  %rd9, [%rd1+-24];
        ld.global.acquire.sys.b64 %rd8, [%rd9];
        setp.lt.u64     %p1, %rd8, %rd2;
        @%p1 bra        $L__BB2_1;
```