### PR TITLE
Add CI pipeline for no-IB environment testing

### DIFF
--- a/include/mscclpp/env.hpp
+++ b/include/mscclpp/env.hpp
@@ -110,10 +110,6 @@ class Env {
   /// Default is false.
   const bool forceDisableNvls;
 
-  /// Env name: `MSCCLPP_DISABLE_IB_TESTS`. If set to true, IB-related tests will be skipped.
-  /// Default is false.
-  const bool disableIbTests;
-
  private:
   Env();
 

--- a/python/csrc/env_py.cpp
+++ b/python/csrc/env_py.cpp
@@ -23,8 +23,7 @@ void register_env(nb::module_& m) {
       .def_ro("ibv_mode", &Env::ibvMode)
       .def_ro("cache_dir", &Env::cacheDir)
       .def_ro("npkit_dump_dir", &Env::npkitDumpDir)
-      .def_ro("cuda_ipc_use_default_stream", &Env::cudaIpcUseDefaultStream)
-      .def_ro("disable_ib_tests", &Env::disableIbTests);
+      .def_ro("cuda_ipc_use_default_stream", &Env::cudaIpcUseDefaultStream);
 
   m.def("env", &env);
 }

--- a/python/test/test_mscclpp.py
+++ b/python/test/test_mscclpp.py
@@ -162,7 +162,7 @@ def create_connection(group: CommGroup, connection_type: str):
 def create_group_and_connection(mpi_group: MpiGroup, connection_type: str):
     if (connection_type == "NVLink" or connection_type == "NVLS") and all_ranks_on_the_same_node(mpi_group) is False:
         pytest.skip("cannot use nvlink/nvls for cross node")
-    if connection_type == "IB" and env().disable_ib_tests:
+    if connection_type == "IB" and os.environ.get("MSCCLPP_DISABLE_IB_TESTS", "0") != "0":
         pytest.skip("IB tests are disabled via MSCCLPP_DISABLE_IB_TESTS=1")
     group = CommGroup(mpi_group.comm)
     connection = create_connection(group, connection_type)
@@ -278,7 +278,7 @@ def test_connection_write_and_signal(mpi_group: MpiGroup, connection_type: str, 
 
 @parametrize_mpi_groups(2, 4, 8, 16)
 def test_h2h_semaphores(mpi_group: MpiGroup):
-    if env().disable_ib_tests:
+    if os.environ.get("MSCCLPP_DISABLE_IB_TESTS", "0") != "0":
         pytest.skip("IB tests are disabled via MSCCLPP_DISABLE_IB_TESTS=1")
     group = CommGroup(mpi_group.comm)
     tran = group.my_ib_device(group.my_rank % 8)
@@ -300,7 +300,7 @@ def test_h2h_semaphores(mpi_group: MpiGroup):
 
 @parametrize_mpi_groups(2, 4, 8, 16)
 def test_h2h_semaphores_gil_release(mpi_group: MpiGroup):
-    if env().disable_ib_tests:
+    if os.environ.get("MSCCLPP_DISABLE_IB_TESTS", "0") != "0":
         pytest.skip("IB tests are disabled via MSCCLPP_DISABLE_IB_TESTS=1")
     group = CommGroup(mpi_group.comm)
     tran = group.my_ib_device(group.my_rank % 8)

--- a/src/core/env.cpp
+++ b/src/core/env.cpp
@@ -65,8 +65,7 @@ Env::Env()
       ncclSharedLibPath(readEnv<std::string>("MSCCLPP_NCCL_LIB_PATH", "")),
       forceNcclFallbackOperation(readEnv<std::string>("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", "")),
       ncclSymmetricMemory(readEnv<bool>("MSCCLPP_NCCL_SYMMETRIC_MEMORY", false)),
-      forceDisableNvls(readEnv<bool>("MSCCLPP_FORCE_DISABLE_NVLS", false)),
-      disableIbTests(readEnv<bool>("MSCCLPP_DISABLE_IB_TESTS", false)) {}
+      forceDisableNvls(readEnv<bool>("MSCCLPP_FORCE_DISABLE_NVLS", false)) {}
 
 std::shared_ptr<Env> env() {
   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
@@ -94,7 +93,6 @@ std::shared_ptr<Env> env() {
     logEnv("MSCCLPP_FORCE_NCCL_FALLBACK_OPERATION", globalEnv->forceNcclFallbackOperation);
     logEnv("MSCCLPP_NCCL_SYMMETRIC_MEMORY", globalEnv->ncclSymmetricMemory);
     logEnv("MSCCLPP_FORCE_DISABLE_NVLS", globalEnv->forceDisableNvls);
-    logEnv("MSCCLPP_DISABLE_IB_TESTS", globalEnv->disableIbTests);
   }
   return globalEnv;
 }


### PR DESCRIPTION
## Summary

Add CI pipeline support for testing in environments without InfiniBand (IB) hardware.

## Changes

### IB stubs for no-IB builds (`src/core/ib.cc`)
- Added stub implementations for `IbMr` and `IbQp` classes in the `#else // !defined(USE_IBVERBS)` block so the library links successfully when built with `-DMSCCLPP_USE_IB=OFF`.

### Environment variable to disable IB tests (`MSCCLPP_DISABLE_IB_TESTS`)
- Added `disableIbTests` field to the `Env` class (`include/mscclpp/env.hpp`, `src/core/env.cpp`), reading from `MSCCLPP_DISABLE_IB_TESTS` env var.
- Exposed as `disable_ib_tests` in Python bindings (`python/csrc/env_py.cpp`).
- Updated `python/test/test_mscclpp.py` to skip IB-dependent tests (`create_group_and_connection` with IB transport, `test_h2h_semaphores`, `test_h2h_semaphores_gil_release`) when `env().disable_ib_tests` is true.

### CI pipeline (`ut-no-ib-env.yaml`, `ut.yml`)
The no-IB environment pipeline runs two phases:

1. **No-IB build phase**: Build with `-DMSCCLPP_USE_IB=OFF`, deploy, run unit tests, multi-process unit tests, and pytests (with `MSCCLPP_DISABLE_IB_TESTS=1`).
2. **IB build phase**: Rebuild with IB enabled (default), stop the existing container, redeploy, and run pytests (with `MSCCLPP_DISABLE_IB_TESTS=1`) — verifying that the full IB-enabled build works correctly in a non-IB environment when IB tests are skipped.

Also increased the job timeout from 40 to 60 minutes to accommodate the two-phase pipeline.