### PR TITLE
all2all implementation

### DIFF
--- a/include/mscclpp/concurrency_device.hpp
+++ b/include/mscclpp/concurrency_device.hpp
@@ -118,7 +118,7 @@ struct DeviceSemaphore {
   MSCCLPP_DEVICE_INLINE void acquire([[maybe_unused]] int maxSpinCount = -1) {
     int oldVal = atomicFetchAdd<int, scopeDevice>(&semaphore_, -1, memoryOrderAcquire);
     if (oldVal <= 0) {
-      POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&semaphore_, memoryOrderAcquire) != oldVal), maxSpinCount);
+      POLL_MAYBE_JAILBREAK((atomicLoad<int, scopeDevice>(&semaphore_, memoryOrderAcquire) < oldVal), maxSpinCount);
     }
   }
 

--- a/test/mscclpp-test/alltoall_test.cu
+++ b/test/mscclpp-test/alltoall_test.cu
@@ -114,7 +114,7 @@ __global__ void __launch_bounds__(1024)
         mscclpp::copy((char*)memoryChannels[peerId].dst_ + dstOffset + i * unit,
                       (char*)inputBuffer + startOffset + i * unit, size, wid * WARP_SIZE + lid,
                       nWarpForPut * WARP_SIZE);
-        asm volatile("bar.sync %0, %1;" ::"r"(0), "r"(nWarpForPut * WARP_SIZE) : "memory");
+        asm volatile("bar.sync %0, %1;" ::"r"(15), "r"(nWarpForPut * WARP_SIZE) : "memory");
         if (tidInPut == 0) {
           memoryChannels[peerId].signal();
           sem.release();
@@ -131,7 +131,7 @@ __global__ void __launch_bounds__(1024)
           size = lastIterSize;
         }
         // barrier for n warp
-        asm volatile("bar.sync %0, %1;" ::"r"(1), "r"(nWarpForCopy * WARP_SIZE) : "memory");
+        asm volatile("bar.sync %0, %1;" ::"r"(14), "r"(nWarpForCopy * WARP_SIZE) : "memory");
         mscclpp::copy((char*)inputBuffer + startOffset + i * unit, (char*)scratchBuffer + startOffset + i * unit, size,
                       tidInCopy, nWarpForCopy * WARP_SIZE);
       }
@@ -182,7 +182,7 @@ __global__ void __launch_bounds__(1024)
         }
         mscclpp::copy((char*)scratchBuffer + startOffset + i * unit, (char*)inputBuffer + startOffset + i * unit, size,
                       tidInCopy, nWarpForCopy * WARP_SIZE);
-        asm volatile("bar.sync %0, %1;" ::"r"(0), "r"(nWarpForCopy * WARP_SIZE) : "memory");
+        asm volatile("bar.sync %0, %1;" ::"r"(15), "r"(nWarpForCopy * WARP_SIZE) : "memory");
         if (tidInCopy == 0) {
           memoryChannels[peerId].signal();
           sem.release();
@@ -199,7 +199,7 @@ __global__ void __launch_bounds__(1024)
           size = lastIterSize;
         }
         // barrier for n warp
-        asm volatile("bar.sync %0, %1;" ::"r"(1), "r"(nWarpForGet * WARP_SIZE) : "memory");
+        asm volatile("bar.sync %0, %1;" ::"r"(14), "r"(nWarpForGet * WARP_SIZE) : "memory");
         mscclpp::copy((char*)inputBuffer + startOffset + i * unit,
                       (char*)memoryChannels[peerId].dst_ + dstOffset + i * unit, size, tidInGet,
                       nWarpForGet * WARP_SIZE);

--- a/test/mscclpp-test/alltoall_test.cu
+++ b/test/mscclpp-test/alltoall_test.cu
@@ -69,6 +69,7 @@ __global__ void __launch_bounds__(1024) alltoall1(int rank, int nRanksPerNode, s
 
 __global__ void __launch_bounds__(1024)
     alltoall2(int rank, int nRanksPerNode, size_t nElements, void* inputBuffer, void* scratchBuffer) {
+#if defined(__CUDA_ARCH__)
   constexpr int nWarpForPut = 20;
   constexpr int nWarpForCopy = 12;
   constexpr int putStartWid = 0;
@@ -136,10 +137,12 @@ __global__ void __launch_bounds__(1024)
       }
     }
   }
