### PR TITLE
Optimized allreduce fallback for ~10KB sizes

### DIFF
--- a/apps/nccl/src/allreduce.hpp
+++ b/apps/nccl/src/allreduce.hpp
@@ -157,55 +157,11 @@ __forceinline__ __device__ int cal_vectors_helper(int a, int b) {
   return bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a), bit_cast<T, int>(b)));
 }
 
-template <typename T, Op OpType>
-__forceinline__ __device__ int4 cal_vectors(int4 a, int4 b) {
+template <typename T, Op OpType, typename DataType>
+__forceinline__ __device__ DataType cal_vectors(DataType a, DataType b) {
   using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
                                                std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
   return cal_vectors_helper<CompType, OpType>(a, b);
-}
-
-template <typename T, Op OpType>
-__forceinline__ __device__ uint2 cal_vectors(uint2 a, uint2 b) {
-  using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
-                                               std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
-  return cal_vectors_helper<CompType, OpType>(a, b);
-}
-
-template <typename T, Op OpType>
-__forceinline__ __device__ int cal_vectors(int a, int b) {
-  using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
-                                               std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
-  return cal_vectors_helper<CompType, OpType>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ int4 cal_vectors(int4 a, int4 b, Op op) {
-  if (op == SUM) {
-    return cal_vectors<T, SUM>(a, b);
-  } else if (op == MIN) {
-    return cal_vectors<T, MIN>(a, b);
-  }
-  return a;
-}
-
-template <typename T>
-__forceinline__ __device__ uint2 cal_vectors(uint2 a, uint2 b, Op op) {
-  if (op == SUM) {
-    return cal_vectors<T, SUM>(a, b);
-  } else if (op == MIN) {
-    return cal_vectors<T, MIN>(a, b);
-  }
-  return a;
-}
-
-template <typename T>
-__forceinline__ __device__ int cal_vectors(int a, int b, Op op) {
-  if (op == SUM) {
-    return cal_vectors<T, SUM>(a, b);
-  } else if (op == MIN) {
-    return cal_vectors<T, MIN>(a, b);
-  }
-  return a;
 }
 
 template <Op OpType, typename T>

--- a/apps/nccl/src/allreduce.hpp
+++ b/apps/nccl/src/allreduce.hpp
@@ -11,6 +11,7 @@
 #include <mscclpp/memory_channel.hpp>
 #include <mscclpp/memory_channel_device.hpp>
 #include <mscclpp/packet_device.hpp>
+#include <type_traits>
 
 #if defined(ENABLE_NPKIT)
 #include <mscclpp/npkit/npkit.hpp>
@@ -73,29 +74,36 @@ __forceinline__ __device__ __bfloat162 clip(__bfloat162 val) {
   return val;
 }
 
-template <typename T>
+template <typename T, bool UseClip = true>
 __forceinline__ __device__ T add_elements(T a, T b) {
-  return clip(a + b);
+  if constexpr (UseClip) {
+    return clip(a + b);
+  } else {
+    return a + b;
+  }
+}
+
+template <bool UseClip = true>
+__forceinline__ __device__ __half2 add_elements(__half2 a, __half2 b) {
+  if constexpr (UseClip) {
+    return clip(__hadd2(a, b));
+  } else {
+    return __hadd2(a, b);
+  }
+}
+
+template <bool UseClip = true>
+__forceinline__ __device__ __bfloat162 add_elements(__bfloat162 a, __bfloat162 b) {
+  if constexpr (UseClip) {
+    return clip(__hadd2(a, b));
+  } else {
+    return __hadd2(a, b);
+  }
 }
 
 template <typename T>
 __forceinline__ __device__ T min_elements(T a, T b) {
   return (a < b ? a : b);
-}
-
-template <typename T, Op op>
-__forceinline__ __device__ T cal_elements(T a, T b) {
-  if constexpr (op == SUM) {
-    return add_elements(a, b);
-  } else if constexpr (op == MIN) {
-    return min_elements(a, b);
-  }
-  return (a < b ? a : b);
-}
-
-template <>
-__forceinline__ __device__ __half2 add_elements(__half2 a, __half2 b) {
-  return clip(__hadd2(a, b));
 }
 
 template <>
@@ -111,337 +119,100 @@ __forceinline__ __device__ __half2 min_elements(__half2 a, __half2 b) {
 }
 
 template <>
-__forceinline__ __device__ __bfloat162 add_elements(__bfloat162 a, __bfloat162 b) {
-  return clip(__hadd2(a, b));
-}
-
-template <>
 __forceinline__ __device__ __bfloat162 min_elements(__bfloat162 a, __bfloat162 b) {
   return __hmin2(a, b);
 }
 
-template <typename T>
-__forceinline__ __device__ int4 add_vectors_helper(int4 a, int4 b) {
-  int4 ret;
-  ret.w = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.w), bit_cast<T, int>(b.w)));
-  ret.x = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
-  ret.y = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
-  ret.z = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.z), bit_cast<T, int>(b.z)));
-  return ret;
-}
-
-template <typename T>
-__forceinline__ __device__ int4 min_vectors_helper(int4 a, int4 b) {
-  int4 ret;
-  ret.w = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.w), bit_cast<T, int>(b.w)));
-  ret.x = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
-  ret.y = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
-  ret.z = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.z), bit_cast<T, int>(b.z)));
-  return ret;
-}
-
-template <typename T, Op op>
-__forceinline__ __device__ int4 cal_vectors_helper(int4 a, int4 b) {
-  if constexpr (op == SUM) {
-    return add_vectors_helper<T>(a, b);
-  } else if constexpr (op == MIN) {
-    return min_vectors_helper<T>(a, b);
+template <typename T, Op OpType>
+__forceinline__ __device__ T cal_elements(T a, T b) {
+  if constexpr (OpType == SUM) {
+    return add_elements(a, b);
+  } else if constexpr (OpType == MIN) {
+    return min_elements(a, b);
+  } else {
+    static_assert(false, "Unsupported operation");
   }
-  return a;
 }
 
-template <typename T>
-__forceinline__ __device__ int4 add_vectors(int4 a, int4 b) {
-  return add_vectors_helper<T>(a, b);
+template <typename T, Op OpType>
+__forceinline__ __device__ int4 cal_vectors_helper(int4 a, int4 b) {
+  int4 ret;
+  ret.w = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.w), bit_cast<T, int>(b.w)));
+  ret.x = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
+  ret.y = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
+  ret.z = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.z), bit_cast<T, int>(b.z)));
+  return ret;
 }
 
