### PR TITLE
Add detailed commit SHA hash to the current version number 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -108,6 +108,47 @@ $ python -m pip install .
 $ CXX=/opt/rocm/bin/hipcc python -m pip install .
 ```
 
+### Version Tracking
+
+The MSCCL++ Python package includes comprehensive version tracking that captures git repository information at build time. This feature allows users to identify the exact source code version of their installed package.
+
+#### Checking Version Information
+
+After installation, you can check the version information in several ways:
+
+**From Python:**
+```python
+import mscclpp
+
+# Show all version information
+mscclpp.show_version()
+# Output:
+# MSCCLPP Version Information:
+#   Package Version: 0.7.0
+#   Git Commit: 43f160c
+#   Git Branch: main
+#   Git Remote: https://github.com/microsoft/mscclpp.git
+
+# Access individual attributes
+print(f"Version: {mscclpp.__version__}")
+print(f"Git commit: {mscclpp.__git_commit__}")
+print(f"Git branch: {mscclpp.__git_branch__}")
+print(f"Git remote: {mscclpp.__git_remote__}")
+
+# Get as dictionary
+info = mscclpp.get_version_info()
+```
+
+#### Version Information Details
+
+The version tracking captures:
+- **Package Version**: The semantic version from setup.py
+- **Git Commit**: Short SHA hash with '-dirty' suffix if there were uncommitted changes at build time
+- **Git Branch**: The branch name at build time
+- **Git Remote**: Repository URL (credentials are automatically stripped for security)
+
+This information is embedded during the package build process and remains accessible even after distribution, making it easier to debug issues and ensure reproducibility.
+
 (vscode-dev-container)=
 ## VSCode Dev Container
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -112,6 +112,13 @@ $ CXX=/opt/rocm/bin/hipcc python -m pip install .
 
 The MSCCL++ Python package includes comprehensive version tracking that captures git repository information at build time. This feature allows users to identify the exact source code version of their installed package.
 
+#### Version Format
+
+The package version includes the git commit hash directly in the version string for development builds:
+- **Release version**: `0.7.0`
+- **Development version**: `0.7.0+git.43f160c` (includes short commit hash)
+- **Development with uncommitted changes**: `0.7.0+git.43f160c-dirty`
+
 #### Checking Version Information
 
 After installation, you can check the version information in several ways:
@@ -124,28 +131,33 @@ import mscclpp
 mscclpp.show_version()
 # Output:
 # MSCCLPP Version Information:
-#   Package Version: 0.7.0
+#   Package Version: 0.7.0+git.43f160c
+#   Base Version: 0.7.0
 #   Git Commit: 43f160c
 #   Git Branch: main
 #   Git Remote: https://github.com/microsoft/mscclpp.git
 
 # Access individual attributes
-print(f"Version: {mscclpp.__version__}")
-print(f"Git commit: {mscclpp.__git_commit__}")
+print(f"Version: {mscclpp.__version__}")           # Full version with commit
+print(f"Base version: {mscclpp.__base_version__}") # Semantic version only
+print(f"Git commit: {mscclpp.__git_commit__}")     # Commit hash only
 print(f"Git branch: {mscclpp.__git_branch__}")
 print(f"Git remote: {mscclpp.__git_remote__}")
 
 # Get as dictionary
 info = mscclpp.get_version_info()
+print(f"Full version: {info['version']}")
+print(f"Base version: {info['base_version']}")
 ```
 
 #### Version Information Details
 
 The version tracking captures:
-- **Package Version**: The semantic version from setup.py
-- **Git Commit**: Short SHA hash with '-dirty' suffix if there were uncommitted changes at build time
-- **Git Branch**: The branch name at build time
-- **Git Remote**: Repository URL (credentials are automatically stripped for security)
+- **Package Version** (`__version__`): Full version string including git commit (e.g., `0.7.0+git.43f160c`)
+- **Base Version** (`__base_version__`): Semantic version without git information (e.g., `0.7.0`)
+- **Git Commit** (`__git_commit__`): Short SHA hash with '-dirty' suffix if there were uncommitted changes at build time
+- **Git Branch** (`__git_branch__`): The branch name at build time
+- **Git Remote** (`__git_remote__`): Repository URL (credentials are automatically stripped for security)
 
 This information is embedded during the package build process and remains accessible even after distribution, making it easier to debug issues and ensure reproducibility.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,51 @@
 # Licensed under the MIT license.
 
 [build-system]
-requires = ["scikit-build-core"]
-build-backend = "scikit_build_core.build"
+requires = [
+    "setuptools>=61.0",
+    "wheel",
+    "cmake>=3.25",
+    "scikit-build-core>=0.9.0",
+]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "mscclpp"
 version = "0.7.0"
+description = "MSCCLPP Python bindings with version tracking"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [
+    {name = "Microsoft"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Topic :: System :: Hardware :: Symmetric Multi-processing",
+    "Topic :: System :: Distributed Computing",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: C++",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/mscclpp"
+Repository = "https://github.com/microsoft/mscclpp.git"
+
+[project.scripts]
+mscclpp-version = "mscclpp.__main__:main"
+
+[tool.setuptools]
+packages = ["mscclpp"]
+package-dir = {"" = "python"}
+
+[tool.setuptools.package-data]
+mscclpp = ["*.py", "*.pyi", "_version.py"]
 
 [tool.scikit-build]
 cmake.version = ">=3.25.0"

--- a/python/mscclpp/__init__.py
+++ b/python/mscclpp/__init__.py
@@ -11,6 +11,7 @@ from functools import wraps
 try:
     from ._version import (
         __version__,
+        __base_version__,
         __git_commit__,
         __git_branch__,
         __git_remote__,
@@ -19,7 +20,8 @@ try:
     )
 except ImportError:
     # Fallback if version file doesn't exist
-    __version__ = "unknown"
+    __version__ = "0.7.0"
+    __base_version__ = "0.7.0"
     __git_commit__ = "unknown"
     __git_branch__ = "unknown"
     __git_remote__ = "unknown"
@@ -28,6 +30,7 @@ except ImportError:
         """Fallback version info"""
         return {
             "version": __version__,
+            "base_version": __base_version__,
             "commit": __git_commit__,
             "branch": __git_branch__,
             "remote": __git_remote__
@@ -38,7 +41,11 @@ except ImportError:
         info = get_version_info()
         if verbose:
             print("MSCCL++ Version Information:")
-            print(f"  Package Version: {info['version']} (version tracking unavailable)")
+            print(f"  Package Version: {info['version']}")
+            print(f"  Base Version: {info['base_version']}")
+            print(f"  Git Commit: {info['commit']}")
+            print(f"  Git Branch: {info['branch']}")
+            print(f"  Git Remote: {info['remote']}")
         return info
 
 # Try to import the C++ extension

--- a/python/mscclpp/build_helper.py
+++ b/python/mscclpp/build_helper.py
@@ -1,0 +1,213 @@
+"""Build helper utilities for MSCCLPP package setup"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
+
+# Import version_helper carefully to avoid circular imports
+try:
+    from . import version_helper
+except ImportError:
+    # If relative import fails (e.g., when called from setup.py), try direct import
+    import version_helper
+
+
+class CustomBuildPy(build_py):
+    """Custom build_py command to generate version file before building"""
+    
+    def run(self):
+        """Run the build_py command with version file generation"""
+        # Generate version file before building
+        try:
+            # Get the python/mscclpp directory
+            if hasattr(self, 'build_lib'):
+                # During actual build, use build_lib path
+                mscclpp_build_dir = os.path.join(self.build_lib, 'mscclpp')
+                os.makedirs(mscclpp_build_dir, exist_ok=True)
+                version_file = os.path.join(mscclpp_build_dir, '_version.py')
+            else:
+                # Fallback to source directory
+                mscclpp_dir = os.path.dirname(os.path.abspath(__file__))
+                version_file = os.path.join(mscclpp_dir, '_version.py')
+            
+            # Also generate in source directory for development
+            src_version_file = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), '_version.py'
+            )
+            
+            version_helper.write_version_file(src_version_file)
+            print(f"Successfully generated version file at {src_version_file}")
+            
+            # Copy to build directory if different
+            if hasattr(self, 'build_lib') and version_file != src_version_file:
+                import shutil
+                shutil.copy2(src_version_file, version_file)
+                print(f"Copied version file to {version_file}")
+            
+        except Exception as e:
+            print(f"Warning: Failed to generate version file: {e}")
+            # Create a fallback version file
+            self._create_fallback_version_file()
+        
+        # Continue with normal build
+        super().run()
+    
+    def _create_fallback_version_file(self):
+        """Create a fallback version file if git info is not available"""
+        # Create in both source and build directories
+        for base_dir in [os.path.dirname(os.path.abspath(__file__)),
+                        getattr(self, 'build_lib', None)]:
+            if base_dir is None:
+                continue
+                
+            if hasattr(self, 'build_lib') and base_dir == self.build_lib:
+                version_file = os.path.join(base_dir, 'mscclpp', '_version.py')
+                os.makedirs(os.path.dirname(version_file), exist_ok=True)
+            else:
+                version_file = os.path.join(base_dir, '_version.py')
+            
+            with open(version_file, 'w') as f:
+                f.write('''# Auto-generated fallback version file
+__version__ = "0.1.0"
+__git_commit__ = "unknown"
+__git_branch__ = "unknown"
+__git_remote__ = "unknown"
+
+def get_version_info():
+    return {
+        "version": __version__,
+        "commit": __git_commit__,
+        "branch": __git_branch__,
+        "remote": __git_remote__
+    }
+
+def show_version(verbose=True):
+    info = get_version_info()
+    if verbose:
+        print("MSCCLPP Version Information:")
+        print(f"  Package Version: {info['version']}")
+        print(f"  Git Commit: {info['commit']} (build info unavailable)")
+    return info
+''')
+            print(f"Created fallback version file at {version_file}")
+
+
+class CMakeExtension(Extension):
+    """CMake-based extension"""
+    
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        """Initialize CMake extension
+        
+        Args:
+            name: Extension name
+            sourcedir: Source directory for CMake project
+        """
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    """CMake build extension command"""
+    
+    def build_extension(self, ext: CMakeExtension) -> None:
+        """Build a CMake extension
+        
+        Args:
+            ext: The CMakeExtension to build
+        """
+        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        # Determine build type
+        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
+        cfg = "Debug" if debug else "Release"
+
+        # Configure CMake arguments
+        cmake_args = [
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",
+        ]
+        
+        build_args = []
+
+        # Add any user-provided CMake arguments
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+
+        # Set parallel build level if not already set
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            if hasattr(self, "parallel") and self.parallel:
+                build_args += [f"-j{self.parallel}"]
+
+        # Create build directory
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        # Configure the project
+        print(f"Configuring CMake project with args: {cmake_args}")
+        subprocess.run(
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+        )
+        
+        # Build the project
+        print(f"Building CMake project with args: {build_args}")
+        subprocess.run(
+            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+        )
+
+
+def get_package_version():
+    """Get the package version from various sources
+    
+    Returns:
+        str: The package version
+    """
+    # Default version
+    version = "0.1.0"
+    
+    # Try to get version from environment variable
+    if "MSCCLPP_VERSION" in os.environ:
+        return os.environ["MSCCLPP_VERSION"]
+    
+    # Try to get version from VERSION file
+    try:
+        version_file = Path(__file__).parent.parent.parent / "VERSION"
+        if version_file.exists():
+            version = version_file.read_text().strip()
+    except:
+        pass
+    
+    return version
+
+
+def get_long_description():
+    """Get the long description from README
+    
+    Returns:
+        str: The long description
+    """
+    try:
+        readme_file = Path(__file__).parent.parent.parent / "README.md"
+        if readme_file.exists():
+            return readme_file.read_text()
+    except:
+        pass
+    
+    return "Microsoft Collective Communication Library++ (MSCCL++) Python bindings"
+
+
+# Export the build commands and utilities
+__all__ = [
+    'CustomBuildPy',
+    'CMakeExtension', 
+    'CMakeBuild',
+    'get_package_version',
+    'get_long_description'
+]

--- a/python/mscclpp/version_helper.py
+++ b/python/mscclpp/version_helper.py
@@ -1,0 +1,155 @@
+import subprocess
+import os
+import re
+
+def get_git_revision():
+    """Get the current git commit hash"""
+    try:
+        # Get the short commit hash - use the repository root
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        commit = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            cwd=repo_root,
+            stderr=subprocess.STDOUT
+        ).decode('utf-8').strip()
+        
+        # Check if there are uncommitted changes
+        try:
+            subprocess.check_output(
+                ['git', 'diff-index', '--quiet', 'HEAD'],
+                cwd=repo_root
+            )
+            dirty = False
+        except subprocess.CalledProcessError:
+            dirty = True
+            
+        if dirty:
+            commit += '-dirty'
+            
+        return commit
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 'unknown'
+
+def get_git_branch():
+    """Get the current git branch"""
+    try:
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        branch = subprocess.check_output(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            cwd=repo_root,
+            stderr=subprocess.STDOUT
+        ).decode('utf-8').strip()
+        return branch
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 'unknown'
+
+def get_git_remote_url():
+    """Get the git remote URL"""
+    try:
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        url = subprocess.check_output(
+            ['git', 'config', '--get', 'remote.origin.url'],
+            cwd=repo_root,
+            stderr=subprocess.STDOUT
+        ).decode('utf-8').strip()
+        # Remove any credentials from the URL for security
+        url = re.sub(r'://[^@]+@', '://', url)
+        return url
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 'unknown'
+
+def get_package_version():
+    """Extract version from setup.py or use default"""
+    version = "0.7.0"  # Updated default version
+    try:
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        setup_py = os.path.join(repo_root, 'setup.py')
+        with open(setup_py, 'r') as f:
+            content = f.read()
+            # Look for version in setup()
+            match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+            if match:
+                version = match.group(1)
+    except:
+        pass
+    return version
+
+def write_version_file(output_path=None):
+    """Write version information to a file
+    
+    Args:
+        output_path: Path where to write the version file. If None, uses default location.
+    
+    Returns:
+        dict: Version information dictionary
+    """
+    if output_path is None:
+        # Default to writing _version.py in the same directory as this module
+        output_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '_version.py')
+    
+    commit = get_git_revision()
+    branch = get_git_branch()
+    remote_url = get_git_remote_url()
+    version = get_package_version()
+    
+    version_content = f'''# Auto-generated version file - DO NOT EDIT
+# Generated at build time from git repository information
+
+__version__ = "{version}"
+__git_commit__ = "{commit}"
+__git_branch__ = "{branch}"
+__git_remote__ = "{remote_url}"
+
+def get_version_info():
+    """Get complete version information as a dictionary"""
+    return {{
+        "version": __version__,
+        "commit": __git_commit__,
+        "branch": __git_branch__,
+        "remote": __git_remote__
+    }}
+
+def show_version(verbose=True):
+    """Display version information
+    
+    Args:
+        verbose (bool): If True, print to stdout. Always returns the version dict.
+    
+    Returns:
+        dict: Version information dictionary
+    """
+    info = get_version_info()
+    if verbose:
+        print("MSCCLPP Version Information:")
+        print(f"  Package Version: {{info['version']}}")
+        print(f"  Git Commit: {{info['commit']}}")
+        print(f"  Git Branch: {{info['branch']}}")
+        print(f"  Git Remote: {{info['remote']}}")
+    return info
+'''
+    
+    # Create directory if it doesn't exist
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    
+    with open(output_path, 'w') as f:
+        f.write(version_content)
+    
+    print(f"Generated version file at {output_path}")
+    print(f"  Version: {version}")
+    print(f"  Commit: {commit}")
+    print(f"  Branch: {branch}")
+    print(f"  Git Remote: {remote_url}")
+    
+    return {
+        "version": version,
+        "commit": commit,
+        "branch": branch,
+        "remote": remote_url
+    }
+
+if __name__ == "__main__":
+    # For testing: generate version file
+    import sys
+    output = sys.argv[1] if len(sys.argv) > 1 else None
+    info = write_version_file(output)
+    print(f"\nVersion info: {info}")

--- a/python/mscclpp/version_helper.py
+++ b/python/mscclpp/version_helper.py
@@ -59,20 +59,32 @@ def get_git_remote_url():
         return 'unknown'
 
 def get_package_version():
-    """Extract version from setup.py or use default"""
-    version = "0.7.0"  # Updated default version
+    """Extract version from setup.py or use default, and append git commit"""
+    base_version = "0.7.0"  # Base version
     try:
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         setup_py = os.path.join(repo_root, 'setup.py')
         with open(setup_py, 'r') as f:
             content = f.read()
             # Look for version in setup()
-            match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+            match = re.search(r'VERSION\s*=\s*["\']([^"\']+)["\']', content)
             if match:
-                version = match.group(1)
+                base_version = match.group(1)
     except:
         pass
-    return version
+    
+    # Get git commit hash
+    commit = get_git_revision()
+    
+    # Create version string with commit
+    if commit != 'unknown':
+        # For development versions, append the commit hash
+        # Format: base_version+git.commit_hash
+        version = f"{base_version}+git.{commit}"
+    else:
+        version = base_version
+    
+    return version, base_version, commit
 
 def write_version_file(output_path=None):
     """Write version information to a file
@@ -87,15 +99,15 @@ def write_version_file(output_path=None):
         # Default to writing _version.py in the same directory as this module
         output_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '_version.py')
     
-    commit = get_git_revision()
+    version_with_commit, base_version, commit = get_package_version()
     branch = get_git_branch()
     remote_url = get_git_remote_url()
-    version = get_package_version()
     
     version_content = f'''# Auto-generated version file - DO NOT EDIT
 # Generated at build time from git repository information
 
-__version__ = "{version}"
+__version__ = "{version_with_commit}"
+__base_version__ = "{base_version}"
 __git_commit__ = "{commit}"
 __git_branch__ = "{branch}"
 __git_remote__ = "{remote_url}"
@@ -104,6 +116,7 @@ def get_version_info():
     """Get complete version information as a dictionary"""
     return {{
         "version": __version__,
+        "base_version": __base_version__,
         "commit": __git_commit__,
         "branch": __git_branch__,
         "remote": __git_remote__
@@ -122,6 +135,7 @@ def show_version(verbose=True):
     if verbose:
         print("MSCCLPP Version Information:")
         print(f"  Package Version: {{info['version']}}")
+        print(f"  Base Version: {{info['base_version']}}")
         print(f"  Git Commit: {{info['commit']}}")
         print(f"  Git Branch: {{info['branch']}}")
         print(f"  Git Remote: {{info['remote']}}")
@@ -135,13 +149,15 @@ def show_version(verbose=True):
         f.write(version_content)
     
     print(f"Generated version file at {output_path}")
-    print(f"  Version: {version}")
+    print(f"  Version: {version_with_commit}")
+    print(f"  Base Version: {base_version}")
     print(f"  Commit: {commit}")
     print(f"  Branch: {branch}")
     print(f"  Git Remote: {remote_url}")
     
     return {
-        "version": version,
+        "version": version_with_commit,
+        "base_version": base_version,
         "commit": commit,
         "branch": branch,
         "remote": remote_url

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,216 @@
+"""Setup script for MSCCLPP Python package"""
+
+import sys
+import os
+import subprocess
+from pathlib import Path
+from setuptools import find_packages, setup
+from setuptools.command.build_py import build_py
+from setuptools.command.egg_info import egg_info
+from setuptools.command.sdist import sdist
+
+# Add python/mscclpp to path to import version_helper
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'python', 'mscclpp'))
+
+try:
+    import version_helper
+except ImportError:
+    version_helper = None
+
+
+class GenerateVersionFile:
+    """Mixin to generate version file"""
+    
+    def generate_version_file(self):
+        """Generate the _version.py file with git information"""
+        if version_helper is None:
+            print("Warning: version_helper not available, creating fallback version file")
+            self.create_fallback_version_file()
+            return
+            
+        try:
+            # Determine where to write the version file
+            if hasattr(self, 'build_lib'):
+                # During build, write to build directory
+                version_file = os.path.join(self.build_lib, 'mscclpp', '_version.py')
+                os.makedirs(os.path.dirname(version_file), exist_ok=True)
+            else:
+                # During egg_info or sdist, write to source directory
+                version_file = os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    'python', 'mscclpp', '_version.py'
+                )
+                
+            print(f"Generating version file at {version_file}")
+            version_helper.write_version_file(version_file)
+            
+            # Also ensure it's in the source directory for development
+            src_version_file = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                'python', 'mscclpp', '_version.py'
+            )
+            if version_file != src_version_file:
+                import shutil
+                shutil.copy2(version_file, src_version_file)
+                print(f"Also copied to source at {src_version_file}")
+                
+        except Exception as e:
+            print(f"Warning: Failed to generate version file: {e}")
+            self.create_fallback_version_file()
+    
+    def create_fallback_version_file(self):
+        """Create a fallback version file if git info is not available"""
+        fallback_content = '''# Auto-generated fallback version file
+__version__ = "0.7.0"
+__git_commit__ = "unknown"
+__git_branch__ = "unknown"
+__git_remote__ = "unknown"
+
+def get_version_info():
+    return {
+        "version": __version__,
+        "commit": __git_commit__,
+        "branch": __git_branch__,
+        "remote": __git_remote__
+    }
+
+def show_version(verbose=True):
+    info = get_version_info()
+    if verbose:
+        print("MSCCLPP Version Information:")
+        print(f"  Package Version: {info['version']}")
+        print(f"  Git Commit: {info['commit']}")
+        print(f"  Git Branch: {info['branch']}")
+        print(f"  Git Remote: {info['remote']}")
+    return info
+'''
+        
+        # Write to both source and build directories if available
+        for base_dir in [
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), 'python', 'mscclpp'),
+            getattr(self, 'build_lib', None)
+        ]:
+            if base_dir is None:
+                continue
+                
+            if hasattr(self, 'build_lib') and base_dir == self.build_lib:
+                version_file = os.path.join(base_dir, 'mscclpp', '_version.py')
+                os.makedirs(os.path.dirname(version_file), exist_ok=True)
+            else:
+                version_file = os.path.join(base_dir, '_version.py')
+                
+            with open(version_file, 'w') as f:
+                f.write(fallback_content)
+            print(f"Created fallback version file at {version_file}")
+
+
+class CustomBuildPy(build_py, GenerateVersionFile):
+    """Custom build_py command to generate version file before building"""
+    
+    def run(self):
+        """Run the build_py command with version file generation"""
+        self.generate_version_file()
+        super().run()
+
+
+class CustomEggInfo(egg_info, GenerateVersionFile):
+    """Custom egg_info command to generate version file"""
+    
+    def run(self):
+        """Run the egg_info command with version file generation"""
+        self.generate_version_file()
+        super().run()
+
+
+class CustomSdist(sdist, GenerateVersionFile):
+    """Custom sdist command to include version file in source distribution"""
+    
+    def run(self):
+        """Run the sdist command with version file generation"""
+        self.generate_version_file()
+        super().run()
+
+
+# Get package metadata
+VERSION = "0.7.0"
+LONG_DESCRIPTION = """Microsoft Collective Communication Library++ (MSCCL++) Python bindings"""
+
+try:
+    readme_file = Path(__file__).parent / "README.md"
+    if readme_file.exists():
+        LONG_DESCRIPTION = readme_file.read_text()
+except:
+    pass
+
+# Package configuration
+setup(
+    name="mscclpp",
+    version=VERSION,
+    author="Microsoft",
+    author_email="",
+    description="MSCCLPP Python bindings with version tracking",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    url="https://github.com/microsoft/mscclpp",
+    
+    # Custom build commands
+    cmdclass={
+        "build_py": CustomBuildPy,
+        "egg_info": CustomEggInfo,
+        "sdist": CustomSdist,
+    },
+    
+    # Package configuration
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    
+    # Package data
+    package_data={
+        'mscclpp': ['*.py', '*.pyi', '_version.py'],
+    },
+    include_package_data=True,
+    
+    # Installation requirements
+    python_requires=">=3.8",
+    install_requires=[
+        # Add any runtime dependencies here
+    ],
+    
+    # Development dependencies (optional)
+    extras_require={
+        'dev': [
+            'pytest',
+            'black',
+            'flake8',
+        ],
+        'test': [
+            'pytest',
+            'numpy',
+        ],
+    },
+    
+    # Entry points for command-line scripts
+    entry_points={
+        'console_scripts': [
+            'mscclpp-version=mscclpp.__main__:main',
+        ],
+    },
+    
+    # Additional metadata
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: System :: Hardware :: Symmetric Multi-processing",
+        "Topic :: System :: Distributed Computing",
+        "Topic :: Scientific/Engineering",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: C++",
+    ],
+    
+    # Ensure package is not zipped
+    zip_safe=False,
+)


### PR DESCRIPTION
After installation, you can check the version information in several ways:

**From Python:**
```python
import mscclpp

# Show all version information
mscclpp.show_version()
# Output:
# MSCCLPP Version Information:
#   Package Version: 0.7.0+git.43f160c
#   Base Version: 0.7.0
#   Git Commit: 43f160c
#   Git Branch: main
#   Git Remote: https://github.com/microsoft/mscclpp.git

# Access individual attributes
print(f"Version: {mscclpp.__version__}")           # Full version with commit
Version: 0.7.0+git.70083f7
print(f"Base version: {mscclpp.__base_version__}") # Semantic version only
Base version: 0.7.0
print(f"Git commit: {mscclpp.__git_commit__}")     # Commit hash only
Git commit: 70083f7
print(f"Git branch: {mscclpp.__git_branch__}")
Git branch: qinghuazhou/pip_show_commit_version
print(f"Git remote: {mscclpp.__git_remote__}")
Git remote: https://github.com/microsoft/mscclpp.git

# Get as dictionary
info = mscclpp.get_version_info()
print(f"Full version: {info['version']}")
Full version: 0.7.0+git.70083f7
print(f"Base version: {info['base_version']}")
Base version: 0.7.0
```

#### Version Information Details

The version tracking captures:
- **Package Version** (`__version__`): Full version string including git commit (e.g., `0.7.0+git.43f160c`)
- **Base Version** (`__base_version__`): Semantic version without git information (e.g., `0.7.0`)
- **Git Commit** (`__git_commit__`): Short SHA hash with '-dirty' suffix if there were uncommitted changes at build time
- **Git Branch** (`__git_branch__`): The branch name at build time
- **Git Remote** (`__git_remote__`): Repository URL (credentials are automatically stripped for security)