+#endif
 }
 
 __global__ void __launch_bounds__(1024)
     alltoall3(int rank, int nRanksPerNode, size_t nElements, void* inputBuffer, void* scratchBuffer) {
+#if defined(__CUDA_ARCH__)
   constexpr int nWarpForCopy = 16;
   constexpr int nWarpForGet = 16;
   constexpr int copyStartWid = 0;
@@ -208,6 +211,7 @@ __global__ void __launch_bounds__(1024)
     memoryChannels[lid].relaxedSignal();
     memoryChannels[lid].relaxedWait();
   }
+#endif
 }
 
 

--- a/test/mscclpp-test/alltoall_test.cu
+++ b/test/mscclpp-test/alltoall_test.cu
@@ -242,7 +242,7 @@ void AllToAllTestColl::runColl(const TestArgs& args, cudaStream_t stream) {
 }
 
 void AllToAllTestColl::initData(const TestArgs& args, std::vector<void*> sendBuff, void* expectedBuff) {
-  if (sendBuff.size() != 1) std::runtime_error("unexpected error");
+  if (sendBuff.size() != 1) throw std::runtime_error("unexpected error");
   const int rank = args.rank;
   std::vector<int> dataHost(recvCount_, 0);
   // For rank 0, the data is 0, 1, 2 ... recvCount_ - 1, for rank 1, the data is recvCount_, recvCount_ + 1, ...
@@ -332,14 +332,14 @@ void AllToAllTestEngine::setupConnections() {
                        ChannelSemantic::PUT, 64);
 
   if (portChannels.size() > sizeof(constPortChans) / sizeof(DeviceHandle<mscclpp::PortChannel>)) {
-    std::runtime_error("unexpected error");
+    throw std::runtime_error("unexpected error");
   }
   CUDATHROW(cudaMemcpyToSymbol(constPortChans, portChannels.data(),
                                sizeof(DeviceHandle<mscclpp::PortChannel>) * portChannels.size()));
   std::transform(this->memoryChannels.begin(), this->memoryChannels.end(), std::back_inserter(memoryChannelHandles),
                  [](const mscclpp::MemoryChannel& channel) { return mscclpp::deviceHandle(channel); });
   if (memoryChannelHandles.size() > sizeof(constMemChans) / sizeof(DeviceHandle<mscclpp::MemoryChannel>)) {
-    std::runtime_error("unexpected error");
+    throw std::runtime_error("unexpected error");
   }
   CUDATHROW(cudaMemcpyToSymbol(constMemChans, memoryChannelHandles.data(),
                                sizeof(DeviceHandle<mscclpp::MemoryChannel>) * memoryChannelHandles.size()));

--- a/test/mscclpp-test/alltoall_test.cu
+++ b/test/mscclpp-test/alltoall_test.cu
@@ -19,7 +19,6 @@ using DeviceHandle = mscclpp::DeviceHandle<T>;
 __constant__ DeviceHandle<mscclpp::PortChannel> constPortChans[16];
 __constant__ DeviceHandle<mscclpp::MemoryChannel> constMemChans[512];
 __device__ mscclpp::DeviceSyncer deviceSyncer;
-__device__ mscclpp::DeviceSemaphore deviceSemaphore[128];
 
 static void* localRecvBuff;
 static void* localSendBuff;

--- a/test/mscclpp-test/alltoall_test.cu
+++ b/test/mscclpp-test/alltoall_test.cu
@@ -7,12 +7,30 @@
 
 #include "common.hpp"
 
+
+#if defined(__HIP_PLATFORM_AMD__)
+#define WARP_SIZE 64
+#else
+#define WARP_SIZE 32
+#endif
+
 template <class T>
 using DeviceHandle = mscclpp::DeviceHandle<T>;
 __constant__ DeviceHandle<mscclpp::PortChannel> constPortChans[16];
+__constant__ DeviceHandle<mscclpp::MemoryChannel> constMemChans[512];
 __device__ mscclpp::DeviceSyncer deviceSyncer;
-void* localRecvBuff;
-void* localSendBuff;
+__device__ mscclpp::DeviceSemaphore deviceSemaphore[64];
+__device__ int peerMap[] = {1, 0, 3, 2, 5, 4, 7, 6 /*first */,
+                            2, 3, 0, 1, 6, 7, 4, 5 /* second */,
+                            3, 2, 1, 0, 7, 6, 5, 4 /*third*/,
+                            4, 5, 6, 7, 0, 1, 2, 3 /*forth*/,
+                            5, 4, 7, 6, 1, 0, 3, 2 /*fifth*/,
+                            6, 7, 4, 5, 2, 3, 0, 1 /*sixth*/,
+                            7, 6, 5, 4, 3, 2, 1, 0 /*seventh*/};
+
+static void* localRecvBuff;
+static void* localSendBuff;
+static void* localScratchBuff;
 
 __device__ void localAlltoall(int rank, int nRanksPerNode, size_t nElements) {
   int remoteRank = ((int)blockIdx.x < rank) ? blockIdx.x : blockIdx.x + 1;
@@ -49,6 +67,151 @@ __global__ void __launch_bounds__(1024) alltoall1(int rank, int nRanksPerNode, s
   localAlltoall(rank, nRanksPerNode, nElements);
 }
 
+__global__ void __launch_bounds__(1024)
+    alltoall2(int rank, int nRanksPerNode, size_t nElements, void* inputBuffer, void* scratchBuffer) {
+  constexpr int nWarpForPut = 20;
+  constexpr int nWarpForCopy = 12;
+  constexpr int putStartWid = 0;
+  constexpr int putEndWid = putStartWid + nWarpForPut;
+  constexpr int copyStartWid = putEndWid;
+  constexpr int copyEndWid = copyStartWid + nWarpForCopy;
+  constexpr size_t unit = 1 << 18; // 256K
+
+  assert(nRanksPerNode == 8);
+
+  size_t totalCount = nElements * sizeof(int);
+  size_t nBytesPerBlock = (totalCount + (gridDim.x - 1)) / gridDim.x;
+  nBytesPerBlock = nBytesPerBlock / 16 * 16; // alignment
+  size_t nBytesForLastBlock = totalCount - (nBytesPerBlock * (gridDim.x - 1));
+  size_t totalBytesForCurrentBlock = nBytesPerBlock;
+  if (blockIdx.x == gridDim.x - 1) {
+    totalBytesForCurrentBlock = nBytesForLastBlock;
+  }
+  size_t nIters = (totalBytesForCurrentBlock  + unit - 1) / unit;
+  int wid = threadIdx.x / WARP_SIZE;
+  int lid = threadIdx.x % WARP_SIZE;
+  DeviceHandle<mscclpp::MemoryChannel>* memoryChannels = constMemChans + blockIdx.x * (nRanksPerNode - 1);
+  auto& sem = deviceSemaphore[blockIdx.x];
+  if (wid == 0 && lid < nRanksPerNode - 1) {
+    memoryChannels[lid].relaxedSignal();
+    memoryChannels[lid].relaxedWait();
+  }
+  __syncthreads();
+  size_t lastIterSize = totalBytesForCurrentBlock - (nIters - 1) * unit;
+  for (int step = 0; step < nRanksPerNode - 1; step++) {
+    int peer = peerMap[step * nRanksPerNode + rank];
+    int peerId = peer < rank ? peer : peer - 1;
+    size_t startOffset = peer * totalCount + blockIdx.x * nBytesPerBlock;
+    size_t dstOffset = rank * totalCount + blockIdx.x * nBytesPerBlock;
+    size_t size = unit;
+    if (wid >= putStartWid && wid < putEndWid) {
+      int tidInPut = wid * WARP_SIZE + lid - putStartWid * WARP_SIZE;
+      for (size_t i = 0; i < nIters; i++) {
+        if (i == nIters - 1) {
+          size = lastIterSize;
+        }
+        mscclpp::copy((char*)memoryChannels[peerId].dst_ + dstOffset + i * unit,
+                      (char*)inputBuffer + startOffset + i * unit, size, wid * WARP_SIZE + lid,
+                      nWarpForPut * WARP_SIZE);
+        asm volatile("bar.sync %0, %1;" ::"r"(0), "r"(nWarpForPut * WARP_SIZE) : "memory");
+        if (tidInPut == 0) {
+          memoryChannels[peerId].signal();
+          sem.release();
+        }
+      }
+    } else if (wid >= copyStartWid && wid < copyEndWid) {
+      int tidInCopy = wid * WARP_SIZE + lid - copyStartWid * WARP_SIZE;
+      for (size_t i = 0; i < nIters; i++) {
+        if (tidInCopy == 0) {
+          sem.acquire();
+          memoryChannels[peerId].wait();
+        }
+        if (i == nIters - 1) {
+          size = lastIterSize;
+        }
+        // barrier for n warp
+        asm volatile("bar.sync %0, %1;" ::"r"(1), "r"(nWarpForCopy * WARP_SIZE) : "memory");
+        mscclpp::copy((char*)inputBuffer + startOffset + i * unit, (char*)scratchBuffer + startOffset + i * unit, size,
+                      tidInCopy, nWarpForCopy * WARP_SIZE);
+      }
+    }
+  }
+}
+
+__global__ void __launch_bounds__(1024)
+    alltoall3(int rank, int nRanksPerNode, size_t nElements, void* inputBuffer, void* scratchBuffer) {
+  constexpr int nWarpForCopy = 16;
+  constexpr int nWarpForGet = 16;
+  constexpr int copyStartWid = 0;
+  constexpr int copyEndWid = copyStartWid + nWarpForCopy;
+  constexpr int getStartWid = copyEndWid;
+  constexpr int getEndWid = getStartWid + nWarpForGet;
+  constexpr size_t unit = 1 << 18; // 256K
+
+  assert(nRanksPerNode == 8);
+
+  size_t totalCount = nElements * sizeof(int);
+  size_t nBytesPerBlock = (totalCount + (gridDim.x - 1)) / gridDim.x;
+  nBytesPerBlock = nBytesPerBlock / 16 * 16; // alignment
+  size_t nBytesForLastBlock = totalCount - (nBytesPerBlock * (gridDim.x - 1));
+  size_t totalBytesForCurrentBlock = nBytesPerBlock;
+  if (blockIdx.x == gridDim.x - 1) {
+    totalBytesForCurrentBlock = nBytesForLastBlock;
+  }
+
+  size_t nIters = (totalBytesForCurrentBlock  + unit - 1) / unit;
+  int wid = threadIdx.x / WARP_SIZE;
+  int lid = threadIdx.x % WARP_SIZE;
+  DeviceHandle<mscclpp::MemoryChannel>* memoryChannels = constMemChans + blockIdx.x * (nRanksPerNode - 1);
+  auto& sem = deviceSemaphore[blockIdx.x];
+  size_t lastIterSize = totalBytesForCurrentBlock - (nIters - 1) * unit;
+  for (int step = 0; step < nRanksPerNode - 1; step++) {
+    int peer = peerMap[step * nRanksPerNode + rank];
+    int peerId = peer < rank ? peer : peer - 1;
+    size_t startOffset = peer * totalCount + blockIdx.x * nBytesPerBlock;
+    size_t dstOffset = rank * totalCount + blockIdx.x * nBytesPerBlock;
+    size_t size = unit;
+    if (wid >= copyStartWid && wid < copyEndWid) {
+      int tidInCopy = wid * WARP_SIZE + lid - copyStartWid * WARP_SIZE;
+      for (size_t i = 0; i < nIters; i++) {
+        if (i == nIters - 1) {
+          size = lastIterSize;
+        }
+        mscclpp::copy((char*)scratchBuffer + startOffset + i * unit, (char*)inputBuffer + startOffset + i * unit, size,
+                      tidInCopy, nWarpForCopy * WARP_SIZE);
+        asm volatile("bar.sync %0, %1;" ::"r"(0), "r"(nWarpForCopy * WARP_SIZE) : "memory");
+        if (tidInCopy == 0) {
+          memoryChannels[peerId].signal();
+          sem.release();
+        }
+      }
+    } else if (wid >= getStartWid && wid < getEndWid) {
+      int tidInGet = wid * WARP_SIZE + lid - getStartWid * WARP_SIZE;
+      for (size_t i = 0; i < nIters; i++) {
+        if (tidInGet == 0) {
+          sem.acquire();
+          memoryChannels[peerId].wait();
+        }
+        if (i == nIters - 1) {
+          size = lastIterSize;
+        }
+        // barrier for n warp
+        asm volatile("bar.sync %0, %1;" ::"r"(1), "r"(nWarpForGet * WARP_SIZE) : "memory");
+        mscclpp::copy((char*)inputBuffer + startOffset + i * unit,
+                      (char*)memoryChannels[peerId].dst_ + dstOffset + i * unit, size, tidInGet,
+                      nWarpForGet * WARP_SIZE);
+      }
+    }
+  }
+  __syncthreads();
+  if (wid == 0 && lid < nRanksPerNode - 1) {
+    memoryChannels[lid].relaxedSignal();
+    memoryChannels[lid].relaxedWait();
+  }
+}
+
+
+
 class AllToAllTestColl : public BaseTestColl {
  public:
   AllToAllTestColl() = default;
@@ -66,12 +229,19 @@ void AllToAllTestColl::runColl(const TestArgs& args, cudaStream_t stream) {
   const int rank = args.rank;
   const int kernelNum = args.kernelNum;
   const int nRanksPerNode = args.nRanksPerNode;
-  CUDATHROW(cudaMemcpyAsync((int*)localRecvBuff + paramCount_ * rank, (int*)localSendBuff + paramCount_ * rank,
-                            paramCount_ * sizeof(int), cudaMemcpyDeviceToDevice, stream));
+  auto isInPlaceKernel = [kernelNum]() { return kernelNum == 2 || kernelNum == 3; };
+  if (!isInPlaceKernel()) {
+    CUDATHROW(cudaMemcpyAsync((int*)localRecvBuff + paramCount_ * rank, (int*)localSendBuff + paramCount_ * rank,
+                              paramCount_ * sizeof(int), cudaMemcpyDeviceToDevice, stream));
+  }
   if (kernelNum == 0) {
     alltoall0<<<worldSize - 1, 32, 0, stream>>>(rank, paramCount_);
   } else if (kernelNum == 1) {
     alltoall1<<<worldSize - 1, 32, 0, stream>>>(rank, nRanksPerNode, paramCount_);
+  } else if (kernelNum == 2) {
+    alltoall2<<<64, 1024, 0, stream>>>(rank, nRanksPerNode, paramCount_, localSendBuff, localScratchBuff);
+  } else if (kernelNum == 3) {
+    alltoall3<<<64, 1024, 0, stream>>>(rank, nRanksPerNode, paramCount_, localSendBuff, localScratchBuff);
   }
 }
 
@@ -112,9 +282,11 @@ void AllToAllTestColl::setupCollTest(size_t size) {
 }
 
 std::vector<KernelRestriction> AllToAllTestColl::getKernelRestrictions() {
-  return {// {kernelNum, kernelName, compatibleWithMultiNodes, countDivisorForMultiNodes}
+  return {// {kernelNum, kernelName, compatibleWithMultiNodes, countDivisorForMultiNodes, alignedBytes}
           {0, "alltoall0", true, 1, 4 * worldSize_},
-          {1, "alltoall1", false, 1, 4 * worldSize_}};
+          {1, "alltoall1", false, 1, 4 * worldSize_},
+          {2, "alltoall2", false, 1, 4 * worldSize_},
+          {3, "alltoall3", false, 1, 4 * worldSize_}};
 }
 
 class AllToAllTestEngine : public BaseTestEngine {
@@ -131,37 +303,64 @@ class AllToAllTestEngine : public BaseTestEngine {
 
  private:
   void* getExpectedBuff() override;
+  bool isInPlace() const;
 
   std::shared_ptr<int> sendBuff_;
   std::shared_ptr<int> recvBuff_;
   std::shared_ptr<int[]> expectedBuff_;
+  std::shared_ptr<int> scratchBuff_;
+
+  std::vector<mscclpp::MemoryChannel> memoryChannels;
 };
 
-AllToAllTestEngine::AllToAllTestEngine(const TestArgs& args) : BaseTestEngine(args, "alltoall") { inPlace_ = false; }
+bool AllToAllTestEngine::isInPlace() const {
+  return (args_.kernelNum == 2 || args_.kernelNum == 3);
+}
+
+AllToAllTestEngine::AllToAllTestEngine(const TestArgs& args) : BaseTestEngine(args, "alltoall") {
+  inPlace_ = isInPlace();
+}
 
 void AllToAllTestEngine::allocateBuffer() {
   sendBuff_ = mscclpp::GpuBuffer<int>(args_.maxBytes / sizeof(int)).memory();
   recvBuff_ = mscclpp::GpuBuffer<int>(args_.maxBytes / sizeof(int)).memory();
   expectedBuff_ = std::shared_ptr<int[]>(new int[args_.maxBytes / sizeof(int)]);
+  scratchBuff_ = mscclpp::GpuBuffer<int>(args_.maxBytes / sizeof(int)).memory();
 
   localSendBuff = sendBuff_.get();
   localRecvBuff = recvBuff_.get();
+  localScratchBuff = scratchBuff_.get();
 }
 
 void AllToAllTestEngine::setupConnections() {
   std::vector<DeviceHandle<mscclpp::PortChannel>> portChannels;
+  std::vector<DeviceHandle<mscclpp::MemoryChannel>> memoryChannelHandles;
   setupMeshConnections(portChannels, sendBuff_.get(), args_.maxBytes, recvBuff_.get(), args_.maxBytes);
+  setupMeshConnections(this->memoryChannels, sendBuff_.get(), args_.maxBytes, scratchBuff_.get(), args_.maxBytes,
+                       ChannelSemantic::PUT, 64);
 
   if (portChannels.size() > sizeof(constPortChans) / sizeof(DeviceHandle<mscclpp::PortChannel>)) {
     std::runtime_error("unexpected error");
   }
   CUDATHROW(cudaMemcpyToSymbol(constPortChans, portChannels.data(),
                                sizeof(DeviceHandle<mscclpp::PortChannel>) * portChannels.size()));
+  std::transform(this->memoryChannels.begin(), this->memoryChannels.end(), std::back_inserter(memoryChannelHandles),
+                 [](const mscclpp::MemoryChannel& channel) { return mscclpp::deviceHandle(channel); });
+  if (memoryChannelHandles.size() > sizeof(constMemChans) / sizeof(DeviceHandle<mscclpp::MemoryChannel>)) {
+    std::runtime_error("unexpected error");
+  }
+  CUDATHROW(cudaMemcpyToSymbol(constMemChans, memoryChannelHandles.data(),
+                               sizeof(DeviceHandle<mscclpp::MemoryChannel>) * memoryChannelHandles.size()));
 }
 
 std::vector<void*> AllToAllTestEngine::getSendBuff() { return {sendBuff_.get()}; }
 void* AllToAllTestEngine::getExpectedBuff() { return expectedBuff_.get(); }
-void* AllToAllTestEngine::getRecvBuff() { return recvBuff_.get(); }
+void* AllToAllTestEngine::getRecvBuff() {
+  if (this->isInPlace())
+    return sendBuff_.get();
+  else
+    return recvBuff_.get();
+}
 void* AllToAllTestEngine::getScratchBuff() { return nullptr; }
 
 std::shared_ptr<BaseTestEngine> getTestEngine(const TestArgs& args) {


### PR DESCRIPTION
Implement single node all2all via MSCCL++ C++API
perf kernel 3:
```
       size         count     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong
#        (B)    (elements)     (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)
     1048576         32768                                     23.41   44.78   39.19      0
     2097152         65536                                     23.95   87.56   76.61      0
     4194304        131072                                     27.50  152.51  133.45      0
     8388608        262144                                     35.14  238.73  208.89      0
    16777216        524288                                     57.54  291.55  255.11      0
    33554432       1048576                                     109.7  305.81  267.59      0
    67108864       2097152                                     212.3  316.07  276.56      0
   134217728       4194304                                     410.9  326.64  285.81      0
   268435456       8388608                                     784.9  341.99  299.24      0
```

kernel 2
```

#                                        in-place                       out-of-place
#       size         count     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong
#        (B)    (elements)     (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)
     1048576         32768                                     23.42   44.77   39.17      0
     2097152         65536                                     24.96   84.02   73.52      0
     4194304        131072                                     28.53  147.03  128.65      0
     8388608        262144                                     36.75  228.28  199.75      0
    16777216        524288                                     58.01  289.20  253.05      0
    33554432       1048576                                     110.4  303.83  265.85      0
    67108864       2097152                                     212.4  315.99  276.49      0
   134217728       4194304                                     407.8  329.12  287.98      0
   268435456       8388608                                     797.4  336.64  294.56      0
```

NCCL:
```
NCCL version 2.21.5+cuda12.4
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
     8388608        524288      half    none      -1    38.70  216.75  189.66      0    39.25  213.72  187.00    N/A
    16777216       1048576      half    none      -1    71.39  234.99  205.62      0    68.41  245.25  214.60    N/A
    33554432       2097152      half    none      -1    119.7  280.22  245.20      0    119.8  280.17  245.15    N/A
    67108864       4194304      half    none      -1    211.9  316.66  277.08      0    212.7  315.53  276.09    N/A
   134217728       8388608      half    none      -1    408.4  328.61  287.53      0    393.8  340.87  298.26    N/A
   268435456      16777216      half    none      -1    761.6  352.47  308.41      0    763.3  351.70  307.73    N/A
   536870912      33554432      half    none      -1   1502.5  357.31  312.64      0   1467.3  365.89  320.16    N/A
```