### PR TITLE
Fix #514

### DIFF
--- a/docs/getting-started/tutorials/initialization.md
+++ b/docs/getting-started/tutorials/initialization.md
@@ -32,28 +32,24 @@ void setupMeshTopology(int rank, int worldsize, void* data, size_t dataSize) {
 
   std::vector<mscclpp::SemaphoreId> semaphoreIds;
   std::vector<mscclpp::RegisteredMemory> localMemories;
-  std::vector<mscclpp::NonblockingFuture<std::shared_ptr<mscclpp::Connection>>> connections(world_size);
-  std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>> remoteMemories;
+  std::vector<std::shared_future<std::shared_ptr<mscclpp::Connection>>> connections(world_size);
+  std::vector<std::shared_future<mscclpp::RegisteredMemory>> remoteMemories;
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) continue;
     mscclpp::Transport transport = mscclpp::Transport::CudaIpc;
     // Connect with all other ranks
-    connections[r] = comm.connectOnSetup(r, 0, transport);
+    connections[r] = comm.connect(r, 0, transport);
     auto memory = comm.registerMemory(data, dataSize, mscclpp::Transport::CudaIpc | ibTransport);
     localMemories.push_back(memory);
-    comm.sendMemoryOnSetup(memory, r, 0);
-    remoteMemories.push_back(comm.recvMemoryOnSetup(r, 0));
+    comm.sendMemory(memory, r, 0);
+    remoteMemories.push_back(comm.recvMemory(r, 0));
   }
-
-  comm.setup();
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) continue;
     semaphoreIds.push_back(proxyService.buildAndAddSemaphore(comm, connections[r].get()));
   }
