### PR TITLE
Add flag to disable nvls

### DIFF
--- a/include/mscclpp/env.hpp
+++ b/include/mscclpp/env.hpp
@@ -34,7 +34,7 @@ class Env {
   const std::string forceNcclFallbackOperation;
   const bool enableNcclFallback;
   const bool disableChannelCache;
-  const bool disableNvls;
+  const bool forceDisableNvls;
 
  private:
   Env();

--- a/include/mscclpp/env.hpp
+++ b/include/mscclpp/env.hpp
@@ -34,6 +34,7 @@ class Env {
   const std::string forceNcclFallbackOperation;
   const bool enableNcclFallback;
   const bool disableChannelCache;
+  const bool disableNvls;
 
  private:
   Env();

--- a/include/mscclpp/gpu.hpp
+++ b/include/mscclpp/gpu.hpp
@@ -104,10 +104,10 @@ constexpr auto CU_MEM_ACCESS_FLAGS_PROT_READWRITE = hipMemAccessFlagsProtReadWri
 #if CUDART_VERSION < 12030
 #define CU_MEM_HANDLE_TYPE_FABRIC ((CUmemAllocationHandleType)0x8ULL)
 #endif
-// We need CUDA 12.0 above and kernel 5.6.0 above for NVLS
-#define CUDA_NVLS_SUPPORTED ((CUDART_VERSION >= 12000) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)))
+// We need CUDA 12.0 above and kernel 5.6.0 above for NVLS API
+#define CUDA_NVLS_API_AVAILABLE ((CUDART_VERSION >= 12000) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)))
 #else  // defined(__HIP_PLATFORM_AMD__)
-#define CUDA_NVLS_SUPPORTED 0
+#define CUDA_NVLS_API_AVAILABLE 0
 // NVLS is not supported on AMD platform, just to avoid compilation error
 #define CU_MEM_HANDLE_TYPE_FABRIC (0x8ULL)
 #endif  // !defined(__HIP_PLATFORM_AMD__)

--- a/include/mscclpp/gpu.hpp
+++ b/include/mscclpp/gpu.hpp
@@ -104,8 +104,8 @@ constexpr auto CU_MEM_ACCESS_FLAGS_PROT_READWRITE = hipMemAccessFlagsProtReadWri
 #if CUDART_VERSION < 12030
 #define CU_MEM_HANDLE_TYPE_FABRIC ((CUmemAllocationHandleType)0x8ULL)
 #endif
-// We need CUDA 12.0 above and kernel 5.6.0 above for NVLS API
-#define CUDA_NVLS_API_AVAILABLE ((CUDART_VERSION >= 12000) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)))
+// We need CUDA 12.3 above and kernel 5.6.0 above for NVLS API
+#define CUDA_NVLS_API_AVAILABLE ((CUDART_VERSION >= 12030) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)))
 #else  // defined(__HIP_PLATFORM_AMD__)
 #define CUDA_NVLS_API_AVAILABLE 0
 // NVLS is not supported on AMD platform, just to avoid compilation error

--- a/include/mscclpp/gpu_utils.hpp
+++ b/include/mscclpp/gpu_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "env.hpp"
 #include "errors.hpp"
 #include "gpu.hpp"
 #include "utils.hpp"
@@ -231,7 +232,7 @@ class GpuBuffer {
     }
     MSCCLPP_CUDATHROW(cudaGetDevice(&deviceId_));
 #if (CUDA_NVLS_SUPPORTED)
-    if (isNvlsSupported()) {
+    if (isNvlsSupported() && mscclpp::env()->disableNvls == false) {
       size_t gran = detail::getMulticastGranularity(nelems * sizeof(T), CU_MULTICAST_GRANULARITY_RECOMMENDED);
       bytes_ = (nelems * sizeof(T) + gran - 1) / gran * gran / sizeof(T) * sizeof(T);
       memory_ = detail::gpuCallocPhysicalShared<T>(nelems, gran);

--- a/include/mscclpp/gpu_utils.hpp
+++ b/include/mscclpp/gpu_utils.hpp
@@ -63,16 +63,16 @@ void* gpuCallocHost(size_t bytes);
 #if defined(__HIP_PLATFORM_AMD__)
 void* gpuCallocUncached(size_t bytes);
 #endif  // defined(__HIP_PLATFORM_AMD__)
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 extern CUmemAllocationHandleType nvlsCompatibleMemHandleType;
 void* gpuCallocPhysical(size_t bytes, size_t gran = 0, size_t align = 0);
-#endif  // CUDA_NVLS_SUPPORTED
+#endif  // CUDA_NVLS_API_AVAILABLE
 
 void gpuFree(void* ptr);
 void gpuFreeHost(void* ptr);
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 void gpuFreePhysical(void* ptr);
-#endif  // CUDA_NVLS_SUPPORTED
+#endif  // CUDA_NVLS_API_AVAILABLE
 
 void gpuMemcpyAsync(void* dst, const void* src, size_t bytes, cudaStream_t stream,
                     cudaMemcpyKind kind = cudaMemcpyDefault);
@@ -118,12 +118,12 @@ struct GpuHostDeleter {
   void operator()(void* ptr) { gpuFreeHost(ptr); }
 };
 
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 template <class T = void>
 struct GpuPhysicalDeleter {
   void operator()(void* ptr) { gpuFreePhysical(ptr); }
 };
-#endif  // CUDA_NVLS_SUPPORTED
+#endif  // CUDA_NVLS_API_AVAILABLE
 
 template <class T>
 using UniqueGpuPtr = std::unique_ptr<T, detail::GpuDeleter<T>>;
@@ -165,7 +165,7 @@ auto gpuCallocUncachedUnique(size_t nelems = 1) {
 
 #endif  // defined(__HIP_PLATFORM_AMD__)
 
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 
 template <class T>
 using UniqueGpuPhysicalPtr = std::unique_ptr<T, detail::GpuPhysicalDeleter<T>>;
@@ -184,7 +184,7 @@ auto gpuCallocPhysicalUnique(size_t nelems = 1, size_t gran = 0, size_t align = 
 
 size_t getMulticastGranularity(size_t size, CUmulticastGranularity_flags granFlag);
 
-#endif  // CUDA_NVLS_SUPPORTED
+#endif  // CUDA_NVLS_API_AVAILABLE
 
 }  // namespace detail
 
@@ -231,14 +231,14 @@ class GpuBuffer {
       return;
     }
     MSCCLPP_CUDATHROW(cudaGetDevice(&deviceId_));
-#if (CUDA_NVLS_SUPPORTED)
-    if (isNvlsSupported() && mscclpp::env()->disableNvls == false) {
+#if (CUDA_NVLS_API_AVAILABLE)
+    if (isNvlsSupported()) {
       size_t gran = detail::getMulticastGranularity(nelems * sizeof(T), CU_MULTICAST_GRANULARITY_RECOMMENDED);
       bytes_ = (nelems * sizeof(T) + gran - 1) / gran * gran / sizeof(T) * sizeof(T);
       memory_ = detail::gpuCallocPhysicalShared<T>(nelems, gran);
       return;
     }
-#endif  // CUDA_NVLS_SUPPORTED
+#endif  // CUDA_NVLS_API_AVAILABLE
 
     bytes_ = nelems * sizeof(T);
 #if defined(__HIP_PLATFORM_AMD__)

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -65,7 +65,8 @@ Env::Env()
       ncclSharedLibPath(readEnv<std::string>("MSCCLPP_NCCL_LIB_PATH", "")),
       forceNcclFallbackOperation(readEnv<std::string>("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", "")),
       enableNcclFallback(readEnv<bool>("MSCCLPP_ENABLE_NCCL_FALLBACK", false)),
-      disableChannelCache(readEnv<bool>("MSCCLPP_DISABLE_CHANNEL_CACHE", false)) {}
+      disableChannelCache(readEnv<bool>("MSCCLPP_DISABLE_CHANNEL_CACHE", false)),
+      disableNvls(readEnv<bool>("MSCCLPP_DISABLE_NVLS", false)) {}
 
 std::shared_ptr<Env> env() {
   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
@@ -88,6 +89,7 @@ std::shared_ptr<Env> env() {
     logEnv("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", globalEnv->forceNcclFallbackOperation);
     logEnv("MSCCLPP_ENABLE_NCCL_FALLBACK", globalEnv->enableNcclFallback);
     logEnv("MSCCLPP_DISABLE_CHANNEL_CACHE", globalEnv->disableChannelCache);
+    logEnv("MSCCLPP_DISABLE_NVLS", globalEnv->disableNvls);
   }
   return globalEnv;
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -66,7 +66,7 @@ Env::Env()
       forceNcclFallbackOperation(readEnv<std::string>("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", "")),
       enableNcclFallback(readEnv<bool>("MSCCLPP_ENABLE_NCCL_FALLBACK", false)),
       disableChannelCache(readEnv<bool>("MSCCLPP_DISABLE_CHANNEL_CACHE", false)),
-      disableNvls(readEnv<bool>("MSCCLPP_DISABLE_NVLS", false)) {}
+      forceDisableNvls(readEnv<bool>("MSCCLPP_FORCE_DISABLE_NVLS", false)) {}
 
 std::shared_ptr<Env> env() {
   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
@@ -89,7 +89,7 @@ std::shared_ptr<Env> env() {
     logEnv("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", globalEnv->forceNcclFallbackOperation);
     logEnv("MSCCLPP_ENABLE_NCCL_FALLBACK", globalEnv->enableNcclFallback);
     logEnv("MSCCLPP_DISABLE_CHANNEL_CACHE", globalEnv->disableChannelCache);
-    logEnv("MSCCLPP_DISABLE_NVLS", globalEnv->disableNvls);
+    logEnv("MSCCLPP_FORCE_DISABLE_NVLS", globalEnv->forceDisableNvls);
   }
   return globalEnv;
 }

--- a/src/nvls.cc
+++ b/src/nvls.cc
@@ -15,7 +15,7 @@
 
 namespace mscclpp {
 
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 class NvlsConnection::Impl : public std::enable_shared_from_this<NvlsConnection::Impl> {
  public:
   // use this only for the root of the NVLS
@@ -222,7 +222,7 @@ std::shared_ptr<char> NvlsConnection::Impl::bindMemory(CUdeviceptr devicePtr, si
   return std::shared_ptr<char>(mcPtr, deleter);
 }
 
-#else   // !(CUDA_NVLS_SUPPORTED)
+#else   // !(CUDA_NVLS_API_AVAILABLE)
 class NvlsConnection::Impl {
  public:
   // use this only for the root of the NVLS
@@ -243,7 +243,7 @@ class NvlsConnection::Impl {
   Error notSupportedError =
       Error("NVLS is not supported on this CUDA version (< 12.3) or kernel version (< 5.6.0)", ErrorCode::InvalidUsage);
 };
-#endif  // !(CUDA_NVLS_SUPPORTED)
+#endif  // !(CUDA_NVLS_API_AVAILABLE)
 
 NvlsConnection::NvlsConnection(size_t bufferSize, int numDevices)
     : pimpl_(std::make_shared<Impl>(bufferSize, numDevices)) {}

--- a/src/registered_memory.cc
+++ b/src/registered_memory.cc
@@ -28,7 +28,7 @@
 
 namespace {
 CUmemAllocationHandleType getNvlsMemHandleType() {
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
   if (mscclpp::detail::nvlsCompatibleMemHandleType & CU_MEM_HANDLE_TYPE_FABRIC) {
     return CU_MEM_HANDLE_TYPE_FABRIC;
   } else {
@@ -228,7 +228,7 @@ RegisteredMemory::Impl::Impl(const std::vector<char>& serialization) {
     auto entry = getTransportInfo(Transport::CudaIpc);
     void* base;
     if (this->isCuMemMapAlloc) {
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
       CUmemGenericAllocationHandle handle;
       if (getNvlsMemHandleType() == CU_MEM_HANDLE_TYPE_FABRIC) {
         MSCCLPP_CUTHROW(cuMemImportFromShareableHandle(&handle, entry.shareableHandle, getNvlsMemHandleType()));

--- a/test/nvls_test.cu
+++ b/test/nvls_test.cu
@@ -8,7 +8,7 @@
 #include <unistd.h>
 
 #include <mscclpp/gpu.hpp>
-#if (CUDA_NVLS_SUPPORTED)
+#if (CUDA_NVLS_API_AVAILABLE)
 #include <cuda.h>
 #include <cudaTypedefs.h>
 #include <cuda_runtime.h>
@@ -202,11 +202,11 @@ int main() {
   return 0;
 }
 
-#else  // !(CUDA_NVLS_SUPPORTED)
+#else  // !(CUDA_NVLS_API_AVAILABLE)
 
 int main() {
   printf("This test requires NVLS to be enabled\n");
   return 0;
 }
 
-#endif  // !(CUDA_NVLS_SUPPORTED)
+#endif  // !(CUDA_NVLS_API_AVAILABLE)


### PR DESCRIPTION
Mitigate this issue: #496, for now `ibv_reg_dmabuf_mr` is not supported by Azure vm. Add this flag to force to use cudaMalloc for memory allocation and disable nvls feature