### PR TITLE
DeviceSemaphore  fix

### DIFF
--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -108,12 +108,13 @@ struct DeviceSemaphore {
   /// @param value The value to set.
   MSCCLPP_DEVICE_INLINE void set(int value) { atomicStore<int, scopeDevice>(&semaphore_, value, memoryOrderRelease); }
 
-  /// Acquire the semaphore (wait until the semaphore value is greater than 0 and decrease it by 1).
+  /// Acquire the semaphore (decrease the semaphore value by 1).
   /// This function will spin until the semaphore is acquired or the maximum spin count is reached.
   /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
   MSCCLPP_DEVICE_INLINE void acquire([[maybe_unused]] int maxSpinCount = -1) {
-    if (atomicFetchAdd<int, scopeDevice>(&semaphore_, -1, memoryOrderAcquire) <= 0) {
-      POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&semaphore_, memoryOrderAcquire) < 0), maxSpinCount);
+    int oldVal = atomicFetchAdd<int, scopeDevice>(&semaphore_, -1, memoryOrderAcquire);
+    if (oldVal <= 0) {
+      POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&semaphore_, memoryOrderAcquire) != oldVal), maxSpinCount);
     }
   }
 


### PR DESCRIPTION
Fix the bug, make sure a thread will be wake up if semaphore be released.

This pull request includes a modification to the `DeviceSemaphore` struct in the `concurrency_device.hpp` file, specifically in the `acquire` method. The change refines the logic for acquiring a semaphore by adjusting the condition used to handle contention scenarios.
