### PR TITLE
Fifo test with multiple gpus 

### DIFF
--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -40,3 +40,4 @@ endfunction()
 
 # Add FIFO test  
 add_perf_test_executable(fifo_test "framework.cc;fifo_test.cu")
+add_perf_test_executable(fifo_test_multi_gpu "framework.cc;fifo_test_multi_gpu.cu")

--- a/test/perf/fifo_test_multi_gpu.cu
+++ b/test/perf/fifo_test_multi_gpu.cu
@@ -1,0 +1,390 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <getopt.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mscclpp/fifo.hpp>
+#include <mscclpp/gpu_utils.hpp>
+#include <mscclpp/numa.hpp>
+#include <sstream>
+#include <stdexcept>
+
+#include "framework.hpp"
+
+using namespace mscclpp::test;
+
+// Constants for timeout and trigger calculation
+constexpr uint64_t TIMEOUT_SPINS = 1000000;
+constexpr int MIN_TRIGGERS = 1000;
+constexpr int MIN_WARMUP_TRIGGERS = 100;
+constexpr int TRIGGERS_PER_FIFO_SIZE = 10;
+constexpr int WARMUP_TRIGGERS_PER_FIFO_SIZE = 2;
+
+__constant__ mscclpp::FifoDeviceHandle gFifoDeviceHandle;
+
+__global__ void kernelFifoPush(size_t numTriggers) {
+  mscclpp::FifoDeviceHandle& fifo = gFifoDeviceHandle;
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  mscclpp::ProxyTrigger trigger;
+  for (size_t i = 1; i <= numTriggers; ++i) {
+    trigger.fst = i;
+    trigger.snd = tid ^ i;
+    fifo.push(trigger);
+  }
+}
+
+__global__ void kernelFifoPushSync(size_t numTriggers) {
+  mscclpp::FifoDeviceHandle& fifo = gFifoDeviceHandle;
+  mscclpp::ProxyTrigger trigger;
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  for (size_t i = 1; i <= numTriggers; ++i) {
+    trigger.fst = i;
+    trigger.snd = tid ^ i;
+    fifo.sync(fifo.push(trigger));
+  }
+}
+
+__constant__ mscclpp::PortChannelDeviceHandle gPortChannel;
+
+__global__ void kernelFifoPushAndSignal(mscclpp::PortChannelDeviceHandle portHandle, size_t numTriggers, mscclpp::SemaphoreId semaphoreId) {
+  mscclpp::FifoDeviceHandle& fifo = gFifoDeviceHandle;
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  mscclpp::ProxyTrigger trigger;
+  for (size_t i = 1; i <= numTriggers; ++i) {
+    trigger.fst = semaphoreId;
+    trigger.snd = tid ^ i;
+    fifo.push(trigger);
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+      portHandle.signal();
+  }
+}
+
+__global__ void kernelWaitAndCheck(mscclpp::PortChannelDeviceHandle portHandle, uint64_t* localFlag, int* result) {
+    int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+    // Wait for signal from GPU0
+    portHandle.wait();
+    __syncthreads();
+
+    // Check if flag was updated
+    if (tid == 0) {
+        if (*localFlag != 1ULL) {
+            *result = 1; // Error
+        }
+    }
+}
+
+static void setupCuda(int& cudaDevice, int& numaNode) {
+  utils::CUDA_CHECK(cudaGetDevice(&cudaDevice));
+  numaNode = mscclpp::getDeviceNumaNode(cudaDevice);
+  mscclpp::numaBind(numaNode);
+}
+
+// Helper function to consume triggers from FIFO
+static bool consumeTriggers(std::unique_ptr<mscclpp::Fifo>& hostFifo, int numTriggers, int parallel,
+    std::shared_ptr<mscclpp::Connection> connection,
+    mscclpp::RegisteredMemory remoteFlagRegMem) {
+  int totalTriggers = numTriggers * parallel;
+  std::unordered_map<int, int> triggerCounts;
+  for (int i = 0; i < totalTriggers; ++i) {
+    mscclpp::ProxyTrigger trigger;
+    uint64_t spin = 0;
+    do {
+      trigger = hostFifo->poll();
+      if (spin++ > TIMEOUT_SPINS) {
+        return false;
+      }
+    } while (trigger.fst == 0 || trigger.snd == 0);
+
+    // Process trigger (see src/proxy.cc)
+    trigger.snd ^= ((uint64_t)1 << (uint64_t)63);
+    trigger.snd = trigger.snd ^ trigger.fst;
+    assert(triggerCounts[trigger.snd] + 1 == trigger.fst);
+    triggerCounts[trigger.snd]++;
+    hostFifo->pop();
+
+    // Host-side atomicAdd for each trigger
+    //connection->atomicAdd(remoteFlagRegMem, 0, 1);
+  }
+  return true;
+}
+
+// Helper function to run a single kernel variant and return performance metrics
+std::tuple<double, double, int, int> runSingleKernelVariant(void (*kernel)(size_t),
+                                                            std::unique_ptr<mscclpp::Fifo>& hostFifo,
+                                                            cudaStream_t stream, int numParallel, int rank
+							    mscclpp::PortChannelDeviceHandle,
+							    mscclpp::SemaphoreId, uint64_t* localSemaphoreFlag) {
+  // Calculate triggers based on FIFO size
+  const int numTriggers = std::max(MIN_TRIGGERS, static_cast<int>(hostFifo->size() * TRIGGERS_PER_FIFO_SIZE));
+  const int warmupTriggers =
+      std::max(MIN_WARMUP_TRIGGERS, static_cast<int>(hostFifo->size() * WARMUP_TRIGGERS_PER_FIFO_SIZE));
+
+  /* 
+  // Warmup
+  kernel<<<numParallel, 1, 0, stream>>>(warmupTriggers);
+  utils::CUDA_CHECK(cudaGetLastError());
+
+  // Process warmup triggers (note: total triggers = warmupTriggers * numParallel)
+  if (!consumeTriggers(hostFifo, warmupTriggers, numParallel)) {
+    return {0.0, 0.0, 0, 0};  // Return error values
+  }
+  utils::CUDA_CHECK(cudaStreamSynchronize(stream));
+  */
+
+  // Benchmark
+  utils::Timer timer;
+  timer.start();
+
+  if (rank == 0) {
+    // Launch on GPU0
+    kernel<<<numParallel, 1, 0, stream>>>(gPortChannel, numTriggers, semaphoreId);
+  } else if (rank == 1) {
+    // Launch on GPU1
+    kernelWaitAndCheck<<<numParallel, 1, 0, stream>>>(gPortChannel, localSemaphoreFlag, dResult);
+  }
+  utils::CUDA_CHECK(cudaGetLastError());
+
+  // Process all triggers
+  if (!consumeTriggers(hostFifo, numTriggers, numParallel, connection, remoteFlagRegMem)) {
+    return {0.0, 0.0, 0, 0};
+  }
+  utils::CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  timer.stop();
+
+  const int totalTriggers = numTriggers * numParallel;
+  double throughput = totalTriggers / timer.elapsedSeconds();
+  double duration_us = timer.elapsedMicroseconds();
+
+  utils::CUDA_CHECK(cudaDeviceSynchronize());
+
+  return {throughput, duration_us, totalTriggers, warmupTriggers * numParallel};
+}
+
+void runFifoTestVariant(std::unique_ptr<mscclpp::Fifo>& hostFifo, cudaStream_t stream, int numParallel,
+                        nlohmann::ordered_json& combinedMetrics, int rank,
+		        mscclpp::PortChannelDeviceHandle,
+		        mscclpp::SemaphoreId, uint64_t* localSemaphoreFlag) {
+  auto [pushThroughput, pushDuration, numTriggers, warmupTriggers] =
+      runSingleKernelVariant(kernelFifoPush, hostFifo, stream, numParallel, rank, gPortChannel, semaphoreId, localSemaphoreFlag);
+
+  auto [syncThroughput, syncDuration, syncNumTriggers, syncWarmupTriggers] =
+      runSingleKernelVariant(kernelFifoPushSync, hostFifo, stream, numParallel, rank, gPortChannel, semaphoreId, localSemaphoreFlag);
+
+  auto formatThroughput = [](double thru) {
+    return double(int(thru * 10)) / 10.0;  // Round to 1 decimal place
+  };
+
+  std::string prefix = "p" + std::to_string(numParallel) + "_";
+  combinedMetrics[prefix + "push_throughput"] = formatThroughput(pushThroughput);
+  combinedMetrics[prefix + "push_sync_throughput"] = formatThroughput(syncThroughput);
+  combinedMetrics[prefix + "push_duration_us"] = pushDuration;
+  combinedMetrics[prefix + "push_sync_duration_us"] = syncDuration;
+  combinedMetrics[prefix + "num_triggers"] = numTriggers;
+  combinedMetrics[prefix + "warmup_triggers"] = warmupTriggers;
+}
+
+struct FifoTestConfig {
+  int fifoSize;
+  std::vector<int> parallelismLevels;
+
+  // Constructor with default parallelism levels
+  FifoTestConfig(int size, const std::vector<int>& parallel = {1, 2, 4, 8, 16})
+      : fifoSize(size), parallelismLevels(parallel) {}
+};
+
+void runFifoTest(const FifoTestConfig& config, [[maybe_unused]] int rank, [[maybe_unused]] int worldSize,
+                 [[maybe_unused]] int localRank) {
+  if (config.fifoSize <= 0) {
+    throw std::invalid_argument("FIFO size must be positive");
+  }
+  if (config.parallelismLevels.empty()) {
+    throw std::invalid_argument("At least one parallelism level must be specified");
+  }
+
+  std::vector<mscclpp::PortChannel> portChannels;
+  std::shared_ptr<int> buff = mscclpp::GpuBuffer<int>(nElem).memory();
+
+  // create semaphoreID;
+  for (int r = 0; r < worldSize; r++) {
+    if (r == rank) {
+      continue;
+    }
+    mscclpp::SemaphoreId cid = proxyService->buildAndAddSemaphore(*communicator, this->connectionFutures[r].get());
+
+    portChannels.emplace_back(proxyService->portChannel(cid, proxyService->addMemory(this->remoteMemFutures[r].get()),
+						        proxyService->addMemory(sendBufRegMem)));
+  }
+
+  std::vector<DeviceHandle<mscclpp::PortChannel>> portChannelHandles;
+  for (auto& ch : portChannels) portChannelHandles.push_back(ch.deviceHandle());
+
+  // Set the device for this process
+  cudaSetDevice(rank);
+  uint64_t* localSemaphoreFlag;
+  cudaMalloc(&localSemaphoreFlag, sizeof(uint64_t));
+  cudaMemset(localSemaphoreFlag, 0, sizeof(uint64_t));
+
+  // Register semaphore flag
+  auto localFlagRegmem = communicator->registerMemory(localSemaphoreFlag, sizeof(uint64_t), ibTransport);
+
+  // On host, after connections are established
+  // Build semaphore and port channel for this rank
+  int peerRank = (rank == 0) ? 1 : 0;
+  auto semaphoreId = proxyService->buildAndAddSemaphore(*communicator, connectionFutures[peerRank].get());
+  auto portChannel = proxyService->portChannel(semaphoreId, proxyService->addMemory(remoteMemFutures[peerRank].get()), proxyService->addMemory(localFlagRegmem));
+  auto portChannelHandle = portChannel.deviceHandle();
+  cudaMemcpyToSymbol(gPortChannel, &portChannelHandle, sizeof(portChannelHandle), 0, cudaMemcpyHostToDevice);
+
+  int* dResult;
+  cudaMalloc(&dResult, sizeof(int));
+  cudaMemset(dResult, 0, sizeof(int));
+
+  proxyService->startProxy();
+
+  int cudaDevice, numaNode;
+  setupCuda(cudaDevice, numaNode);
+
+  auto hostFifo = std::make_unique<mscclpp::Fifo>(config.fifoSize);
+
+  mscclpp::FifoDeviceHandle hostHandle = hostFifo->deviceHandle();
+  utils::CUDA_CHECK(cudaMemcpyToSymbol(gFifoDeviceHandle, &hostHandle, sizeof(mscclpp::FifoDeviceHandle)));
+
+  cudaStream_t stream;
+  utils::CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Create test name with parallelism range
+  std::string testName = "FifoTest_Size" + std::to_string(config.fifoSize) + "_Parallel";
+
+  // Add parallelism range to test name (e.g., "P1-16" or "P1-4-16-64")
+  if (!config.parallelismLevels.empty()) {
+    testName += std::to_string(config.parallelismLevels.front());
+    if (config.parallelismLevels.size() > 1) {
+      testName += "-" + std::to_string(config.parallelismLevels.back());
+
+      // If parallelism levels have non-standard steps, include more detail
+      if (config.parallelismLevels.size() > 2 &&
+          (config.parallelismLevels[1] != 2 * config.parallelismLevels[0] || config.parallelismLevels.size() > 3)) {
+        testName = "FifoTest_Size" + std::to_string(config.fifoSize) + "_ParallelCustom";
+      }
+    }
+  }
+
+  // Print test configuration
+  if (utils::isMainRank()) {
+    std::stringstream ss;
+    ss << "Running FIFO test with size=" << config.fifoSize << ", parallelism_levels=[";
+    for (size_t i = 0; i < config.parallelismLevels.size(); ++i) {
+      if (i > 0) ss << ",";
+      ss << config.parallelismLevels[i];
+    }
+    ss << "]";
+    std::cout << ss.str() << std::endl;
+  }
+
+  nlohmann::ordered_json combinedMetrics;
+
+  for (int numParallel : config.parallelismLevels) {
+    runFifoTestVariant(hostFifo, stream, numParallel, combinedMetrics, rank);
+  }
+
+  std::map<std::string, std::string> testParams;
+  testParams["fifo_size"] = std::to_string(static_cast<int>(hostFifo->size()));
+
+  // Add parallelism levels to test parameters
+  std::stringstream parallelismStream;
+  for (size_t i = 0; i < config.parallelismLevels.size(); ++i) {
+    if (i > 0) parallelismStream << ",";
+    parallelismStream << config.parallelismLevels[i];
+  }
+  testParams["parallelism_levels"] = parallelismStream.str();
+
+  utils::recordResult(testName, "fifo", combinedMetrics, testParams);
+
+  utils::CUDA_CHECK(cudaStreamDestroy(stream));
+
+  proxyService->stopProxy();
+}
+
+void runAllFifoTests([[maybe_unused]] int rank, [[maybe_unused]] int worldSize, [[maybe_unused]] int localRank) {
+  // clang-format off
+  std::vector<FifoTestConfig> configs = {
+      {1, {1}},
+      {128, {1, 8, 64, 128}},
+      {512, {1, 8, 64, 256, 512}},
+  };
+  // clang-format on
+
+  for (const auto& config : configs) {
+    runFifoTest(config, rank, worldSize, localRank);
+  }
+}
+
+static void printUsage(char* argv0) {
+  std::stringstream ss;
+  ss << "Usage: " << argv0 << " [OPTIONS]\n"
+     << "\n"
+     << "Options:\n"
+     << "  -o, --output-format FORMAT   Output format: human or json (default: human)\n"
+     << "  -f, --output-file FILE       JSON output file path (default: report.jsonl)\n"
+     << "  -v, --verbose                Increase verbosity\n"
+     << "  -h, --help                   Show this help message\n";
+  std::cout << ss.str();
+}
+
+int main(int argc, char* argv[]) {
+  std::string outputFormat = "human";
+  std::string outputFile = "report.jsonl";
+  bool verbose = false;
+
+  static struct option longOptions[] = {{"output-format", required_argument, 0, 'o'},
+                                        {"output-file", required_argument, 0, 'f'},
+                                        {"verbose", no_argument, 0, 'v'},
+                                        {"help", no_argument, 0, 'h'},
+                                        {0, 0, 0, 0}};
+
+  int c;
+  while ((c = getopt_long(argc, argv, "o:f:vh", longOptions, nullptr)) != -1) {
+    switch (c) {
+      case 'o':
+        outputFormat = optarg;
+        break;
+      case 'f':
+        outputFile = optarg;
+        break;
+      case 'v':
+        verbose = true;
+        break;
+      case 'h':
+        printUsage(argv[0]);
+        return 0;
+      default:
+        printUsage(argv[0]);
+        return 1;
+    }
+  }
+
+  std::vector<std::tuple<std::string, std::string, std::function<void(int, int, int)>>> tests = {
+      {"AllFifoTests", "FIFO performance tests with multiple configurations", runAllFifoTests}};
+
+  int result = utils::runMultipleTests(argc, argv, tests);
+
+  if (utils::isMainRank()) {
+    if (outputFormat == "json") {
+      utils::writeResultsToFile(outputFile);
+    } else {
+      utils::printResults(verbose);
+    }
+  }
+
+  utils::cleanupMPI();
+
+  return result;
+}

