### PR TITLE
Fix the virtual address mapping issue of cuMemMap in fallback code

### DIFF
--- a/src/include/registered_memory.hpp
+++ b/src/include/registered_memory.hpp
@@ -48,6 +48,8 @@ struct RegisteredMemory::Impl {
   // This is the original data pointer the RegisteredMemory was created with.
   void* originalDataPtr;
   size_t size;
+  // This is the size returned by cuMemGetAddressRange of data
+  size_t baseDataSize;
   uint64_t hostHash;
   uint64_t pidHash;
   bool isCuMemMapAlloc;

--- a/src/registered_memory.cc
+++ b/src/registered_memory.cc
@@ -55,7 +55,7 @@ RegisteredMemory::Impl::Impl(void* data, size_t size, TransportFlags transports,
     transportInfo.transport = Transport::CudaIpc;
 
     void* baseDataPtr;
-    size_t baseDataSize;  // dummy
+    size_t baseDataSize;
     MSCCLPP_CUTHROW(cuMemGetAddressRange((CUdeviceptr*)&baseDataPtr, &baseDataSize, (CUdeviceptr)data));
     this->baseDataSize = baseDataSize;
     this->isCuMemMapAlloc = isCuMemMapAllocated(baseDataPtr);

--- a/src/registered_memory.cc
+++ b/src/registered_memory.cc
@@ -252,7 +252,8 @@ RegisteredMemory::Impl::Impl(const std::vector<char>& serialization) {
         close(fd);
       }
       size_t minGran = detail::getMulticastGranularity(this->baseDataSize, CU_MULTICAST_GRANULARITY_MINIMUM);
-      size_t recommendedGran = detail::getMulticastGranularity(this->baseDataSize, CU_MULTICAST_GRANULARITY_RECOMMENDED);
+      size_t recommendedGran =
+          detail::getMulticastGranularity(this->baseDataSize, CU_MULTICAST_GRANULARITY_RECOMMENDED);
       size_t size = (this->baseDataSize + recommendedGran - 1) / recommendedGran * recommendedGran;
       MSCCLPP_CUTHROW(cuMemAddressReserve((CUdeviceptr*)&base, size, minGran, 0, 0));
       MSCCLPP_CUTHROW(cuMemMap((CUdeviceptr)base, size, 0, handle, 0));


### PR DESCRIPTION
Fix the virtual address mapping issue of cuMemMap by using the size of device memory allocation instead of user buffer size