### PR TITLE
Fix #557

### DIFF
--- a/include/mscclpp/semaphore.hpp
+++ b/include/mscclpp/semaphore.hpp
@@ -64,7 +64,7 @@ class BaseSemaphore {
 };
 
 /// A semaphore for sending signals from the host to the device.
-class Host2DeviceSemaphore : public BaseSemaphore<detail::GpuDeleter, detail::GpuHostDeleter> {
+class Host2DeviceSemaphore : public BaseSemaphore<detail::GpuDeleter, std::default_delete> {
  private:
   std::shared_ptr<Connection> connection_;
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -93,8 +93,6 @@ MSCCLPP_API_CPP std::shared_ptr<Connection> Context::connect(Endpoint localEndpo
   } else {
     throw mscclpp::Error("Unsupported transport", ErrorCode::InternalError);
   }
-
-  pimpl_->connections_.push_back(conn);
   return conn;
 }
 

--- a/src/include/context.hpp
+++ b/src/include/context.hpp
@@ -33,10 +33,8 @@ class CudaIpcStream {
 };
 
 struct Context::Impl {
-  std::vector<std::shared_ptr<Connection>> connections_;
   std::unordered_map<Transport, std::unique_ptr<IbCtx>> ibContexts_;
   std::vector<std::shared_ptr<CudaIpcStream>> ipcStreams_;
-  CUmemGenericAllocationHandle mcHandle_;
 
   Impl();
 

--- a/src/semaphore.cc
+++ b/src/semaphore.cc
@@ -29,7 +29,7 @@ static detail::UniqueGpuPtr<uint64_t> createGpuSemaphoreId() {
 
 MSCCLPP_API_CPP Host2DeviceSemaphore::Host2DeviceSemaphore(Communicator& communicator,
                                                            std::shared_ptr<Connection> connection)
-    : BaseSemaphore(createGpuSemaphoreId(), createGpuSemaphoreId(), detail::gpuCallocHostUnique<uint64_t>()),
+    : BaseSemaphore(createGpuSemaphoreId(), createGpuSemaphoreId(), std::make_unique<uint64_t>()),
       connection_(connection) {
   INFO(MSCCLPP_INIT, "Creating a Host2Device semaphore for %s transport from %d to %d",
        connection->getTransportName().c_str(), communicator.bootstrap()->getRank(),


### PR DESCRIPTION
* Page-locking `Host2DeviceSemaphore::outboundSemaphore_` caused unexpected performance issues so reverting it back. We may revisit this later.
* Removed reference to connections from context as now connections refer to context.