--- a/test/perf/framework.cc
+++ b/test/perf/framework.cc
@@ -225,7 +225,7 @@ int runMultipleTests(
     MPI_Bcast((void*)&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD);
     bootstrap->initialize(id);
 
-    std::vector<mscclpp::Transport> trans {mscclpp::Transport::IB0, mscclpp::Transport::IB1};
+    std::vector<mscclpp::Transport> trans{mscclpp::Transport::IB0, mscclpp::Transport::IB1};
     cudaSetDevice(rank);
     std::vector<std::shared_ptr<mscclpp::Connection>> conns;
     std::shared_ptr<mscclpp::Communicator> comm = std::make_shared<mscclpp::Communicator>(bootstrap);

--- a/test/perf/framework.hpp
+++ b/test/perf/framework.hpp
@@ -20,6 +20,19 @@
 namespace mscclpp {
 namespace test {
 
+// Forward declarations
+class Communicator;
+class Connection;
+
+// Test context structure containing MPI and MSCCLPP objects
+struct TestContext {
+  int rank;
+  int size;
+  int local_rank;
+  std::shared_ptr<mscclpp::Communicator> communicator;
+  std::vector<std::shared_ptr<mscclpp::Connection>> connections;
+};
+
 // Test result structure
 struct TestResult {
   std::string test_name;
@@ -38,6 +51,10 @@ namespace utils {
 int runMultipleTests(
     int argc, char* argv[],
     const std::vector<std::tuple<std::string, std::string, std::function<void(int, int, int)>>>& tests);
+
+int runMultipleTests(
+    int argc, char* argv[],
+    const std::vector<std::tuple<std::string, std::string, std::function<void(const TestContext&)>>>& tests);
 
 // MPI management
 void initializeMPI(int argc, char* argv[]);

--- a/test/perf/framework.hpp
+++ b/test/perf/framework.hpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <functional>
 #include <map>
+#include <mscclpp/core.hpp>
 #include <mscclpp/gpu.hpp>
 #include <nlohmann/json.hpp>
 #include <string>


### PR DESCRIPTION
Add two gpu for fifo_test in test/perf
Leverage PortChannelDeviceHandle::signal() and wait() to communicate between two GPUs.