### PR TITLE
Bypassing SSCA alerts

### DIFF
--- a/docker/base-dev-x.dockerfile
+++ b/docker/base-dev-x.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=base-cuda13.0-x86_64
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="MSCCL++"

--- a/docker/base-x-rocm.dockerfile
+++ b/docker/base-x-rocm.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=tmp-rocm6.2-x86_64
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="MSCCL++"

--- a/docker/base-x.dockerfile
+++ b/docker/base-x.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu24.04
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="MSCCL++"


### PR DESCRIPTION
Remove default image tags to bypass SSCA alerts