### PR TITLE
Fix build processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-set(MSCCLPP_MAJOR "0")
-set(MSCCLPP_MINOR "6")
-set(MSCCLPP_PATCH "0")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" MSCCLPP_VERSION_CONTENT)
+if(MSCCLPP_VERSION_CONTENT MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(MSCCLPP_MAJOR "${CMAKE_MATCH_1}")
+    set(MSCCLPP_MINOR "${CMAKE_MATCH_2}")
+    set(MSCCLPP_PATCH "${CMAKE_MATCH_3}")
+else()
+    message(FATAL_ERROR "VERSION file must be in the format MAJOR.MINOR.PATCH")
+endif()
 
 set(MSCCLPP_SOVERSION ${MSCCLPP_MAJOR})
 set(MSCCLPP_VERSION "${MSCCLPP_MAJOR}.${MSCCLPP_MINOR}.${MSCCLPP_PATCH}")
@@ -21,7 +26,7 @@ option(MSCCLPP_BUILD_APPS_NCCL "Build NCCL interfaces" ON)
 option(MSCCLPP_USE_CUDA "Use NVIDIA/CUDA." OFF)
 option(MSCCLPP_USE_ROCM "Use AMD/ROCm." OFF)
 option(MSCCLPP_BYPASS_GPU_CHECK "Bypass GPU check." OFF)
-option(MSCCLPP_NPKIT_FLAGS "Enable NPKIT" OFF)
+option(MSCCLPP_NPKIT_FLAGS "Set NPKIT flags" OFF)
 set(MSCCLPP_GPU_ARCHS "" CACHE STRING "Specify GPU architectures with delimiters (comma, space, or semicolon).")
 
 if(MSCCLPP_BYPASS_GPU_CHECK)
@@ -124,7 +129,6 @@ endif()
 # Format targets
 include(${PROJECT_SOURCE_DIR}/cmake/AddFormatTargets.cmake)
 
-# Find ibverbs and libnuma
 find_package(IBVerbs)
 find_package(NUMA REQUIRED)
 find_package(Threads REQUIRED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-dir = "build/{wheel_tag}"
 [tool.scikit-build.wheel]
 packages = ["python/mscclpp", "python/mscclpp_benchmark"]
 install-dir = "mscclpp"
-license-files = ["LICENSE", "CITATION.cff", "CODE_OF_CONDUCT.md", "README.md", "SECURITY.md", "SUPPORT.md"]
+license-files = ["VERSION", "LICENSE", "CITATION.cff", "CODE_OF_CONDUCT.md", "README.md", "SECURITY.md", "SUPPORT.md"]
 exclude = ["mscclpp/*.cpp"]
 
 [tool.scikit-build.cmake.define]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,13 @@ version = "0.6.0"
 [tool.scikit-build]
 cmake.version = ">=3.25.0"
 cmake.build-type = "Release"
-# for dlpack issue: https://github.com/microsoft/vcpkg/pull/44679
-cmake.args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
 build-dir = "build/{wheel_tag}"
-wheel.packages = ["python/mscclpp", "python/mscclpp_benchmark"]
-wheel.install-dir = "mscclpp"
+
+[tool.scikit-build.wheel]
+packages = ["python/mscclpp", "python/mscclpp_benchmark"]
+install-dir = "mscclpp"
+license-files = ["LICENSE", "CITATION.cff", "CODE_OF_CONDUCT.md", "README.md", "SECURITY.md", "SUPPORT.md"]
+exclude = ["mscclpp/*.cpp"]
 
 [tool.scikit-build.cmake.define]
 MSCCLPP_BUILD_PYTHON_BINDINGS = "ON"

--- a/python/mscclpp/CMakeLists.txt
+++ b/python/mscclpp/CMakeLists.txt
@@ -6,8 +6,17 @@ include(FetchContent)
 FetchContent_Declare(nanobind GIT_REPOSITORY https://github.com/wjakob/nanobind.git GIT_TAG v1.4.0)
 FetchContent_MakeAvailable(nanobind)
 
-FetchContent_Declare(dlpack GIT_REPOSITORY https://github.com/dmlc/dlpack.git GIT_TAG v1.1)
-FetchContent_MakeAvailable(dlpack)
+FetchContent_Declare(dlpack
+    GIT_REPOSITORY https://github.com/dmlc/dlpack.git
+    GIT_TAG 5c210da409e7f1e51ddf445134a4376fdbd70d7d
+)
+
+FetchContent_GetProperties(dlpack)
+if(NOT dlpack_POPULATED)
+    FetchContent_Populate(dlpack)
+    # Add dlpack subdirectory but exclude it from installation
+    add_subdirectory(${dlpack_SOURCE_DIR} ${dlpack_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp)
 nanobind_add_module(mscclpp_py ${SOURCES})


### PR DESCRIPTION
* Let CMake read version numbers from the `VERSION` file.
* Upgrade dlpack and drop `CMAKE_POLICY_VERSION_MINIMUM`.
* Do not install dlpack.
* Add license files in the wheel and exclude `*.cpp` files.