### PR TITLE
Fix Illegal Memory Access in nvls_test for CUDA12.9

### DIFF
--- a/test/nvls_test.cu
+++ b/test/nvls_test.cu
@@ -148,10 +148,11 @@ int main() {
 
   // Map a VA to UC space
   CUCHECK(cuMemAddressReserve((CUdeviceptr*)&uc_va, mcSize, minGran, 0U, 0));
-  cudaMemset(uc_va, 0, mcSize);
   CUCHECK(cuMemMap((CUdeviceptr)uc_va, mcSize, 0, memhandle, 0));
   // set access on UC address
   CUCHECK(cuMemSetAccess((CUdeviceptr)uc_va, mcSize, &accessDesc, 1));
+  //Memset uc space
+  cudaMemset(uc_va, 0, mcSize);
 
   // everyone binds memory to the multicast
   CUCHECK(cuMulticastBindAddr(handle, 0 /*mcOffset*/, (CUdeviceptr)uc_va, mcSize, 0));


### PR DESCRIPTION
Running NVLS test, `test/nvls_test.cu` in CUDA 12.9 leads to illegal memory access at https://github.com/microsoft/mscclpp/blob/571fee16fb872df75061b8b7231446243f591ddb/test/nvls_test.cu#L151 . 
This PR addresses this error by moving cudaMemset after memory mapping. 