### PR TITLE
Use implicit ctors for default device ctors

### DIFF
--- a/include/mscclpp/packet_device.hpp
+++ b/include/mscclpp/packet_device.hpp
@@ -29,14 +29,9 @@ union alignas(16) LL16Packet {
 #if defined(MSCCLPP_DEVICE_COMPILE)
   ulonglong2 raw_;
 
-  MSCCLPP_DEVICE_INLINE LL16Packet() {}
+  MSCCLPP_DEVICE_INLINE LL16Packet() = default;
 
-  MSCCLPP_DEVICE_INLINE LL16Packet(uint2 val, uint32_t flag) {
-    data1 = val.x;
-    flag1 = flag;
-    data2 = val.y;
-    flag2 = flag;
-  }
+  MSCCLPP_DEVICE_INLINE LL16Packet(uint2 val, uint32_t flag) : data1(val.x), flag1(flag), data2(val.y), flag2(flag) {}
 
   /// Write 8 bytes of data to the packet.
   /// @param val1 The first 4-byte data to write.
@@ -112,12 +107,9 @@ union alignas(8) LL8Packet {
   using Payload = uint32_t;
 #if defined(MSCCLPP_DEVICE_COMPILE)
 
-  MSCCLPP_DEVICE_INLINE LL8Packet() {}
+  MSCCLPP_DEVICE_INLINE LL8Packet() = default;
 
-  MSCCLPP_DEVICE_INLINE LL8Packet(uint32_t val, uint32_t flag) {
-    this->data = val;
-    this->flag = flag;
-  }
+  MSCCLPP_DEVICE_INLINE LL8Packet(uint32_t val, uint32_t flag) : data(val), flag(flag) {}
 
   MSCCLPP_DEVICE_INLINE void write(uint32_t val, uint32_t flag) {
 #if defined(MSCCLPP_DEVICE_CUDA)

--- a/include/mscclpp/port_channel_device.hpp
+++ b/include/mscclpp/port_channel_device.hpp
@@ -49,7 +49,7 @@ union ChannelTrigger {
 
 #if defined(MSCCLPP_DEVICE_COMPILE)
   /// Default constructor.
-  MSCCLPP_DEVICE_INLINE ChannelTrigger() {}
+  MSCCLPP_DEVICE_INLINE ChannelTrigger() = default;
 
   /// Copy constructor.
   MSCCLPP_DEVICE_INLINE ChannelTrigger(ProxyTrigger value) : value(value) {}
@@ -92,7 +92,7 @@ struct BasePortChannelDeviceHandle {
   // can produce for and the sole proxy thread consumes it.
   FifoDeviceHandle fifo_;
 
-  MSCCLPP_HOST_DEVICE_INLINE BasePortChannelDeviceHandle() {}
+  MSCCLPP_HOST_DEVICE_INLINE BasePortChannelDeviceHandle() = default;
 
   MSCCLPP_HOST_DEVICE_INLINE BasePortChannelDeviceHandle(SemaphoreId semaphoreId,
                                                          Host2DeviceSemaphoreDeviceHandle semaphore,
@@ -186,7 +186,7 @@ struct PortChannelDeviceHandle : public BasePortChannelDeviceHandle {
   MemoryId dst_;
   MemoryId src_;
 
-  MSCCLPP_HOST_DEVICE_INLINE PortChannelDeviceHandle(){};
+  MSCCLPP_HOST_DEVICE_INLINE PortChannelDeviceHandle() = default;
 
   MSCCLPP_HOST_DEVICE_INLINE PortChannelDeviceHandle(SemaphoreId semaphoreId,
                                                      Host2DeviceSemaphoreDeviceHandle semaphore, FifoDeviceHandle fifo,


### PR DESCRIPTION
By using implicit constructors, the compiler doesn't need to dynamically initialize the instances.