### PR TITLE
Fix AllReduce3 auto-tune launch parameters

### DIFF
--- a/python/mscclpp_benchmark/mscclpp_op.py
+++ b/python/mscclpp_benchmark/mscclpp_op.py
@@ -208,7 +208,7 @@ class MscclppAllReduce3:
         self.set_params(nblocks, block_size)
 
     def __call__(self, stream):
-        self.kernel.launch_kernel(self.params, 24, 1024, 0, stream)
+        self.kernel.launch_kernel(self.params, self.nblocks, self.block_size, 0, stream)
         return self.memory
 
     def set_params(self, nblocks, block_size):


### PR DESCRIPTION
## Summary

This PR fixes the launch parameters used by the AllReduce3 auto-tune path.

Previously, the kernel launch used hardcoded values:

```python
self.kernel.launch_kernel(self.params, 24, 1024, 0, stream)
```

This prevented the auto-tuned `nblocks` and `block_size` values from actually being applied during execution. The launch now uses the configured parameters:

```python
self.kernel.launch_kernel(self.params, self.nblocks, self.block_size, 0, stream)
```

## Changes

* Replace hardcoded kernel launch parameters with `self.nblocks` and `self.block_size`.
* Ensure AllReduce3 uses the parameters selected by auto-tuning.
* Make launch behavior consistent with the configurable tuning interface.

## Motivation

The auto-tune logic should be able to control the kernel launch configuration. Using fixed values makes tuning ineffective and may lead to suboptimal performance across different message sizes, GPU counts, or hardware environments.

## Testing

* Verified that the kernel launch now uses the tuned `nblocks` and `block_size` values.
* Confirmed that the updated launch path can still be automatically merged.