-
-  comm.setup();
 
   std::vector<DeviceHandle<mscclpp::PortChannel>> portChannels;
   for (size_t i = 0; i < semaphoreIds.size(); ++i) {

--- a/include/mscclpp/port_channel_device.hpp
+++ b/include/mscclpp/port_channel_device.hpp
@@ -148,12 +148,13 @@ struct BasePortChannelDeviceHandle {
   /// @param src The source memory region.
   /// @param srcOffset The offset into the source memory region.
   /// @param size The size of the transfer.
+  /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
   MSCCLPP_DEVICE_INLINE void putWithSignalAndFlush(MemoryId dst, uint64_t dstOffset, MemoryId src, uint64_t srcOffset,
-                                                   uint64_t size) {
+                                                   uint64_t size, int64_t maxSpinCount = 1000000) {
     uint64_t curFifoHead = fifo_.push(
         ChannelTrigger(TriggerData | TriggerFlag | TriggerSync, dst, dstOffset, src, srcOffset, size, semaphoreId_)
             .value);
-    fifo_.sync(curFifoHead);
+    fifo_.sync(curFifoHead, maxSpinCount);
   }
 
   /// Push a @ref TriggerData, a @ref TriggerFlag, and a @ref TriggerSync at the same time to the FIFO.
@@ -161,14 +162,17 @@ struct BasePortChannelDeviceHandle {
   /// @param src The source memory region.
   /// @param offset The common offset into the destination and source memory regions.
   /// @param size The size of the transfer.
-  MSCCLPP_DEVICE_INLINE void putWithSignalAndFlush(MemoryId dst, MemoryId src, uint64_t offset, uint64_t size) {
-    putWithSignalAndFlush(dst, offset, src, offset, size);
+  /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
+  MSCCLPP_DEVICE_INLINE void putWithSignalAndFlush(MemoryId dst, MemoryId src, uint64_t offset, uint64_t size,
+                                                   int64_t maxSpinCount = 1000000) {
+    putWithSignalAndFlush(dst, offset, src, offset, size, maxSpinCount);
   }
 
   /// Push a @ref TriggerSync to the FIFO.
-  MSCCLPP_DEVICE_INLINE void flush() {
+  /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
+  MSCCLPP_DEVICE_INLINE void flush(int64_t maxSpinCount = 1000000) {
     uint64_t curFifoHead = fifo_.push(ChannelTrigger(TriggerSync, 0, 0, 0, 0, 1, semaphoreId_).value);
-    fifo_.sync(curFifoHead);
+    fifo_.sync(curFifoHead, maxSpinCount);
   }
 
   /// Check if the port channel has been signaled.
@@ -224,8 +228,10 @@ struct PortChannelDeviceHandle : public BasePortChannelDeviceHandle {
   /// @param dstOffset The offset into the destination memory region.
   /// @param srcOffset The offset into the source memory region.
   /// @param size The size of the transfer.
-  MSCCLPP_DEVICE_INLINE void putWithSignalAndFlush(uint64_t dstOffset, uint64_t srcOffset, uint64_t size) {
-    BasePortChannelDeviceHandle::putWithSignalAndFlush(dst_, dstOffset, src_, srcOffset, size);
+  /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
+  MSCCLPP_DEVICE_INLINE void putWithSignalAndFlush(uint64_t dstOffset, uint64_t srcOffset, uint64_t size,
+                                                   int64_t maxSpinCount = 1000000) {
+    BasePortChannelDeviceHandle::putWithSignalAndFlush(dst_, dstOffset, src_, srcOffset, size, maxSpinCount);
   }
 
   /// Push a @ref TriggerData, a @ref TriggerFlag, and a @ref TriggerSync at the same time to the FIFO.

--- a/python/mscclpp/comm.py
+++ b/python/mscclpp/comm.py
@@ -101,8 +101,7 @@ class CommGroup:
             if endpoint.transport == Transport.Nvls:
                 return connect_nvls_collective(self.communicator, all_ranks, 2**30)
             else:
-                connections[rank] = self.communicator.connect_on_setup(rank, 0, endpoint)
-        self.communicator.setup()
+                connections[rank] = self.communicator.connect(rank, 0, endpoint)
         connections = {rank: connections[rank].get() for rank in connections}
         return connections
 
@@ -125,9 +124,8 @@ class CommGroup:
         all_registered_memories[self.my_rank] = local_reg_memory
         future_memories = {}
         for rank in connections:
-            self.communicator.send_memory_on_setup(local_reg_memory, rank, 0)
-            future_memories[rank] = self.communicator.recv_memory_on_setup(rank, 0)
-        self.communicator.setup()
+            self.communicator.send_memory(local_reg_memory, rank, 0)
+            future_memories[rank] = self.communicator.recv_memory(rank, 0)
         for rank in connections:
             all_registered_memories[rank] = future_memories[rank].get()
         return all_registered_memories
@@ -140,7 +138,6 @@ class CommGroup:
         semaphores = {}
         for rank in connections:
             semaphores[rank] = semaphore_type(self.communicator, connections[rank])
-        self.communicator.setup()
         return semaphores
 
     def make_memory_channels(self, tensor: cp.ndarray, connections: dict[int, Connection]) -> dict[int, MemoryChannel]:

--- a/python/mscclpp/comm.py
+++ b/python/mscclpp/comm.py
@@ -107,7 +107,7 @@ class CommGroup:
         return connections
 
     def register_tensor_with_connections(
-        self, tensor: Type[cp.ndarray] or Type[np.ndarray], connections: dict[int, Connection]
+        self, tensor: Type[cp.ndarray] | Type[np.ndarray], connections: dict[int, Connection]
     ) -> dict[int, RegisteredMemory]:
         transport_flags = TransportFlags()
         for rank in connections:
@@ -135,7 +135,7 @@ class CommGroup:
     def make_semaphore(
         self,
         connections: dict[int, Connection],
-        semaphore_type: Type[Host2HostSemaphore] or Type[Host2DeviceSemaphore] or Type[MemoryDevice2DeviceSemaphore],
+        semaphore_type: Type[Host2HostSemaphore] | Type[Host2DeviceSemaphore] | Type[MemoryDevice2DeviceSemaphore],
     ) -> dict[int, Host2HostSemaphore]:
         semaphores = {}
         for rank in connections:

--- a/python/mscclpp/core_py.cpp
+++ b/python/mscclpp/core_py.cpp
@@ -27,9 +27,9 @@ extern void register_npkit(nb::module_& m);
 extern void register_gpu_utils(nb::module_& m);
 
 template <typename T>
-void def_nonblocking_future(nb::handle& m, const std::string& typestr) {
-  std::string pyclass_name = std::string("NonblockingFuture") + typestr;
-  nb::class_<NonblockingFuture<T>>(m, pyclass_name.c_str()).def("get", &NonblockingFuture<T>::get);
+void def_shared_future(nb::handle& m, const std::string& typestr) {
+  std::string pyclass_name = std::string("shared_future_") + typestr;
+  nb::class_<std::shared_future<T>>(m, pyclass_name.c_str()).def("get", &std::shared_future<T>::get);
 }
 
 void register_core(nb::module_& m) {
@@ -158,8 +158,8 @@ void register_core(nb::module_& m) {
       .def("create_endpoint", &Context::createEndpoint, nb::arg("config"))
       .def("connect", &Context::connect, nb::arg("local_endpoint"), nb::arg("remote_endpoint"));
 
-  def_nonblocking_future<RegisteredMemory>(m, "RegisteredMemory");
-  def_nonblocking_future<std::shared_ptr<Connection>>(m, "shared_ptr_Connection");
+  def_shared_future<RegisteredMemory>(m, "RegisteredMemory");
+  def_shared_future<std::shared_ptr<Connection>>(m, "shared_ptr_Connection");
 
   nb::class_<Communicator>(m, "Communicator")
       .def(nb::init<std::shared_ptr<Bootstrap>, std::shared_ptr<Context>>(), nb::arg("bootstrap"),
@@ -172,14 +172,15 @@ void register_core(nb::module_& m) {
             return self->registerMemory((void*)ptr, size, transports);
           },
           nb::arg("ptr"), nb::arg("size"), nb::arg("transports"))
-      .def("send_memory_on_setup", &Communicator::sendMemoryOnSetup, nb::arg("memory"), nb::arg("remoteRank"),
-           nb::arg("tag"))
-      .def("recv_memory_on_setup", &Communicator::recvMemoryOnSetup, nb::arg("remoteRank"), nb::arg("tag"))
-      .def("connect_on_setup", &Communicator::connectOnSetup, nb::arg("remoteRank"), nb::arg("tag"),
-           nb::arg("localConfig"))
+      .def("send_memory", &Communicator::sendMemory, nb::arg("memory"), nb::arg("remoteRank"), nb::arg("tag"))
+      .def("recv_memory", &Communicator::recvMemory, nb::arg("remoteRank"), nb::arg("tag"))
+      .def("connect", &Communicator::connect, nb::arg("remoteRank"), nb::arg("tag"), nb::arg("localConfig"))
+      .def("send_memory_on_setup", &Communicator::sendMemory, nb::arg("memory"), nb::arg("remoteRank"), nb::arg("tag"))
+      .def("recv_memory_on_setup", &Communicator::recvMemory, nb::arg("remoteRank"), nb::arg("tag"))
+      .def("connect_on_setup", &Communicator::connect, nb::arg("remoteRank"), nb::arg("tag"), nb::arg("localConfig"))
       .def("remote_rank_of", &Communicator::remoteRankOf)
       .def("tag_of", &Communicator::tagOf)
-      .def("setup", &Communicator::setup);
+      .def("setup", [](Communicator*) {});
 }
 
 NB_MODULE(_mscclpp, m) {

--- a/src/bootstrap/bootstrap.cc
+++ b/src/bootstrap/bootstrap.cc
@@ -528,6 +528,7 @@ std::shared_ptr<Socket> TcpBootstrap::Impl::getPeerRecvSocket(int peer, int tag)
     if (recvPeer == peer && recvTag == tag) {
       return sock;
     }
+    // TODO(chhwang): set an exit condition or timeout
   }
 }
 

--- a/src/bootstrap/bootstrap.cc
+++ b/src/bootstrap/bootstrap.cc
@@ -52,14 +52,14 @@ MSCCLPP_API_CPP void Bootstrap::groupBarrier(const std::vector<int>& ranks) {
 MSCCLPP_API_CPP void Bootstrap::send(const std::vector<char>& data, int peer, int tag) {
   size_t size = data.size();
   send((void*)&size, sizeof(size_t), peer, tag);
-  send((void*)data.data(), data.size(), peer, tag + 1);
+  send((void*)data.data(), data.size(), peer, tag);
 }
 
 MSCCLPP_API_CPP void Bootstrap::recv(std::vector<char>& data, int peer, int tag) {
   size_t size;
   recv((void*)&size, sizeof(size_t), peer, tag);
   data.resize(size);
-  recv((void*)data.data(), data.size(), peer, tag + 1);
+  recv((void*)data.data(), data.size(), peer, tag);
 }
 
 struct UniqueIdInternal {

--- a/src/include/communicator.hpp
+++ b/src/include/communicator.hpp
@@ -44,7 +44,19 @@ struct Communicator::Impl {
   std::unordered_map<const Connection*, ConnectionInfo> connectionInfos_;
   std::shared_ptr<BaseRecvItem> lastRecvItem_;
 
+  // Temporary storage for the latest RecvItem of each {remoteRank, tag} pair.
+  // If the RecvItem gets ready, it will be removed at the next call to getLastRecvItem.
+  std::unordered_map<std::pair<int, int>, std::shared_ptr<BaseRecvItem>, PairHash> lastRecvItems_;
+
   Impl(std::shared_ptr<Bootstrap> bootstrap, std::shared_ptr<Context> context);
+
+  // Set the last RecvItem for a {remoteRank, tag} pair.
+  // This is used to store the corresponding RecvItem of a future returned by recvMemory() or connect().
+  void setLastRecvItem(int remoteRank, int tag, std::shared_ptr<BaseRecvItem> item);
+
+  // Return the last RecvItem that is not ready.
+  // If the item is ready, it will be removed from the map and nullptr will be returned.
+  std::shared_ptr<BaseRecvItem> getLastRecvItem(int remoteRank, int tag);
 
   struct Connector;
 };

--- a/src/include/communicator.hpp
+++ b/src/include/communicator.hpp
@@ -17,6 +17,7 @@ class BaseRecvItem {
  public:
   virtual ~BaseRecvItem() = default;
   virtual void wait() = 0;
+  virtual bool isReady() const = 0;
 };
 
 template <typename T>
@@ -25,6 +26,8 @@ class RecvItem : public BaseRecvItem {
   RecvItem(std::shared_future<T> future) : future_(future) {}
 
   void wait() { future_.wait(); }
+
+  bool isReady() const { return future_.wait_for(std::chrono::seconds(0)) == std::future_status::ready; }
 
  private:
   std::shared_future<T> future_;

--- a/src/include/communicator.hpp
+++ b/src/include/communicator.hpp
@@ -9,9 +9,49 @@
 #include <unordered_map>
 #include <vector>
 
+#include "utils_internal.hpp"
+
 namespace mscclpp {
 
-class ConnectionBase;
+class BaseRecvItem {
+ public:
+  virtual ~BaseRecvItem() = default;
+  virtual void wait() = 0;
+};
+
+template <typename T>
+class RecvItem : public BaseRecvItem {
+ public:
+  RecvItem(std::shared_future<T> future) : future_(future) {}
+
+  void wait() { future_.wait(); }
+
+ private:
+  std::shared_future<T> future_;
+};
+
+class RecvQueues {
+ public:
+  RecvQueues() = default;
+
+  template <typename T>
+  void addRecvItem(int remoteRank, int tag, std::shared_future<T> future) {
+    auto& queue = queues_[std::make_pair(remoteRank, tag)];
+    queue.emplace_back(std::make_shared<RecvItem<T>>(future));
+  }
+
+  size_t getNumRecvItems(int remoteRank, int tag) { return queues_[std::make_pair(remoteRank, tag)].size(); }
+
+  void waitN(int remoteRank, int tag, size_t n) {
+    auto& queue = queues_[std::make_pair(remoteRank, tag)];
+    for (size_t i = 0; i < n; ++i) {
+      queue[i]->wait();
+    }
+  }
+
+ private:
+  std::unordered_map<std::pair<int, int>, std::vector<std::shared_ptr<BaseRecvItem>>, PairHash> queues_;
+};
 
 struct ConnectionInfo {
   int remoteRank;
@@ -22,6 +62,7 @@ struct Communicator::Impl {
   std::shared_ptr<Bootstrap> bootstrap_;
   std::shared_ptr<Context> context_;
   std::unordered_map<const Connection*, ConnectionInfo> connectionInfos_;
+  RecvQueues recvQueues_;
 
   Impl(std::shared_ptr<Bootstrap> bootstrap, std::shared_ptr<Context> context);
 

--- a/src/include/communicator.hpp
+++ b/src/include/communicator.hpp
@@ -30,29 +30,6 @@ class RecvItem : public BaseRecvItem {
   std::shared_future<T> future_;
 };
 
-class RecvQueues {
- public:
-  RecvQueues() = default;
-
-  template <typename T>
-  void addRecvItem(int remoteRank, int tag, std::shared_future<T> future) {
-    auto& queue = queues_[std::make_pair(remoteRank, tag)];
-    queue.emplace_back(std::make_shared<RecvItem<T>>(future));
-  }
-
-  size_t getNumRecvItems(int remoteRank, int tag) { return queues_[std::make_pair(remoteRank, tag)].size(); }
-
-  void waitN(int remoteRank, int tag, size_t n) {
-    auto& queue = queues_[std::make_pair(remoteRank, tag)];
-    for (size_t i = 0; i < n; ++i) {
-      queue[i]->wait();
-    }
-  }
-
- private:
-  std::unordered_map<std::pair<int, int>, std::vector<std::shared_ptr<BaseRecvItem>>, PairHash> queues_;
-};
-
 struct ConnectionInfo {
   int remoteRank;
   int tag;
@@ -62,7 +39,7 @@ struct Communicator::Impl {
   std::shared_ptr<Bootstrap> bootstrap_;
   std::shared_ptr<Context> context_;
   std::unordered_map<const Connection*, ConnectionInfo> connectionInfos_;
-  RecvQueues recvQueues_;
+  std::shared_ptr<BaseRecvItem> lastRecvItem_;
 
   Impl(std::shared_ptr<Bootstrap> bootstrap, std::shared_ptr<Context> context);
 

--- a/src/semaphore.cc
+++ b/src/semaphore.cc
@@ -9,14 +9,14 @@
 
 namespace mscclpp {
 
-static NonblockingFuture<RegisteredMemory> setupInboundSemaphoreId(Communicator& communicator, Connection* connection,
-                                                                   void* localInboundSemaphoreId) {
+static std::shared_future<RegisteredMemory> setupInboundSemaphoreId(Communicator& communicator, Connection* connection,
+                                                                    void* localInboundSemaphoreId) {
   auto localInboundSemaphoreIdsRegMem =
       communicator.registerMemory(localInboundSemaphoreId, sizeof(uint64_t), connection->transport());
   int remoteRank = communicator.remoteRankOf(*connection);
   int tag = communicator.tagOf(*connection);
-  communicator.sendMemoryOnSetup(localInboundSemaphoreIdsRegMem, remoteRank, tag);
-  return communicator.recvMemoryOnSetup(remoteRank, tag);
+  communicator.sendMemory(localInboundSemaphoreIdsRegMem, remoteRank, tag);
+  return communicator.recvMemory(remoteRank, tag);
 }
 
 static detail::UniqueGpuPtr<uint64_t> createGpuSemaphoreId() {

--- a/test/allgather_test_cpp.cu
+++ b/test/allgather_test_cpp.cu
@@ -206,8 +206,8 @@ void setupMscclppConnections(int rank, int world_size, mscclpp::Communicator& co
   mscclpp::Transport ibTransport = mscclpp::getIBTransportByDeviceName(ibDevStr);
   std::vector<mscclpp::SemaphoreId> semaphoreIds;
   std::vector<mscclpp::RegisteredMemory> localMemories;
-  std::vector<mscclpp::NonblockingFuture<std::shared_ptr<mscclpp::Connection>>> connections(world_size);
-  std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>> remoteMemories;
+  std::vector<std::shared_future<std::shared_ptr<mscclpp::Connection>>> connections(world_size);
+  std::vector<std::shared_future<mscclpp::RegisteredMemory>> remoteMemories;
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) continue;
@@ -218,21 +218,17 @@ void setupMscclppConnections(int rank, int world_size, mscclpp::Communicator& co
       transport = ibTransport;
     }
     // Connect with all other ranks
-    connections[r] = comm.connectOnSetup(r, 0, transport);
+    connections[r] = comm.connect(r, 0, transport);
     auto memory = comm.registerMemory(data_d, dataSize, mscclpp::Transport::CudaIpc | ibTransport);
     localMemories.push_back(memory);
-    comm.sendMemoryOnSetup(memory, r, 0);
-    remoteMemories.push_back(comm.recvMemoryOnSetup(r, 0));
+    comm.sendMemory(memory, r, 0);
+    remoteMemories.push_back(comm.recvMemory(r, 0));
   }
-
-  comm.setup();
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) continue;
     semaphoreIds.push_back(proxyService.buildAndAddSemaphore(comm, connections[r].get()));
   }
-
-  comm.setup();
 
   std::vector<DeviceHandle<mscclpp::PortChannel>> portChannels;
   for (size_t i = 0; i < semaphoreIds.size(); ++i) {

--- a/test/mp_unit/memory_channel_tests.cu
+++ b/test/mp_unit/memory_channel_tests.cu
@@ -25,8 +25,8 @@ void MemoryChannelOneToOneTest::setupMeshConnections(std::vector<mscclpp::Memory
   const bool isInPlace = (outputBuff == nullptr);
   mscclpp::TransportFlags transport = mscclpp::Transport::CudaIpc | ibTransport;
 
-  std::vector<mscclpp::NonblockingFuture<std::shared_ptr<mscclpp::Connection>>> connectionFutures(worldSize);
-  std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>> remoteMemFutures(worldSize);
+  std::vector<std::shared_future<std::shared_ptr<mscclpp::Connection>>> connectionFutures(worldSize);
+  std::vector<std::shared_future<mscclpp::RegisteredMemory>> remoteMemFutures(worldSize);
 
   mscclpp::RegisteredMemory inputBufRegMem = communicator->registerMemory(inputBuff, inputBuffBytes, transport);
   mscclpp::RegisteredMemory outputBufRegMem;
@@ -39,20 +39,18 @@ void MemoryChannelOneToOneTest::setupMeshConnections(std::vector<mscclpp::Memory
       continue;
     }
     if (rankToNode(r) == rankToNode(gEnv->rank)) {
-      connectionFutures[r] = communicator->connectOnSetup(r, 0, mscclpp::Transport::CudaIpc);
+      connectionFutures[r] = communicator->connect(r, 0, mscclpp::Transport::CudaIpc);
     } else {
-      connectionFutures[r] = communicator->connectOnSetup(r, 0, ibTransport);
+      connectionFutures[r] = communicator->connect(r, 0, ibTransport);
     }
 
     if (isInPlace) {
-      communicator->sendMemoryOnSetup(inputBufRegMem, r, 0);
+      communicator->sendMemory(inputBufRegMem, r, 0);
     } else {
-      communicator->sendMemoryOnSetup(outputBufRegMem, r, 0);
+      communicator->sendMemory(outputBufRegMem, r, 0);
     }
-    remoteMemFutures[r] = communicator->recvMemoryOnSetup(r, 0);
+    remoteMemFutures[r] = communicator->recvMemory(r, 0);
   }
-
-  communicator->setup();
 
   for (int r = 0; r < worldSize; r++) {
     if (r == rank) {
@@ -65,8 +63,6 @@ void MemoryChannelOneToOneTest::setupMeshConnections(std::vector<mscclpp::Memory
     memoryChannels.emplace_back(memorySemaphores[r], remoteMemFutures[r].get(), inputBufRegMem.data(),
                                 (isInPlace ? nullptr : outputBufRegMem.data()));
   }
-
-  communicator->setup();
 }
 
 __constant__ DeviceHandle<mscclpp::MemoryChannel> gChannelOneToOneTestConstMemChans;

--- a/test/mscclpp-test/allgather_test.cu
+++ b/test/mscclpp-test/allgather_test.cu
@@ -764,7 +764,7 @@ void AllGatherTestEngine::setupConnections() {
     auto service = std::dynamic_pointer_cast<AllGatherProxyService>(chanService_);
     setupMeshConnections(devPortChannels, sendBuff_.get(), args_.maxBytes, nullptr, 0,
                          [&](std::vector<std::shared_ptr<mscclpp::Connection>> conns,
-                             std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>>& remoteMemories,
+                             std::vector<std::shared_future<mscclpp::RegisteredMemory>>& remoteMemories,
                              const mscclpp::RegisteredMemory& localMemory) {
                            std::vector<mscclpp::SemaphoreId> semaphoreIds;
                            for (size_t i = 0; i < conns.size(); ++i) {
@@ -772,7 +772,6 @@ void AllGatherTestEngine::setupConnections() {
                              service->addRemoteMemory(remoteMemories[i].get());
                            }
                            service->setLocalMemory(localMemory);
-                           comm_->setup();
                          });
     auto portChannels = service->portChannels();
     if (portChannels.size() > sizeof(constRawPortChan) / sizeof(DeviceHandle<mscclpp::BasePortChannel>)) {

--- a/test/mscclpp-test/common.hpp
+++ b/test/mscclpp-test/common.hpp
@@ -102,14 +102,14 @@ class BaseTestEngine {
 
   double benchTime();
 
-  void setupMeshConnectionsInternal(
-      std::vector<std::shared_ptr<mscclpp::Connection>>& connections, mscclpp::RegisteredMemory& localMemory,
-      std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>>& remoteRegMemories,
-      bool addConnections = true);
+  void setupMeshConnectionsInternal(std::vector<std::shared_ptr<mscclpp::Connection>>& connections,
+                                    mscclpp::RegisteredMemory& localMemory,
+                                    std::vector<std::shared_future<mscclpp::RegisteredMemory>>& remoteRegMemories,
+                                    bool addConnections = true);
 
  protected:
   using SetupChannelFunc = std::function<void(std::vector<std::shared_ptr<mscclpp::Connection>>,
-                                              std::vector<mscclpp::NonblockingFuture<mscclpp::RegisteredMemory>>&,
+                                              std::vector<std::shared_future<mscclpp::RegisteredMemory>>&,
                                               const mscclpp::RegisteredMemory&)>;
   template <class T>
   using DeviceHandle = mscclpp::DeviceHandle<T>;

--- a/test/unit/core_tests.cc
+++ b/test/unit/core_tests.cc
@@ -29,9 +29,8 @@ TEST_F(LocalCommunicatorTest, RegisterMemory) {
 TEST_F(LocalCommunicatorTest, SendMemoryToSelf) {
   int dummy[42];
   auto memory = comm->registerMemory(&dummy, sizeof(dummy), mscclpp::NoTransports);
-  comm->sendMemoryOnSetup(memory, 0, 0);
-  auto memoryFuture = comm->recvMemoryOnSetup(0, 0);
-  comm->setup();
+  comm->sendMemory(memory, 0, 0);
+  auto memoryFuture = comm->recvMemory(0, 0);
   auto sameMemory = memoryFuture.get();
   EXPECT_EQ(sameMemory.data(), memory.data());
   EXPECT_EQ(sameMemory.size(), memory.size());


### PR DESCRIPTION
* In cases when the same `tag` is used for receiving data from the same remote rank, #514 changed the behavior of `Communicator::connect` and `Communicator::recvMemory` to receive data in the order of `std::shared_future::get()` is called, instead of the original behvaior that receive data in the order of the method calls. Since the original behavior is more intuitive, we get that back. Now when `get()` is called on a future, the async function will first call `wait()` on the latest previously returned future. In a recursive manner, this will call `wait()` on all previous futures that are not yet ready.
* Removed all deprecated API calls and replaced into the new ones.