-template <typename T>
-__forceinline__ __device__ int4 min_vectors(int4 a, int4 b) {
-  return min_vectors_helper<T>(a, b);
+template <typename T, Op OpType>
+__forceinline__ __device__ uint2 cal_vectors_helper(uint2 a, uint2 b) {
+  uint2 ret;
+  ret.x = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
+  ret.y = bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
+  return ret;
+}
+
+template <typename T, Op OpType>
+__forceinline__ __device__ int cal_vectors_helper(int a, int b) {
+  return bit_cast<int, T>(cal_elements<T, OpType>(bit_cast<T, int>(a), bit_cast<T, int>(b)));
+}
+
+template <typename T, Op OpType>
+__forceinline__ __device__ int4 cal_vectors(int4 a, int4 b) {
+  using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
+                                               std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
+  return cal_vectors_helper<CompType, OpType>(a, b);
+}
+
+template <typename T, Op OpType>
+__forceinline__ __device__ uint2 cal_vectors(uint2 a, uint2 b) {
+  using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
+                                               std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
+  return cal_vectors_helper<CompType, OpType>(a, b);
+}
+
+template <typename T, Op OpType>
+__forceinline__ __device__ int cal_vectors(int a, int b) {
+  using CompType = typename std::conditional_t<std::is_same_v<T, __half>, __half2,
+                                               std::conditional_t<std::is_same_v<T, __bfloat16>, __bfloat162, T>>;
+  return cal_vectors_helper<CompType, OpType>(a, b);
 }
 
 template <typename T>
 __forceinline__ __device__ int4 cal_vectors(int4 a, int4 b, Op op) {
   if (op == SUM) {
-    return cal_vectors_helper<T, SUM>(a, b);
+    return cal_vectors<T, SUM>(a, b);
   } else if (op == MIN) {
-    return cal_vectors_helper<T, MIN>(a, b);
-  }
-  // SHOULD NOT REACH HERE
-  return a;
-}
-
-template <>
-__forceinline__ __device__ int4 add_vectors<__half>(int4 a, int4 b) {
-  return add_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int4 min_vectors<__half>(int4 a, int4 b) {
-  return min_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int4 add_vectors<__bfloat16>(int4 a, int4 b) {
-  return add_vectors_helper<__bfloat162>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ uint2 add_vectors_helper(uint2 a, uint2 b) {
-  uint2 ret;
-  ret.x = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
-  ret.y = bit_cast<int, T>(add_elements(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
-  return ret;
-}
-
-template <typename T>
-__forceinline__ __device__ uint2 min_vectors_helper(uint2 a, uint2 b) {
-  uint2 ret;
-  ret.x = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.x), bit_cast<T, int>(b.x)));
-  ret.y = bit_cast<int, T>(min_elements(bit_cast<T, int>(a.y), bit_cast<T, int>(b.y)));
-  return ret;
-}
-
-template <typename T, Op op>
-__forceinline__ __device__ uint2 cal_vectors_helper(uint2 a, uint2 b) {
-  if constexpr (op == SUM) {
-    return add_vectors_helper<T>(a, b);
-  } else if constexpr (op == MIN) {
-    return min_vectors_helper<T>(a, b);
+    return cal_vectors<T, MIN>(a, b);
   }
   return a;
-}
-
-template <typename T>
-__forceinline__ __device__ uint2 add_vectors(uint2 a, uint2 b) {
-  return add_vectors_helper<T>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ uint2 min_vectors(uint2 a, uint2 b) {
-  return min_vectors_helper<T>(a, b);
 }
 
 template <typename T>
 __forceinline__ __device__ uint2 cal_vectors(uint2 a, uint2 b, Op op) {
   if (op == SUM) {
-    return cal_vectors_helper<T, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<T, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ uint2 add_vectors<__half>(uint2 a, uint2 b) {
-  return add_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint2 min_vectors<__half>(uint2 a, uint2 b) {
-  return min_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint2 cal_vectors<__half>(uint2 a, uint2 b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<__half2, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<__half2, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ uint2 add_vectors<__bfloat16>(uint2 a, uint2 b) {
-  return add_vectors_helper<__bfloat162>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint2 min_vectors<__bfloat16>(uint2 a, uint2 b) {
-  return min_vectors_helper<__bfloat162>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ int add_vectors_helper(int a, int b) {
-  return bit_cast<int, T>(add_elements(bit_cast<T, int>(a), bit_cast<T, int>(b)));
-}
-
-template <typename T>
-__forceinline__ __device__ int min_vectors_helper(int a, int b) {
-  return bit_cast<int, T>(min_elements(bit_cast<T, int>(a), bit_cast<T, int>(b)));
-}
-
-template <typename T, Op op>
-__forceinline__ __device__ int cal_vectors_helper(int a, int b) {
-  if constexpr (op == SUM) {
-    return add_vectors_helper<T>(a, b);
-  } else if constexpr (op == MIN) {
-    return min_vectors_helper<T>(a, b);
+    return cal_vectors<T, SUM>(a, b);
+  } else if (op == MIN) {
+    return cal_vectors<T, MIN>(a, b);
   }
   return a;
-}
-
-template <typename T>
-__forceinline__ __device__ int add_vectors(int a, int b) {
-  return add_vectors_helper<T>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ int min_vectors(int a, int b) {
-  return min_vectors_helper<T>(a, b);
 }
 
 template <typename T>
 __forceinline__ __device__ int cal_vectors(int a, int b, Op op) {
   if (op == SUM) {
-    return cal_vectors_helper<T, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<T, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ int add_vectors<__half>(int a, int b) {
-  return add_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int min_vectors<__half>(int a, int b) {
-  return min_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int cal_vectors<__half>(int a, int b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<__half2, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<__half2, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ int add_vectors<__bfloat16>(int a, int b) {
-  return add_vectors_helper<__bfloat162>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int min_vectors<__bfloat16>(int a, int b) {
-  return min_vectors_helper<__bfloat162>(a, b);
-}
-
-template <>
-__forceinline__ __device__ int cal_vectors<__bfloat16>(int a, int b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<__bfloat162, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<__bfloat162, MIN>(a, b);
-  }
-}
-
-template <typename T>
-__forceinline__ __device__ uint32_t add_vectors_helper(uint32_t a, uint32_t b) {
-  return bit_cast<uint32_t, T>(add_elements(bit_cast<T, uint32_t>(a), bit_cast<T, uint32_t>(b)));
-}
-
-template <typename T>
-__forceinline__ __device__ uint32_t min_vectors_helper(uint32_t a, uint32_t b) {
-  return bit_cast<uint32_t, T>(min_elements(bit_cast<T, uint32_t>(a), bit_cast<T, uint32_t>(b)));
-}
-
-template <typename T, Op op>
-__forceinline__ __device__ uint32_t cal_vectors_helper(uint32_t a, uint32_t b) {
-  if constexpr (op == SUM) {
-    return add_vectors_helper<T>(a, b);
-  } else if constexpr (op == MIN) {
-    return min_vectors_helper<T>(a, b);
+    return cal_vectors<T, SUM>(a, b);
+  } else if (op == MIN) {
+    return cal_vectors<T, MIN>(a, b);
   }
   return a;
 }
 
-template <typename T>
-__forceinline__ __device__ uint32_t add_vectors(uint32_t a, uint32_t b) {
-  return add_vectors_helper<T>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ uint32_t min_vectors(uint32_t a, uint32_t b) {
-  return min_vectors_helper<T>(a, b);
-}
-
-template <typename T>
-__forceinline__ __device__ uint32_t cal_vectors(uint32_t a, uint32_t b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<T, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<T, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ uint32_t add_vectors<__half>(uint32_t a, uint32_t b) {
-  return add_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint32_t min_vectors<__half>(uint32_t a, uint32_t b) {
-  return min_vectors_helper<__half2>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint32_t cal_vectors<__half>(uint32_t a, uint32_t b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<__half2, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<__half2, MIN>(a, b);
-  }
-}
-
-template <>
-__forceinline__ __device__ uint32_t add_vectors<__bfloat16>(uint32_t a, uint32_t b) {
-  return add_vectors_helper<__bfloat162>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint32_t min_vectors<__bfloat16>(uint32_t a, uint32_t b) {
-  return min_vectors_helper<__bfloat162>(a, b);
-}
-
-template <>
-__forceinline__ __device__ uint32_t cal_vectors<__bfloat16>(uint32_t a, uint32_t b, Op op) {
-  if (op == SUM) {
-    return cal_vectors_helper<__bfloat162, SUM>(a, b);
-  } else {
-    return cal_vectors_helper<__bfloat162, MIN>(a, b);
-  }
-}
-
-template <typename T>
-__forceinline__ __device__ void vectorSum(T* dst, T* src, size_t nElem, int blockId, int nBlocks) {
-  size_t nInt4 = nElem / 4;
-  size_t nLastInts = nElem % 4;
-  int4* dst4 = (int4*)dst;
-  int4* src4 = (int4*)src;
-  for (size_t i = threadIdx.x + blockId * blockDim.x; i < nInt4; i += blockDim.x * nBlocks) {
-    dst4[i] = add_vectors<T>(dst4[i], src4[i]);
-  }
-  if (nLastInts > 0) {
-    int* dstLast = ((int*)dst) + nInt4 * 4;
-    int* srcLast = ((int*)src) + nInt4 * 4;
-    for (size_t i = threadIdx.x + blockId * blockDim.x; i < nLastInts; i += blockDim.x * nBlocks) {
-      dstLast[i] = add_vectors<T>(dstLast[i], srcLast[i]);
-    }
-  }
-}
-
-template <typename T>
-__forceinline__ __device__ void vectorSum(T* dst, T* src, size_t nElem) {
-  vectorSum(dst, src, nElem, blockIdx.x, gridDim.x);
-}
-
-template <typename T>
-__global__ void __launch_bounds__(32, 1)
-    allreduceAllToAll(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
-                      size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
-                      Op op, size_t nelems, uint32_t flag) {
+template <Op OpType, typename T>
+__global__ void allreduceAllPairs(T* buff, T* scratch, T* resultBuff,
+                                  mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
+                                  size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode,
+                                  int worldSize, size_t nelems, uint32_t flag) {
   // This version of allreduce only works for single nodes
   if (worldSize != nRanksPerNode) return;
   if (sizeof(T) == 2) nelems = (nelems * sizeof(T) + sizeof(T)) / sizeof(int);
@@ -456,16 +227,9 @@ __global__ void __launch_bounds__(32, 1)
   uint32_t* src = (uint32_t*)((char*)buff);
   uint32_t* dst = (uint32_t*)((char*)resultBuff);
 
-  __shared__ mscclpp::DeviceHandle<mscclpp::MemoryChannel> channels[NRANKS_PER_NODE - 1];
-  const int lid = tid % WARP_SIZE;
-  if (lid < nPeers) {
-    channels[lid] = memoryChannels[lid];
-  }
-  __syncwarp();
-
   // step 1: write data to each peer's scratch buffer
-  channels[peerIdx].putPackets<mscclpp::LL8Packet>(scratchOffset, srcOffset, nelems * sizeof(uint32_t), tid,
-                                                   blockDim.x * nBlocksPerPeer, flag);
+  memoryChannels[peerIdx].putPackets<mscclpp::LL8Packet>(scratchOffset, srcOffset, nelems * sizeof(uint32_t), tid,
+                                                         blockDim.x * nBlocksPerPeer, flag);
 
   // step 2: Reduce Data
   for (size_t idx = threadIdx.x + blockIdx.x * blockDim.x; idx < nelems; idx += blockDim.x * gridDim.x) {
@@ -474,16 +238,16 @@ __global__ void __launch_bounds__(32, 1)
       const int remoteRank = index < rank ? index : index + 1;
       mscclpp::LL8Packet* dstPkt = (mscclpp::LL8Packet*)scratchBuff + remoteRank * nelems;
       uint32_t val = dstPkt[idx].read(flag, -1);
-      data = cal_vectors<T>(val, data, op);
+      data = cal_vectors<T, OpType>(val, data);
     }
     dst[idx] = data;
   }
 }
 
-template <typename T>
+template <Op OpType, typename T>
 __global__ void __launch_bounds__(1024, 1)
     allreduce7(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
-               size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize, Op op,
+               size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
                size_t nelems, uint32_t flag
 #if defined(ENABLE_NPKIT)
                ,
@@ -563,8 +327,8 @@ __global__ void __launch_bounds__(1024, 1)
       const int remoteRank = index < rank ? index : index + 1;
       mscclpp::LLPacket* dstPkt = (mscclpp::LLPacket*)scratchBuff + remoteRank * nPktsPerRank;
       uint2 val = dstPkt[idx].read(flag);
-      data.x = cal_vectors<T>(val.x, data.x, op);
-      data.y = cal_vectors<T>(val.y, data.y, op);
+      data.x = cal_vectors<T, OpType>(val.x, data.x);
+      data.y = cal_vectors<T, OpType>(val.y, data.y);
     }
 
     dst[idx].x = data.x;
@@ -601,7 +365,7 @@ __global__ void __launch_bounds__(1024, 1)
 #endif
 }
 
-template <typename T>
+template <Op OpType, typename T>
 __global__ void __launch_bounds__(512, 1)
     allreduce8(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
                mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryOutChannels, size_t channelOutDataOffset,
@@ -678,7 +442,7 @@ __global__ void __launch_bounds__(512, 1)
       for (int peerIdx = 0; peerIdx < NPEERS; peerIdx++) {
         const int remoteRank = (peerIdx < rank) ? peerIdx : peerIdx + 1;
         int4 val = scratch4[chunkSizePerRank * remoteRank + blockOffset + idx];
-        data = add_vectors<T>(val, data);
+        data = cal_vectors<T, OpType>(val, data);
       }
       resultBuff4[nInt4PerRank * rank + idx + offsetOfThisBlock] = data;
       for (int peerIdx = 0; peerIdx < NPEERS; peerIdx++) {
@@ -718,7 +482,7 @@ __global__ void __launch_bounds__(512, 1)
       for (int peerIdx = 0; peerIdx < NPEERS; peerIdx++) {
         const int remoteRank = (peerIdx < rank) ? peerIdx : peerIdx + 1;
         int4 val = scratch4[chunkSizePerRank * remoteRank + blockOffset + idx];
-        data = add_vectors<T>(val, data);
+        data = cal_vectors<T, OpType>(val, data);
       }
       resultBuff4[nInt4PerRank * rank + idx + offsetOfThisBlock] = data;
       for (int peerIdx = 0; peerIdx < NPEERS; peerIdx++) {
@@ -737,19 +501,26 @@ __global__ void __launch_bounds__(512, 1)
   }
 }
 
-template <typename T>
-cudaError_t allreduce(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
+template <Op OpType, typename T>
+cudaError_t allreduce(const void* buff, void* scratch, void* resultBuff,
+                      mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryChannels,
                       mscclpp::DeviceHandle<mscclpp::MemoryChannel>* memoryOutChannels, size_t channelInOffset,
                       size_t channelOutOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
-                      Op op, size_t nelems, cudaStream_t stream) {
+                      size_t nelems, cudaStream_t stream) {
   static uint32_t flag = 1;
 
   if (sizeof(T) * nelems < worldSize * sizeof(int)) {
     int nBlocks = 7;
     int nThreadsPerBlock = 32;
-    allreduceAllToAll<<<nBlocks, nThreadsPerBlock, 0, stream>>>(buff, scratch, resultBuff, memoryChannels,
-                                                                channelInOffset, channelScratchOffset, rank,
-                                                                nRanksPerNode, worldSize, op, nelems, flag++);
+    allreduceAllPairs<OpType><<<nBlocks, nThreadsPerBlock, 0, stream>>>(
+        (T*)buff, (T*)scratch, (T*)resultBuff, memoryChannels, channelInOffset, channelScratchOffset, rank,
+        nRanksPerNode, worldSize, nelems, flag++);
+  } else if (sizeof(T) * nelems <= (1 << 14)) {
+    int nBlocks = 28;
+    int nThreadsPerBlock = 512;
+    allreduceAllPairs<OpType><<<nBlocks, nThreadsPerBlock, 0, stream>>>(
+        (T*)buff, (T*)scratch, (T*)resultBuff, memoryChannels, channelInOffset, channelScratchOffset, rank,
+        nRanksPerNode, worldSize, nelems, flag++);
   } else if (sizeof(T) * nelems <= (1 << 20)) {
     int nBlocks = 28;
     int nThreadsPerBlock = 1024;
@@ -759,20 +530,20 @@ cudaError_t allreduce(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
     }
 #if defined(ENABLE_NPKIT)
     size_t NpkitSharedMemSize = NPKIT_SHM_NUM_EVENTS * sizeof(NpKitEvent);
-    allreduce7<<<nBlocks, nThreadsPerBlock, NpkitSharedMemSize, stream>>>(
-        buff, scratch, resultBuff, memoryChannels, channelInOffset, channelScratchOffset, rank, nRanksPerNode,
-        worldSize, op, nelems, flag++, NpKit::GetGpuEventCollectContexts(), NpKit::GetCpuTimestamp());
+    allreduce7<OpType><<<nBlocks, nThreadsPerBlock, NpkitSharedMemSize, stream>>>(
+        (T*)buff, (T*)scratch, (T*)resultBuff, memoryChannels, channelInOffset, channelScratchOffset, rank,
+        nRanksPerNode, worldSize, nelems, flag++, NpKit::GetGpuEventCollectContexts(), NpKit::GetCpuTimestamp());
 #else
-    allreduce7<<<nBlocks, nThreadsPerBlock, 0, stream>>>(buff, scratch, resultBuff, memoryChannels, channelInOffset,
-                                                         channelScratchOffset, rank, nRanksPerNode, worldSize, op,
-                                                         nelems, flag++);
+    allreduce7<OpType><<<nBlocks, nThreadsPerBlock, 0, stream>>>((T*)buff, (T*)scratch, (T*)resultBuff, memoryChannels,
+                                                                 channelInOffset, channelScratchOffset, rank,
+                                                                 nRanksPerNode, worldSize, nelems, flag++);
 #endif
   } else {
     int nBlocks = 35;
     int nThreadsPerBlock = 512;
-    allreduce8<<<nBlocks, nThreadsPerBlock, 0, stream>>>(buff, scratch, resultBuff, memoryChannels, memoryOutChannels,
-                                                         channelOutOffset, channelScratchOffset, rank, nRanksPerNode,
-                                                         worldSize, nelems);
+    allreduce8<OpType><<<nBlocks, nThreadsPerBlock, 0, stream>>>(
+        (T*)buff, (T*)scratch, (T*)resultBuff, memoryChannels, memoryOutChannels, channelOutOffset,
+        channelScratchOffset, rank, nRanksPerNode, worldSize, nelems);
   }
 
   return cudaGetLastError();

--- a/apps/nccl/src/allreduce.hpp
+++ b/apps/nccl/src/allreduce.hpp
@@ -129,9 +129,9 @@ __forceinline__ __device__ T cal_elements(T a, T b) {
     return add_elements(a, b);
   } else if constexpr (OpType == MIN) {
     return min_elements(a, b);
-  } else {
-    static_assert(false, "Unsupported operation");
   }
+  // Should never reach here
+  return a;
 }
 
 template <typename T, Op OpType>

--- a/apps/nccl/src/nccl.cu
+++ b/apps/nccl/src/nccl.cu
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <functional>
 #include <mscclpp/concurrency_device.hpp>
 #include <mscclpp/core.hpp>
 #include <mscclpp/env.hpp>
@@ -380,32 +381,40 @@ static ncclResult_t ncclAllReduceFallback(const void* sendbuff, void* recvbuff, 
   }
 
   Op reduceOp = getReduceOp(op);
-  switch (datatype) {
-    case ncclFloat16:
-      CUDACHECK(allreduce((half*)sendbuff, (half*)comm->scratchBuff.get(), (half*)recvbuff, memoryChannels,
-                          memoryOutChannels, offsetIn, offsetOut, offsetScratch, rank, NRANKS_PER_NODE,
-                          comm->comm->bootstrap()->getNranks(), reduceOp, count, stream));
-      break;
-    case ncclFloat32:
-      CUDACHECK(allreduce((float*)sendbuff, (float*)comm->scratchBuff.get(), (float*)recvbuff, memoryChannels,
-                          memoryOutChannels, offsetIn, offsetOut, offsetScratch, comm->comm->bootstrap()->getRank(),
-                          NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), reduceOp, count, stream));
-      break;
-    case ncclBfloat16:
-      CUDACHECK(allreduce((__bfloat16*)sendbuff, (__bfloat16*)comm->scratchBuff.get(), (__bfloat16*)recvbuff,
-                          memoryChannels, memoryOutChannels, offsetIn, offsetOut, offsetScratch, rank, NRANKS_PER_NODE,
-                          comm->comm->bootstrap()->getNranks(), reduceOp, count, stream));
-      break;
-    case ncclInt32:
-    case ncclUint32:
-      CUDACHECK(allreduce((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, memoryChannels,
-                          memoryOutChannels, offsetIn, offsetOut, offsetScratch, comm->comm->bootstrap()->getRank(),
-                          NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), reduceOp, count, stream));
-      break;
-    default:
+  std::function<cudaError_t(const void*, void*, void*, mscclpp::DeviceHandle<mscclpp::MemoryChannel>*,
+                            mscclpp::DeviceHandle<mscclpp::MemoryChannel>*, size_t, size_t, size_t, int, int, int,
+                            size_t, cudaStream_t)>
+      allreduceFunc;
+  if (reduceOp == SUM) {
+    if (datatype == ncclFloat16) {
+      allreduceFunc = allreduce<SUM, half>;
+    } else if (datatype == ncclFloat32) {
+      allreduceFunc = allreduce<SUM, float>;
+    } else if (datatype == ncclBfloat16) {
+      allreduceFunc = allreduce<SUM, __bfloat16>;
+    } else if (datatype == ncclInt32 || datatype == ncclUint32) {
+      allreduceFunc = allreduce<SUM, int>;
+    } else {
       WARN("datatype is invalid, datatype: %d", datatype);
       return ncclInvalidArgument;
+    }
+  } else if (reduceOp == MIN) {
+    if (datatype == ncclFloat16) {
+      allreduceFunc = allreduce<MIN, half>;
+    } else if (datatype == ncclFloat32) {
+      allreduceFunc = allreduce<MIN, float>;
+    } else if (datatype == ncclBfloat16) {
+      allreduceFunc = allreduce<MIN, __bfloat16>;
+    } else if (datatype == ncclInt32 || datatype == ncclUint32) {
+      allreduceFunc = allreduce<MIN, int>;
+    } else {
+      WARN("datatype is invalid, datatype: %d", datatype);
+      return ncclInvalidArgument;
+    }
   }
+  CUDACHECK(allreduceFunc(sendbuff, comm->scratchBuff.get(), recvbuff, memoryChannels, memoryOutChannels, offsetIn,
+                          offsetOut, offsetScratch, comm->comm->bootstrap()->getRank(), NRANKS_PER_NODE,
+                          comm->comm->bootstrap()->getNranks(), count, stream));
   return ncclSuccess;
 }
 


### PR DESCRIPTION
* Pass the op type as a template parameter
* Use the all-pairs algorithm for ~10KB
* Don't write channel handles on the shared memory for small sizes
* A reduction bug fix & cleanup