### PR TITLE
Increase `DefaultMaxCqPollNum` from 1 to 256

### DIFF
--- a/include/mscclpp/core.hpp
+++ b/include/mscclpp/core.hpp
@@ -398,7 +398,7 @@ struct EndpointConfig {
     static constexpr int DefaultPort = -1;
     static constexpr int DefaultGidIndex = -1;
     static constexpr int DefaultMaxCqSize = 1024;
-    static constexpr int DefaultMaxCqPollNum = 1;
+    static constexpr int DefaultMaxCqPollNum = 256;
     static constexpr int DefaultMaxSendWr = 8192;
     static constexpr int DefaultMaxRecvWr = 16;
     static constexpr int DefaultMaxWrPerSend = 64;


### PR DESCRIPTION
Batch send-CQ polling drains more completions per `ibv_poll_cq` call, reducing poll overhead under multi-QP IB load.