### PR TITLE
Clean up completed communicator receives

### DIFF
--- a/src/core/communicator.cc
+++ b/src/core/communicator.cc
@@ -3,9 +3,60 @@
 
 #include "communicator.hpp"
 
+#include <utility>
+
 #include "api.h"
 
 namespace mscclpp {
+
+namespace {
+
+template <typename Fn>
+class ScopeGuard {
+ public:
+  explicit ScopeGuard(Fn fn) : fn_(std::move(fn)) {}
+  ScopeGuard(const ScopeGuard&) = delete;
+  ScopeGuard& operator=(const ScopeGuard&) = delete;
+  ~ScopeGuard() { fn_(); }
+
+ private:
+  Fn fn_;
+};
+
+template <typename Fn>
+ScopeGuard<Fn> makeScopeGuard(Fn fn) {
+  return ScopeGuard<Fn>(std::move(fn));
+}
+
+template <typename T, typename Impl, typename Fn>
+std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag, Fn fn) {
+  // Weak placeholder to avoid a reference cycle; updated with the real recvItem after the future is created.
+  auto thisRecvItem = std::make_shared<std::weak_ptr<BaseRecvItem>>();
+  auto future = std::async(std::launch::deferred,
+                           [impl, remoteRank, tag, thisRecvItem, lastRecvItem = impl->getLastRecvItem(remoteRank, tag),
+                            fn = std::move(fn)]() mutable {
+                             [[maybe_unused]] auto cleanup = makeScopeGuard([impl, remoteRank, tag, thisRecvItem]() {
+                               auto item = thisRecvItem->lock();
+                               auto it = impl->lastRecvItems_.find({remoteRank, tag});
+                               if (item && it != impl->lastRecvItems_.end() && it->second == item) {
+                                 impl->lastRecvItems_.erase(it);
+                               }
+                             });
+
+                             if (lastRecvItem) {
+                               // Recursive call to the previous receive items
+                               lastRecvItem->wait();
+                             }
+                             return fn();
+                           });
+  auto sharedFuture = std::shared_future<T>(std::move(future));
+  auto recvItem = std::make_shared<RecvItem<T>>(sharedFuture);
+  *thisRecvItem = recvItem;
+  impl->setLastRecvItem(remoteRank, tag, recvItem);
+  return sharedFuture;
+}
+
+}  // namespace
 
 Communicator::Impl::Impl(std::shared_ptr<Bootstrap> bootstrap, std::shared_ptr<Context> context)
     : bootstrap_(bootstrap) {
@@ -83,19 +134,11 @@ MSCCLPP_API_CPP std::shared_future<RegisteredMemory> Communicator::recvMemory(in
     locRecvMemList.push_back(std::move(locRecvMem));
     return future;
   }
-  auto future = std::async(std::launch::deferred,
-                           [this, remoteRank, tag, lastRecvItem = pimpl_->getLastRecvItem(remoteRank, tag)]() {
-                             if (lastRecvItem) {
-                               // Recursive call to the previous receive items
-                               lastRecvItem->wait();
-                             }
-                             std::vector<char> data;
-                             bootstrap()->recv(data, remoteRank, tag);
-                             return RegisteredMemory::deserialize(data);
-                           });
-  auto shared_future = std::shared_future<RegisteredMemory>(std::move(future));
-  pimpl_->setLastRecvItem(remoteRank, tag, std::make_shared<RecvItem<RegisteredMemory>>(shared_future));
-  return shared_future;
+  return makeOrderedRecvFuture<RegisteredMemory>(pimpl_.get(), remoteRank, tag, [this, remoteRank, tag]() {
+    std::vector<char> data;
+    bootstrap()->recv(data, remoteRank, tag);
+    return RegisteredMemory::deserialize(data);
+  });
 }
 
 MSCCLPP_API_CPP std::shared_future<Connection> Communicator::connect(const Endpoint& localEndpoint, int remoteRank,
@@ -112,22 +155,15 @@ MSCCLPP_API_CPP std::shared_future<Connection> Communicator::connect(const Endpo
 
   bootstrap()->send(localEndpoint.serialize(), remoteRank, tag);
 
-  auto future = std::async(std::launch::deferred, [this, remoteRank, tag, localEndpoint,
-                                                   lastRecvItem = pimpl_->getLastRecvItem(remoteRank, tag)]() mutable {
-    if (lastRecvItem) {
-      // Recursive call to the previous receive items
-      lastRecvItem->wait();
-    }
-    std::vector<char> data;
-    bootstrap()->recv(data, remoteRank, tag);
-    auto remoteEndpoint = Endpoint::deserialize(data);
-    auto connection = context()->connect(localEndpoint, remoteEndpoint);
-    pimpl_->connectionInfos_[connection.impl_.get()] = {remoteRank, tag};
-    return connection;
-  });
-  auto shared_future = std::shared_future<Connection>(std::move(future));
-  pimpl_->setLastRecvItem(remoteRank, tag, std::make_shared<RecvItem<Connection>>(shared_future));
-  return shared_future;
+  return makeOrderedRecvFuture<Connection>(pimpl_.get(), remoteRank, tag,
+                                           [this, remoteRank, tag, localEndpoint]() mutable {
+                                             std::vector<char> data;
+                                             bootstrap()->recv(data, remoteRank, tag);
+                                             auto remoteEndpoint = Endpoint::deserialize(data);
+                                             auto connection = context()->connect(localEndpoint, remoteEndpoint);
+                                             pimpl_->connectionInfos_[connection.impl_.get()] = {remoteRank, tag};
+                                             return connection;
+                                           });
 }
 
 MSCCLPP_API_CPP std::shared_future<Connection> Communicator::connect(const EndpointConfig& localConfig, int remoteRank,
@@ -141,21 +177,12 @@ MSCCLPP_API_CPP std::shared_future<Semaphore> Communicator::buildSemaphore(const
   SemaphoreStub localStub(connection);
   bootstrap()->send(localStub.serialize(), remoteRank, tag);
 
-  auto future =
-      std::async(std::launch::deferred, [this, remoteRank, tag, lastRecvItem = pimpl_->getLastRecvItem(remoteRank, tag),
-                                         localStub = localStub]() mutable {
-        if (lastRecvItem) {
-          // Recursive call to the previous receive items
-          lastRecvItem->wait();
-        }
-        std::vector<char> data;
-        bootstrap()->recv(data, remoteRank, tag);
-        auto remoteStub = SemaphoreStub::deserialize(data);
-        return Semaphore(localStub, remoteStub);
-      });
-  auto shared_future = std::shared_future<Semaphore>(std::move(future));
-  pimpl_->setLastRecvItem(remoteRank, tag, std::make_shared<RecvItem<Semaphore>>(shared_future));
-  return shared_future;
+  return makeOrderedRecvFuture<Semaphore>(pimpl_.get(), remoteRank, tag, [this, remoteRank, tag, localStub]() mutable {
+    std::vector<char> data;
+    bootstrap()->recv(data, remoteRank, tag);
+    auto remoteStub = SemaphoreStub::deserialize(data);
+    return Semaphore(localStub, remoteStub);
+  });
 }
 
 MSCCLPP_API_CPP int Communicator::remoteRankOf(const Connection& connection) {

--- a/src/core/communicator.cc
+++ b/src/core/communicator.cc
@@ -17,38 +17,34 @@ class ScopeGuard {
   explicit ScopeGuard(Func func) : func_(std::move(func)) {}
   ScopeGuard(const ScopeGuard&) = delete;
   ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ~ScopeGuard() { func_(); }
+  ScopeGuard(ScopeGuard&&) = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
+  ~ScopeGuard() noexcept {
+    static_assert(noexcept(std::declval<Func&>()()), "ScopeGuard cleanup must be noexcept");
+    func_();
+  }
 
  private:
   Func func_;
 };
 
-template <typename Func>
-ScopeGuard<Func> makeScopeGuard(Func func) {
-  return ScopeGuard<Func>(std::move(func));
-}
-
 template <typename T, typename Impl, typename Func>
 std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag, Func func) {
   // Weak placeholder to avoid a reference cycle; updated with the real recvItem after the future is created.
   auto thisRecvItem = std::make_shared<std::weak_ptr<BaseRecvItem>>();
-  auto future = std::async(std::launch::deferred,
-                           [impl, remoteRank, tag, thisRecvItem, lastRecvItem = impl->getLastRecvItem(remoteRank, tag),
-                            func = std::move(func)]() mutable {
-                             [[maybe_unused]] auto cleanup = makeScopeGuard([impl, remoteRank, tag, thisRecvItem]() {
-                               auto item = thisRecvItem->lock();
-                               auto it = impl->lastRecvItems_.find({remoteRank, tag});
-                               if (item && it != impl->lastRecvItems_.end() && it->second == item) {
-                                 impl->lastRecvItems_.erase(it);
-                               }
-                             });
+  auto future = std::async(
+      std::launch::deferred, [impl, remoteRank, tag, thisRecvItem,
+                              lastRecvItem = impl->getLastRecvItem(remoteRank, tag), func = std::move(func)]() mutable {
+        [[maybe_unused]] ScopeGuard cleanup([impl, remoteRank, tag, thisRecvItem]() noexcept {
+          impl->clearLastRecvItemIfMatches(remoteRank, tag, thisRecvItem->lock());
+        });
 
-                             if (lastRecvItem) {
-                               // Recursive call to the previous receive items
-                               lastRecvItem->wait();
-                             }
-                             return func();
-                           });
+        if (lastRecvItem) {
+          // Recursive call to the previous receive items
+          lastRecvItem->wait();
+        }
+        return func();
+      });
   auto sharedFuture = std::shared_future<T>(std::move(future));
   auto recvItem = std::make_shared<RecvItem<T>>(sharedFuture);
   *thisRecvItem = recvItem;
@@ -81,6 +77,14 @@ std::shared_ptr<BaseRecvItem> Communicator::Impl::getLastRecvItem(int remoteRank
     return nullptr;
   }
   return it->second;
+}
+
+void Communicator::Impl::clearLastRecvItemIfMatches(int remoteRank, int tag,
+                                                    const std::shared_ptr<BaseRecvItem>& expectedItem) {
+  auto it = lastRecvItems_.find({remoteRank, tag});
+  if (it != lastRecvItems_.end() && it->second == expectedItem) {
+    lastRecvItems_.erase(it);
+  }
 }
 
 MSCCLPP_API_CPP Communicator::~Communicator() = default;

--- a/src/core/communicator.cc
+++ b/src/core/communicator.cc
@@ -3,8 +3,6 @@
 
 #include "communicator.hpp"
 
-#include <utility>
-
 #include "api.h"
 
 namespace mscclpp {

--- a/src/core/communicator.cc
+++ b/src/core/communicator.cc
@@ -11,40 +11,25 @@ namespace mscclpp {
 
 namespace {
 
-template <typename Func>
-class ScopeGuard {
- public:
-  explicit ScopeGuard(Func func) : func_(std::move(func)) {}
-  ScopeGuard(const ScopeGuard&) = delete;
-  ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ScopeGuard(ScopeGuard&&) = delete;
-  ScopeGuard& operator=(ScopeGuard&&) = delete;
-  ~ScopeGuard() noexcept {
-    static_assert(noexcept(std::declval<Func&>()()), "ScopeGuard cleanup must be noexcept");
-    func_();
-  }
-
- private:
-  Func func_;
-};
-
 template <typename T, typename Impl, typename Func>
 std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag, Func func) {
   // Weak placeholder to avoid a reference cycle; updated with the real recvItem after the future is created.
   auto thisRecvItem = std::make_shared<std::weak_ptr<BaseRecvItem>>();
-  auto future = std::async(
-      std::launch::deferred, [impl, remoteRank, tag, thisRecvItem,
-                              lastRecvItem = impl->getLastRecvItem(remoteRank, tag), func = std::move(func)]() mutable {
-        [[maybe_unused]] ScopeGuard cleanup([impl, remoteRank, tag, thisRecvItem]() noexcept {
-          impl->clearLastRecvItemIfMatches(remoteRank, tag, thisRecvItem->lock());
-        });
+  auto future = std::async(std::launch::deferred,
+                           [impl, remoteRank, tag, thisRecvItem, lastRecvItem = impl->getLastRecvItem(remoteRank, tag),
+                            func = std::move(func)]() mutable {
+                             auto cleanup = [impl, remoteRank, tag, thisRecvItem]() {
+                               impl->clearLastRecvItemIfMatches(remoteRank, tag, thisRecvItem->lock());
+                             };
 
-        if (lastRecvItem) {
-          // Recursive call to the previous receive items
-          lastRecvItem->wait();
-        }
-        return func();
-      });
+                             if (lastRecvItem) {
+                               // Recursive call to the previous receive items
+                               lastRecvItem->wait();
+                             }
+                             auto result = func();
+                             cleanup();
+                             return result;
+                           });
   auto sharedFuture = std::shared_future<T>(std::move(future));
   auto recvItem = std::make_shared<RecvItem<T>>(sharedFuture);
   *thisRecvItem = recvItem;

--- a/src/core/communicator.cc
+++ b/src/core/communicator.cc
@@ -11,30 +11,30 @@ namespace mscclpp {
 
 namespace {
 
-template <typename Fn>
+template <typename Func>
 class ScopeGuard {
  public:
-  explicit ScopeGuard(Fn fn) : fn_(std::move(fn)) {}
+  explicit ScopeGuard(Func func) : func_(std::move(func)) {}
   ScopeGuard(const ScopeGuard&) = delete;
   ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ~ScopeGuard() { fn_(); }
+  ~ScopeGuard() { func_(); }
 
  private:
-  Fn fn_;
+  Func func_;
 };
 
-template <typename Fn>
-ScopeGuard<Fn> makeScopeGuard(Fn fn) {
-  return ScopeGuard<Fn>(std::move(fn));
+template <typename Func>
+ScopeGuard<Func> makeScopeGuard(Func func) {
+  return ScopeGuard<Func>(std::move(func));
 }
 
-template <typename T, typename Impl, typename Fn>
-std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag, Fn fn) {
+template <typename T, typename Impl, typename Func>
+std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag, Func func) {
   // Weak placeholder to avoid a reference cycle; updated with the real recvItem after the future is created.
   auto thisRecvItem = std::make_shared<std::weak_ptr<BaseRecvItem>>();
   auto future = std::async(std::launch::deferred,
                            [impl, remoteRank, tag, thisRecvItem, lastRecvItem = impl->getLastRecvItem(remoteRank, tag),
-                            fn = std::move(fn)]() mutable {
+                            func = std::move(func)]() mutable {
                              [[maybe_unused]] auto cleanup = makeScopeGuard([impl, remoteRank, tag, thisRecvItem]() {
                                auto item = thisRecvItem->lock();
                                auto it = impl->lastRecvItems_.find({remoteRank, tag});
@@ -47,7 +47,7 @@ std::shared_future<T> makeOrderedRecvFuture(Impl* impl, int remoteRank, int tag,
                                // Recursive call to the previous receive items
                                lastRecvItem->wait();
                              }
-                             return fn();
+                             return func();
                            });
   auto sharedFuture = std::shared_future<T>(std::move(future));
   auto recvItem = std::make_shared<RecvItem<T>>(sharedFuture);

--- a/src/core/include/communicator.hpp
+++ b/src/core/include/communicator.hpp
@@ -62,7 +62,7 @@ struct Communicator::Impl {
   std::unordered_map<const BaseConnection*, ConnectionInfo> connectionInfos_;
 
   // Temporary storage for the latest RecvItem of each {remoteRank, tag} pair.
-  // If the RecvItem gets ready, it will be removed at the next call to getLastRecvItem.
+  // The RecvItem is removed when it finishes or when getLastRecvItem observes that it is ready.
   std::unordered_map<std::pair<int, int>, std::shared_ptr<BaseRecvItem>, PairHash> lastRecvItems_;
 
   // RegisteredMemory items sent to the local rank of each tag. Sending memory to the local rank is
@@ -78,6 +78,9 @@ struct Communicator::Impl {
   // Return the last RecvItem that is not ready.
   // If the item is ready, it will be removed from the map and nullptr will be returned.
   std::shared_ptr<BaseRecvItem> getLastRecvItem(int remoteRank, int tag);
+
+  // Clear the last RecvItem only if it still matches the expected item.
+  void clearLastRecvItemIfMatches(int remoteRank, int tag, const std::shared_ptr<BaseRecvItem>& expectedItem);
 
   struct Connector;
 };


### PR DESCRIPTION
## Summary
- Release the reference after last requests are ready.
- Keep ordered receive chaining for repeated rank/tag operations while cleaning up completed receive bookkeeping.

