### PR TITLE
Add LL MXFP8 scale-32 dispatch

### DIFF
--- a/python/mscclpp/ep/README.md
+++ b/python/mscclpp/ep/README.md
@@ -259,7 +259,6 @@ can leave those fields as `None`.
 class QuantConfig:
     format: Optional[DispatchDataType] = None
     block_scales: Optional[torch.Tensor] = None
-    global_scale: Optional[torch.Tensor] = None
 
 
 class DispatchLayout(str, Enum):
@@ -485,12 +484,12 @@ and scale layout.
 
 Examples:
 
-| Format | `input` | `quant.block_scales` | `quant.global_scale` |
-|---|---|---|---|
-| BF16/FP16 | `[T, H]` | `None` | `None` |
-| FP8 E4M3 | `[T, H]` FP8 | `[T, H / 128]` | usually `None` |
-| NVFP4 | backend-defined packed/logical `[T, H]` | block scale tensor | optional global scale |
-| MXFP8 | backend-defined `[T, H]` | micro-scale tensor, e.g. E8M0 blocks | optional/global if required |
+| Format | `input` | `quant.block_scales` |
+|---|---|---|
+| BF16/FP16 | `[T, H]` | `None` |
+| FP8 E4M3 | `[T, H]` FP8 | `[T, H / 128]` |
+| NVFP4 | backend-defined packed/logical `[T, H]` | block scale tensor |
+| MXFP8 E4M3 | `[T, H]` FP8 | `[T, H / 32]` float scales |
 
 The API should not assume quantization scale is a scalar. For FP8 paths in
 DeepEP/SGLang, scales are usually per token and per hidden block.
@@ -573,13 +572,13 @@ LL can also return `DispatchLayout.TOKEN_MAJOR`:
 
 ```python
 dispatch_out.tokens            # [world_size * max_tokens_per_rank, H]
-dispatch_out.topk_ids          # [world_size * max_tokens_per_rank, K], int32 local expert IDs
+dispatch_out.topk_ids          # [world_size * max_tokens_per_rank, K], int32 global expert IDs
 dispatch_out.weights           # [world_size * max_tokens_per_rank, K], float32
 ```
 
 Only the prefix ending at `dispatch_out.layout.offsets[-1]` contains valid
-tokens. Non-local entries always use expert ID `-1` and weight `0`; padding uses
-expert ID `num_experts` and weight `0` when
+tokens. Non-local entries use expert ID `num_experts` and weight `0`; padding
+uses the same sentinel when
 `token_major_init_padding=True`. Per-source-rank counts are returned in
 `dispatch_out.layout.num_tokens_per_rank`.
 For expert-major output, only the first
@@ -603,11 +602,13 @@ Examples:
 
 ```text
 token-major tokens:   HT [total_recv_tokens, H]; LL [world_size * max_tokens_per_rank, H]
-token-major scales:   LL [world_size * max_tokens_per_rank, H / 128]
+token-major scales:   LL [world_size * max_tokens_per_rank, S]
 
 expert-major tokens:  [num_local_experts, max_slots, H]
-expert-major scales:  [num_local_experts, max_slots, H / 128]
+expert-major scales:  [num_local_experts, max_slots, S]
 ```
+
+`S` is `H / 128` for `FP8_E4M3` and `H / 32` for `MXFP8_E4M3`.
 
 ## MLP contract
 
@@ -689,6 +690,9 @@ dispatch_out, handle = moe_comm.dispatch(
 expert_output = mlp(dispatch_out.tokens, dispatch_out.layout)
 output = moe_comm.combine(expert_output, handle)
 ```
+
+Use `DispatchDataType.MXFP8_E4M3` for the same E4M3 payload with one float
+scale per 32 hidden elements.
 
 For overlap, expose two optional APIs rather than adding many flags to the
 default path:

--- a/python/mscclpp/ep/low_latency.py
+++ b/python/mscclpp/ep/low_latency.py
@@ -33,13 +33,19 @@ def _resolve_dispatch_data_type(quant: Optional[QuantConfig]) -> DispatchDataTyp
         raise TypeError("quant.format must be a DispatchDataType")
     if quant_format is None:
         raise ValueError("quant.format is required")
-    if quant_format == DispatchDataType.MXFP8_E4M3:
-        raise NotImplementedError("MXFP8 dispatch is reserved but not implemented")
-    if quant_format != DispatchDataType.FP8_E4M3:
+    if quant_format not in (DispatchDataType.FP8_E4M3, DispatchDataType.MXFP8_E4M3):
         raise ValueError("unsupported low-latency quantization format")
-    if quant.block_scales is not None or quant.global_scale is not None:
+    if quant.block_scales is not None:
         raise ValueError("communicator quant config must not contain precomputed scales")
-    return DispatchDataType.FP8_E4M3
+    return quant_format
+
+
+def _dispatch_scale_block_size(data_type: DispatchDataType) -> int:
+    if data_type == DispatchDataType.FP8_E4M3:
+        return 128
+    if data_type == DispatchDataType.MXFP8_E4M3:
+        return 32
+    return 0
 
 
 class LowLatencyRuntime:
@@ -309,8 +315,9 @@ class LowLatencyBackend:
                     (self.num_local_experts, self.world_size), dtype=torch.int64, device=device
                 )
                 self._dispatch_count = torch.empty((self.num_local_experts,), dtype=torch.int32, device=device)
-                if self.dispatch_data_type == DispatchDataType.FP8_E4M3:
-                    num_scales = self.hidden_size // 128
+                scale_block_size = _dispatch_scale_block_size(self.dispatch_data_type)
+                if scale_block_size:
+                    num_scales = self.hidden_size // scale_block_size
                     scale_storage = torch.empty(
                         (self.num_local_experts, num_scales, slots_per_expert), dtype=torch.float32, device=device
                     )
@@ -322,9 +329,10 @@ class LowLatencyBackend:
                 self._dispatch_weights = torch.empty((token_capacity, self.topk), dtype=torch.float32, device=device)
                 self._dispatch_layout_range = torch.empty((self.world_size + 1,), dtype=torch.int64, device=device)
                 self._dispatch_count = torch.empty((self.world_size,), dtype=torch.int32, device=device)
-                if self.dispatch_data_type == DispatchDataType.FP8_E4M3:
+                scale_block_size = _dispatch_scale_block_size(self.dispatch_data_type)
+                if scale_block_size:
                     self._dispatch_scales = torch.empty(
-                        (token_capacity, self.hidden_size // 128), dtype=torch.float32, device=device
+                        (token_capacity, self.hidden_size // scale_block_size), dtype=torch.float32, device=device
                     )
             else:
                 raise ValueError(f"unsupported low-latency output layout: {self.output_layout}")
@@ -377,7 +385,7 @@ class LowLatencyBackend:
             raise ValueError(f"unsupported low-latency output layout: {self.output_layout}")
         if output_buffer.dim() != len(expected_shape) or not output_buffer.is_contiguous():
             raise ValueError(f"output_buffer must be a contiguous {self.output_layout} tensor")
-        expected_dtype = torch.float8_e4m3fn if self.dispatch_data_type == DispatchDataType.FP8_E4M3 else torch.bfloat16
+        expected_dtype = torch.bfloat16 if self.dispatch_data_type == DispatchDataType.BF16 else torch.float8_e4m3fn
         if output_buffer.device != input.device or output_buffer.dtype != expected_dtype:
             raise ValueError(f"output_buffer must be a {expected_dtype} CUDA tensor on the same device as input")
         if tuple(output_buffer.shape) != expected_shape:

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -20,12 +20,12 @@ class QuantConfig:
     """Quantization metadata associated with an activation tensor.
 
     Low-latency FP8 dispatch returns ``block_scales`` with the activation's
-    leading dimensions and a format-defined final scale dimension.
+    leading dimensions and a format-defined final scale dimension (128-element
+    blocks for ``FP8_E4M3`` and 32-element blocks for ``MXFP8_E4M3``).
     """
 
     format: Optional[DispatchDataType] = None
     block_scales: Optional[torch.Tensor] = None
-    global_scale: Optional[torch.Tensor] = None
 
 
 # Communicator construction.

--- a/src/ext/ep/README.md
+++ b/src/ext/ep/README.md
@@ -33,14 +33,17 @@ and the required fabric services are available.
 LL dispatch supports two user-visible layouts:
 
 - `EXPERT_MAJOR`: one row per `(token, local expert)`.
-- `TOKEN_MAJOR`: one row per `(token, destination rank)`, plus local top-k expert
+- `TOKEN_MAJOR`: one row per `(token, destination rank)`, plus global top-k expert
   IDs, routing weights, source-token IDs, per-source-rank counts, and exclusive
   offsets. Valid rows occupy a compact prefix of the caller-provided capacity
-  buffer. With `token_major_init_padding=True`, padding rows have top-k IDs
-  equal to `num_experts`, allowing fixed-capacity Triton kernels to skip them
-  without a CPU count
-  synchronization. The option is disabled by default. The caller must produce
-  one pre-weighted local partial per valid row before combine.
+  buffer. Entries not owned by the destination rank use expert ID `num_experts`
+  and weight `0`. With `token_major_init_padding=True`, padding rows use the
+  same sentinel, allowing fixed-capacity Triton kernels to skip them without a
+  CPU count synchronization. The option is disabled by default. The caller must
+  produce one pre-weighted local partial per valid row before combine.
+
+LL quantized dispatch supports E4M3 payloads with float scales per 128 hidden
+elements (`FP8_E4M3`) or per 32 hidden elements (`MXFP8_E4M3`).
 
 ### High throughput
 

--- a/src/ext/ep/config.hpp
+++ b/src/ext/ep/config.hpp
@@ -143,11 +143,11 @@ struct Layout {
   Layout(void* symmetricBuffer, int maxTokensPerRank, int hidden, int numRanks, int numExperts, int numTopk) {
     const PayloadView<Bf16> bf16Payload(hidden, numTopk);
     const PayloadView<Fp8E4M3, float> fp8Payload128(hidden, numTopk, 128);
-    const PayloadView<Fp8E4M3, float> fp8Payload64(hidden, numTopk, 64);
+    const PayloadView<Fp8E4M3, float> fp8Payload32(hidden, numTopk, 32);
     const size_t dispatchMetadataBytes =
         configAlign<size_t>(static_cast<size_t>(numRanks + numExperts) * sizeof(uint64_t), 128);
     const size_t dispatchPayloadStride =
-        configAlign<size_t>(std::max({bf16Payload.numBytes_, fp8Payload128.numBytes_, fp8Payload64.numBytes_}), 128);
+        configAlign<size_t>(std::max({bf16Payload.numBytes_, fp8Payload128.numBytes_, fp8Payload32.numBytes_}), 128);
     const size_t dispatchBufferBytes =
         dispatchMetadataBytes + static_cast<size_t>(numRanks) * maxTokensPerRank * dispatchPayloadStride;
     const size_t combineBufferBytes = static_cast<size_t>(numExperts) * maxTokensPerRank * hidden * sizeof(Bf16);

--- a/src/ext/ep/include/api.cuh
+++ b/src/ext/ep/include/api.cuh
@@ -95,7 +95,7 @@ enum class DispatchDataType {
   BF16,
   /// FP8 E4M3 payload with one floating-point scale per 128 hidden elements.
   FP8_E4M3,
-  /// Reserved for MXFP8 E4M3 payloads with micro-scales.
+  /// FP8 E4M3 payload with one floating-point scale per 32 hidden elements.
   MXFP8_E4M3
 };
 
@@ -150,7 +150,8 @@ size_t workspaceSize(int numRanks, int numExperts);
 /// Workload::outputLayout_.
 /// @param[out] outputScales Layout-matched FP8 block scales, or nullptr for BF16 dispatch.
 /// @param[out] outputSrcInfo Original source-token index for every output row.
-/// @param[out] outputTopkIdx Token-major local expert indices [num_ranks * max_tokens_per_rank, num_topk], or nullptr.
+/// @param[out] outputTopkIdx Token-major global expert indices [num_ranks * max_tokens_per_rank, num_topk], or nullptr.
+/// Non-local and padding entries use numExperts as the sentinel.
 /// @param[out] outputTopkWeights Token-major routing weights
 /// [num_ranks * max_tokens_per_rank, num_topk], or nullptr.
 /// @param[out] outputLayout Per-[local expert, source rank] packed count and offset for expert-major output, or

--- a/src/ext/ep/low_latency/combine.cu
+++ b/src/ext/ep/low_latency/combine.cu
@@ -511,7 +511,10 @@ inline void combineHidden(void* output, const void* expertOutput, const int64_t*
                                                               layoutRange, workload, recvBuffer, dispatchRecvBuffer,
                                                               comm, workspace, numBlocks, stream);
       case DispatchDataType::MXFP8_E4M3:
-        EP_HOST_ASSERT(false && "MXFP8 dispatch metadata is not implemented");
+        return combineHiddenMode<low_latency::CombineMode::RANK_LOCAL_REDUCE, Hidden, DispatchDataType::MXFP8_E4M3, 32,
+                                 DispatchLayout::TOKEN_MAJOR>(output, expertOutput, topkIndices, topkWeights, srcInfo,
+                                                              layoutRange, workload, recvBuffer, dispatchRecvBuffer,
+                                                              comm, workspace, numBlocks, stream);
     }
   } else if (mode == low_latency::CombineMode::RANK_LOCAL_REDUCE) {
     switch (workload.dispatchDataType_) {
@@ -526,7 +529,10 @@ inline void combineHidden(void* output, const void* expertOutput, const int64_t*
                                                                layoutRange, workload, recvBuffer, dispatchRecvBuffer,
                                                                comm, workspace, numBlocks, stream);
       case DispatchDataType::MXFP8_E4M3:
-        EP_HOST_ASSERT(false && "MXFP8 dispatch metadata is not implemented");
+        return combineHiddenMode<low_latency::CombineMode::RANK_LOCAL_REDUCE, Hidden, DispatchDataType::MXFP8_E4M3, 32,
+                                 DispatchLayout::EXPERT_MAJOR>(output, expertOutput, topkIndices, topkWeights, srcInfo,
+                                                               layoutRange, workload, recvBuffer, dispatchRecvBuffer,
+                                                               comm, workspace, numBlocks, stream);
     }
   }
   switch (workload.dispatchDataType_) {
@@ -541,7 +547,10 @@ inline void combineHidden(void* output, const void* expertOutput, const int64_t*
                                                              layoutRange, workload, recvBuffer, dispatchRecvBuffer,
                                                              comm, workspace, numBlocks, stream);
     case DispatchDataType::MXFP8_E4M3:
-      EP_HOST_ASSERT(false && "MXFP8 dispatch metadata is not implemented");
+      return combineHiddenMode<low_latency::CombineMode::DIRECT_SEND, Hidden, DispatchDataType::MXFP8_E4M3, 32,
+                               DispatchLayout::EXPERT_MAJOR>(output, expertOutput, topkIndices, topkWeights, srcInfo,
+                                                             layoutRange, workload, recvBuffer, dispatchRecvBuffer,
+                                                             comm, workspace, numBlocks, stream);
   }
   EP_HOST_ASSERT(false && "unsupported dispatch data type");
 }

--- a/src/ext/ep/low_latency/config.cuh
+++ b/src/ext/ep/low_latency/config.cuh
@@ -72,6 +72,12 @@ struct DispatchDataTypeTraits<DispatchDataType::FP8_E4M3> {
   using ScaleType = float;
 };
 
+template <>
+struct DispatchDataTypeTraits<DispatchDataType::MXFP8_E4M3> {
+  using ElementType = Fp8E4M3;
+  using ScaleType = float;
+};
+
 template <DispatchDataType DataType>
 using DispatchElementType = typename DispatchDataTypeTraits<DataType>::ElementType;
 
@@ -82,7 +88,8 @@ template <DispatchDataType DataType>
 using DispatchPayloadView = PayloadView<DispatchElementType<DataType>, DispatchScaleType<DataType>>;
 
 MSCCLPP_HOST_DEVICE_INLINE constexpr bool isSupportedDispatchDataType(DispatchDataType dataType) {
-  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP8_E4M3;
+  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP8_E4M3 ||
+         dataType == DispatchDataType::MXFP8_E4M3;
 }
 
 template <DispatchDataType DataType>

--- a/src/ext/ep/low_latency/dispatch.cu
+++ b/src/ext/ep/low_latency/dispatch.cu
@@ -116,12 +116,13 @@ MSCCLPP_DEVICE_INLINE void dispatchSendBf16(const void* inputTokens, int nExpert
   }
 }
 
-template <int Hidden, int ScaleBlockSize>
+template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
 MSCCLPP_DEVICE_INLINE void dispatchSendFp8(const void* inputTokens, int nExperts, int rank, int nRanks,
                                            const int64_t* __restrict__ topkIndices,
                                            const float* __restrict__ topkWeights, int nTokens, int nTopk,
                                            int maxTokensPerRank, void* recvBuffer, const TransportView& transport,
                                            void* workspace, int* sharedMem) {
+  static_assert(DataType == DispatchDataType::FP8_E4M3 || DataType == DispatchDataType::MXFP8_E4M3);
   const int nWorkerBlocks = static_cast<int>(gridDim.x) - DispatchControlBlocks;
   if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nWorkerBlocks) return;
 
@@ -139,8 +140,8 @@ MSCCLPP_DEVICE_INLINE void dispatchSendFp8(const void* inputTokens, int nExperts
   constexpr int HiddenVectors = Hidden / mscclpp::bf16x8::Size;
   const int nLocalExperts = nExperts / nRanks;
   const size_t metadataBytes = dispatchMetadataBytes(nRanks, nExperts);
-  const DispatchPayloadView<DispatchDataType::FP8_E4M3> payloadView(Hidden, nTopk, ScaleBlockSize);
-  const size_t payloadStride = dispatchPayloadStride<DispatchDataType::FP8_E4M3>(Hidden, nTopk, ScaleBlockSize);
+  const DispatchPayloadView<DataType> payloadView(Hidden, nTopk, ScaleBlockSize);
+  const size_t payloadStride = dispatchPayloadStride<DataType>(Hidden, nTopk, ScaleBlockSize);
   auto* sharedPayloadBase = reinterpret_cast<uint8_t*>(sharedMem) + dispatchSharedControlBytes(nRanks);
   auto* stagedPayload = sharedPayloadBase + static_cast<size_t>(warpGroupId) * payloadStride;
   auto* destinationSlots = sharedMem + warpGroupId * WARP_SIZE;
@@ -154,9 +155,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSendFp8(const void* inputTokens, int nExperts
     const auto* inputData =
         reinterpret_cast<const mscclpp::bf16x8*>(inputTokens) + static_cast<size_t>(tokenIdx) * HiddenVectors;
     if (subWarpId == 0) {
-      stageDispatchPayloadMetadata<DispatchDataType::FP8_E4M3>(payloadView, stagedPayload, destinationSlots,
-                                                               workspaceView, topkIndices, topkWeights, tokenIdx, nTopk,
-                                                               nLocalExperts, maxTokensPerRank, rank, laneId);
+      stageDispatchPayloadMetadata<DataType>(payloadView, stagedPayload, destinationSlots, workspaceView, topkIndices,
+                                             topkWeights, tokenIdx, nTopk, nLocalExperts, maxTokensPerRank, rank,
+                                             laneId);
     }
     for (int inputIdx = groupThreadId; inputIdx < HiddenVectors; inputIdx += groupThreadCount) {
       outputData[inputIdx] = quantizeBf16x8ToFp8E4M3<ScaleBlockSize>(
@@ -166,9 +167,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSendFp8(const void* inputTokens, int nExperts
 
     if (subWarpId == 0) {
       fenceProxyAsyncSharedCta();
-      sendStagedDispatchPayload<DispatchDataType::FP8_E4M3>(payloadView, stagedPayload, destinationSlots, workspaceView,
-                                                            nTopk, nLocalExperts, maxTokensPerRank, metadataBytes,
-                                                            payloadStride, recvBuffer, transport, laneId);
+      sendStagedDispatchPayload<DataType>(payloadView, stagedPayload, destinationSlots, workspaceView, nTopk,
+                                          nLocalExperts, maxTokensPerRank, metadataBytes, payloadStride, recvBuffer,
+                                          transport, laneId);
     }
     syncNamedBarrier(groupBarrierId, groupThreadCount);
   }
@@ -262,9 +263,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSend(const void* inputTokens, const Transport
       dispatchSendBf16<Hidden>(inputTokens, nExperts, transport.rank_, nRanks, topkIndices, topkWeights, nTokens, nTopk,
                                maxTokensPerRank, recvBuffer, transport, workspace, sharedMem);
     } else {
-      dispatchSendFp8<Hidden, ScaleBlockSize>(inputTokens, nExperts, transport.rank_, nRanks, topkIndices, topkWeights,
-                                              nTokens, nTopk, maxTokensPerRank, recvBuffer, transport, workspace,
-                                              sharedMem);
+      dispatchSendFp8<Hidden, DataType, ScaleBlockSize>(inputTokens, nExperts, transport.rank_, nRanks, topkIndices,
+                                                        topkWeights, nTokens, nTopk, maxTokensPerRank, recvBuffer,
+                                                        transport, workspace, sharedMem);
     }
   } else if (static_cast<int>(blockIdx.x) == nWorkerBlocks + 1) {
     dispatchNotify(transport, nExperts, nRanks, topkIndices, nTokens, nTopk, recvBuffer, workspace, dispatchEpoch,
@@ -479,8 +480,9 @@ template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
 MSCCLPP_DEVICE_INLINE bool dispatchRecvTokenMajorOutput(void* output, float* outputScales, int* outputSrcInfo,
                                                         int* outputTopkIdx, float* outputTopkWeights,
                                                         const DispatchPayloadView<DataType>& payloadView,
-                                                        const void* sourcePayload, int localExpertIdx, int outputRow,
-                                                        int sourceTokenIdx, int nTopk, uint8_t* sharedTile,
+                                                        const void* sourcePayload, int routedExpertIdx,
+                                                        int localExpertIdx, int outputRow, int sourceTokenIdx,
+                                                        int nExperts, int nTopk, uint8_t* sharedTile,
                                                         uint64_t* tmaBarrier, uint32_t& recvTmaPhase) {
   using OutputType = DispatchElementType<DataType>;
   constexpr size_t OutputBytes = static_cast<size_t>(Hidden) * sizeof(OutputType);
@@ -489,7 +491,7 @@ MSCCLPP_DEVICE_INLINE bool dispatchRecvTokenMajorOutput(void* output, float* out
 
   if (laneId == 0) outputSrcInfo[outputRow] = sourceTokenIdx;
   if (laneId < nTopk) {
-    outputTopkIdx[static_cast<size_t>(outputRow) * nTopk + laneId] = localExpertIdx;
+    outputTopkIdx[static_cast<size_t>(outputRow) * nTopk + laneId] = localExpertIdx >= 0 ? routedExpertIdx : nExperts;
     outputTopkWeights[static_cast<size_t>(outputRow) * nTopk + laneId] =
         localExpertIdx >= 0 ? payloadView.topKValues(sourcePayload)[laneId] : 0.0f;
   }
@@ -575,7 +577,8 @@ MSCCLPP_DEVICE_INLINE void dispatchRecvWorker(void* output, float* outputScales,
           warpBroadcast(laneId == 0 ? static_cast<int>(outputLayout[sourceRank]) : 0, 0) + sourceTokenSlot;
       hasPendingStore = dispatchRecvTokenMajorOutput<Hidden, DataType, ScaleBlockSize>(
           output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, payloadView, sourcePayload,
-          localExpertIdx, outputRow, sourceTokenIdx, nTopk, sharedTile, tmaBarrier, recvTmaPhase);
+          routedExpertIdx, localExpertIdx, outputRow, sourceTokenIdx, nExperts, nTopk, sharedTile, tmaBarrier,
+          recvTmaPhase);
     }
   }
 
@@ -673,7 +676,9 @@ inline void dispatchHidden(void* output, float* outputScales, int* outputSrcInfo
           output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
           topkIdx, topkWeights, workload, recvBuffer, comm, workspace, numBlocks, stream);
     case DispatchDataType::MXFP8_E4M3:
-      EP_HOST_ASSERT(false && "MXFP8 dispatch is not implemented");
+      return dispatchHiddenMode<Hidden, DispatchDataType::MXFP8_E4M3, 32, Layout, InitializeTokenMajorPadding>(
+          output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
+          topkIdx, topkWeights, workload, recvBuffer, comm, workspace, numBlocks, stream);
   }
   EP_HOST_ASSERT(false && "unsupported dispatch data type");
 }

--- a/test/python/ep/ep_bench_ll.py
+++ b/test/python/ep/ep_bench_ll.py
@@ -126,7 +126,7 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--dispatch-dtype",
-        choices=("bf16", "fp8_e4m3"),
+        choices=("bf16", "fp8_e4m3", "mxfp8_e4m3"),
         default="bf16",
         help="low-latency dispatch payload format",
     )
@@ -332,6 +332,7 @@ def main() -> None:
     dispatch_data_type = {
         "bf16": ep.DispatchDataType.BF16,
         "fp8_e4m3": ep.DispatchDataType.FP8_E4M3,
+        "mxfp8_e4m3": ep.DispatchDataType.MXFP8_E4M3,
     }[args.dispatch_dtype]
     combine_mode = {
         "rank_local_reduce": ep.CombineMode.RANK_LOCAL_REDUCE,
@@ -347,7 +348,16 @@ def main() -> None:
         None if dispatch_data_type == ep.DispatchDataType.BF16 else ep.QuantConfig(format=dispatch_data_type)
     )
     dispatch_dtype = torch.bfloat16 if dispatch_quant is None else torch.float8_e4m3fn
-    dispatch_label = "BF16" if dispatch_quant is None else "FP8_E4M3"
+    dispatch_label = {
+        ep.DispatchDataType.BF16: "BF16",
+        ep.DispatchDataType.FP8_E4M3: "FP8_E4M3",
+        ep.DispatchDataType.MXFP8_E4M3: "MXFP8_E4M3",
+    }[dispatch_data_type]
+    scale_block_size = 0
+    if dispatch_data_type == ep.DispatchDataType.FP8_E4M3:
+        scale_block_size = 128
+    elif dispatch_data_type == ep.DispatchDataType.MXFP8_E4M3:
+        scale_block_size = 32
 
     # bf16 precision anchor (same convention as test_low_latency_multirank.py).
     rank_offset = 128
@@ -374,7 +384,7 @@ def main() -> None:
             valid = expert >= 0
             destination_mask[valid, expert[valid] // num_local_experts] = True
         num_dispatch_rows = int(destination_mask.sum().item())
-    dispatch_bytes_per_token = hidden * 2 if dispatch_quant is None else hidden + hidden // 128 * 4
+    dispatch_bytes_per_token = hidden * 2 if dispatch_quant is None else hidden + hidden // scale_block_size * 4
     disp_bytes = num_dispatch_rows * dispatch_bytes_per_token
     comb_bytes = num_dispatch_rows * hidden * 2
 

--- a/test/python/ep/mscclpp_ep_bench.cu
+++ b/test/python/ep/mscclpp_ep_bench.cu
@@ -222,12 +222,16 @@ int main(int argc, char** argv) {
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
   const int Elocal = E / W;
-  const auto dispatchDataType = args.dispatch_dtype == "fp8_e4m3" ? mscclpp::ep::low_latency::DispatchDataType::FP8_E4M3
-                                                                  : mscclpp::ep::low_latency::DispatchDataType::BF16;
+  auto dispatchDataType = mscclpp::ep::low_latency::DispatchDataType::BF16;
+  if (args.dispatch_dtype == "fp8_e4m3") {
+    dispatchDataType = mscclpp::ep::low_latency::DispatchDataType::FP8_E4M3;
+  } else if (args.dispatch_dtype == "mxfp8_e4m3") {
+    dispatchDataType = mscclpp::ep::low_latency::DispatchDataType::MXFP8_E4M3;
+  }
   const auto combineMode = args.combine_mode == "direct_send"
                                ? mscclpp::ep::low_latency::CombineMode::DIRECT_SEND
                                : mscclpp::ep::low_latency::CombineMode::RANK_LOCAL_REDUCE;
-  if (args.dispatch_dtype != "bf16" && args.dispatch_dtype != "fp8_e4m3") {
+  if (args.dispatch_dtype != "bf16" && args.dispatch_dtype != "fp8_e4m3" && args.dispatch_dtype != "mxfp8_e4m3") {
     if (rank == 0) fprintf(stderr, "unsupported --dispatch-dtype=%s\n", args.dispatch_dtype.c_str());
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
@@ -240,8 +244,11 @@ int main(int argc, char** argv) {
     if (rank == 0) fprintf(stderr, "--num-blocks must be in [world_size + 2, 130]\n");
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
-  const bool fp8Dispatch = dispatchDataType == mscclpp::ep::low_latency::DispatchDataType::FP8_E4M3;
-  const char* dispatchLabel = fp8Dispatch ? "FP8_E4M3" : "BF16";
+  const bool fp8Dispatch = dispatchDataType != mscclpp::ep::low_latency::DispatchDataType::BF16;
+  const int scaleBlockSize = dispatchDataType == mscclpp::ep::low_latency::DispatchDataType::MXFP8_E4M3 ? 32 : 128;
+  const char* dispatchLabel = dispatchDataType == mscclpp::ep::low_latency::DispatchDataType::MXFP8_E4M3
+                                  ? "MXFP8_E4M3"
+                                  : (fp8Dispatch ? "FP8_E4M3" : "BF16");
 
   // --- Bootstrap mscclpp::Communicator (TcpBootstrap + MPI_Bcast of UniqueId). ---
   auto bootstrap = std::make_shared<mscclpp::TcpBootstrap>(rank, nRanks);
@@ -251,7 +258,7 @@ int main(int argc, char** argv) {
   bootstrap->initialize(uid);
   mscclpp::Communicator comm(bootstrap);
 
-  mscclpp::ep::MoERuntime rt(comm, T, H, E, K);
+  mscclpp::ep::MoERuntime rt(comm, T, H, E, K, false);
   if (!rt.isAvailable()) {
     if (rank == 0) fprintf(stderr, "MoERuntime not available\n");
     MPI_Abort(MPI_COMM_WORLD, 1);
@@ -281,7 +288,7 @@ int main(int argc, char** argv) {
   const size_t recvBytes = (size_t)Elocal * slots * H * (fp8Dispatch ? sizeof(Fp8E4M3) : sizeof(Bf16));
   CUDA_CHECK(cudaMalloc(&d_recv, recvBytes));
   if (fp8Dispatch) {
-    CUDA_CHECK(cudaMalloc(&d_scales, (size_t)Elocal * slots * (H / 128) * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_scales, (size_t)Elocal * slots * (H / scaleBlockSize) * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&d_expert_output, (size_t)Elocal * slots * H * sizeof(Bf16)));
     CUDA_CHECK(cudaMemset(d_expert_output, 0, (size_t)Elocal * slots * H * sizeof(Bf16)));
   } else {
@@ -329,7 +336,7 @@ int main(int argc, char** argv) {
   long long num_valid_selections = 0;
   for (size_t i = 0; i < h_topk.size(); ++i)
     if (h_topk[i] >= 0) ++num_valid_selections;
-  const double dispatchBytesPerToken = fp8Dispatch ? H + (H / 128) * sizeof(float) : H * sizeof(Bf16);
+  const double dispatchBytesPerToken = fp8Dispatch ? H + (H / scaleBlockSize) * sizeof(float) : H * sizeof(Bf16);
   const double disp_bytes = (double)num_valid_selections * dispatchBytesPerToken;
   const double comb_bytes = (double)num_valid_selections * H * sizeof(Bf16);
 
@@ -337,12 +344,13 @@ int main(int argc, char** argv) {
   CUDA_CHECK(cudaStreamCreate(&stream));
 
   auto dispatch = [&]() {
-    rt.dispatch(d_recv, d_scales, d_srcinfo, d_layout, d_count, d_x, d_topk, d_weights, T, H, K,
-                /*maxTokensPerRank=*/T, E, dispatchDataType, args.num_blocks, stream);
+    rt.dispatch(d_recv, d_scales, d_srcinfo, nullptr, nullptr, d_layout, d_count, d_x, d_topk, d_weights, T, H, K,
+                /*maxTokensPerRank=*/T, E, mscclpp::ep::DispatchLayout::EXPERT_MAJOR, dispatchDataType, args.num_blocks,
+                stream);
   };
   auto combine = [&]() {
     rt.combine(d_out, d_expert_output, d_topk, d_weights, d_srcinfo, d_layout, T, H, K,
-               /*maxTokensPerRank=*/T, E, dispatchDataType, combineMode,
+               /*maxTokensPerRank=*/T, E, mscclpp::ep::DispatchLayout::EXPERT_MAJOR, dispatchDataType, combineMode,
                args.num_blocks - mscclpp::ep::low_latency::DispatchControlBlocks, stream);
   };
 

--- a/test/python/ep/run_ep_bench.py
+++ b/test/python/ep/run_ep_bench.py
@@ -118,7 +118,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("-i", "--num-iters", type=int, default=50, help="timed iterations")
     p.add_argument(
         "--dispatch-dtype",
-        choices=("bf16", "fp8_e4m3"),
+        choices=("bf16", "fp8_e4m3", "mxfp8_e4m3"),
         default="bf16",
         help="MSCCL++ dispatch format; NCCL-EP runs keep their own configured format",
     )

--- a/test/python/ep/test_low_latency_multirank.py
+++ b/test/python/ep/test_low_latency_multirank.py
@@ -69,7 +69,7 @@ def parse_args():
     parser.add_argument("--no-weights", action="store_true", help="Use implicit unit routing weights")
     parser.add_argument(
         "--dispatch-dtype",
-        choices=("bf16", "fp8_e4m3"),
+        choices=("bf16", "fp8_e4m3", "mxfp8_e4m3"),
         default="bf16",
         help="Wire format for low-latency dispatch",
     )
@@ -117,8 +117,8 @@ def init_dist():
     return rank, world_size, local_rank, dist.new_group(list(range(world_size)))
 
 
-def fp8_e4m3_block128_scales(x):
-    blocks = x.float().reshape(*x.shape[:-1], x.size(-1) // 128, 128)
+def fp8_e4m3_scales(x, scale_block_size):
+    blocks = x.float().reshape(*x.shape[:-1], x.size(-1) // scale_block_size, scale_block_size)
     max_abs = blocks.abs().amax(dim=-1).clamp_min(1e-4)
     return max_abs / 448.0
 
@@ -129,7 +129,9 @@ def dequantized_dispatch_tokens(dispatch_out):
     assert dispatch_out.tokens.dtype == torch.float8_e4m3fn
     assert dispatch_out.quant.block_scales is not None
     tokens = dispatch_out.tokens
-    token_blocks = tokens.float().reshape(*tokens.shape[:-1], tokens.size(-1) // 128, 128)
+    num_scales = dispatch_out.quant.block_scales.size(-1)
+    scale_block_size = tokens.size(-1) // num_scales
+    token_blocks = tokens.float().reshape(*tokens.shape[:-1], num_scales, scale_block_size)
     return (token_blocks * dispatch_out.quant.block_scales.unsqueeze(-1)).reshape(tokens.shape).to(torch.bfloat16)
 
 
@@ -209,6 +211,7 @@ def validate_expert_major_dispatch(
         assert expected_scales is not None
         assert dispatch_out.quant is not None
         assert dispatch_out.quant.block_scales is not None
+        scale_block_size = hidden // expected_scales.size(-1)
         for source_rank in range(num_ranks):
             packed_range = int(recv_layout_range[source_rank].item())
             source_count = packed_range & int_mask
@@ -225,9 +228,13 @@ def validate_expert_major_dispatch(
             reference_scales = expected_scales[source_rank, source_tokens]
             torch.testing.assert_close(actual_scales, reference_scales, rtol=1e-6, atol=1e-7)
             actual_dequantized = actual_tokens.float().reshape(
-                source_count, hidden // 128, 128
+                source_count, hidden // scale_block_size, scale_block_size
             ) * actual_scales.unsqueeze(-1)
-            reference_tokens = all_x[source_rank, source_tokens].float().reshape(source_count, hidden // 128, 128)
+            reference_tokens = (
+                all_x[source_rank, source_tokens]
+                .float()
+                .reshape(source_count, hidden // scale_block_size, scale_block_size)
+            )
             quant_error = (actual_dequantized - reference_tokens).abs()
             quant_error_bound = reference_scales.unsqueeze(-1) * 16.1 + 1e-6
             max_scale_error = (quant_error / reference_scales.unsqueeze(-1)).max().item()
@@ -301,13 +308,13 @@ def validate_token_major_dispatch(
         actual_weights = dispatch_out.weights[row_begin:row_end]
         expected_global_ids = all_topk_idx[source_rank, source_tokens]
         local_mask = (expected_global_ids >= local_expert_begin) & (expected_global_ids < local_expert_end)
-        expected_local_ids = torch.where(
-            local_mask, expected_global_ids - local_expert_begin, torch.full_like(expected_global_ids, -1)
+        expected_output_ids = torch.where(
+            local_mask, expected_global_ids, torch.full_like(expected_global_ids, num_experts)
         )
         expected_weights = torch.where(
             local_mask, all_topk_weights[source_rank, source_tokens], torch.zeros_like(actual_weights)
         )
-        assert torch.equal(actual_topk_ids, expected_local_ids.to(torch.int32))
+        assert torch.equal(actual_topk_ids, expected_output_ids.to(torch.int32))
         torch.testing.assert_close(actual_weights, expected_weights)
 
         if dispatch_quant is None:
@@ -317,11 +324,16 @@ def validate_token_major_dispatch(
         assert expected_scales is not None
         assert dispatch_out.quant is not None
         assert dispatch_out.quant.block_scales is not None
+        scale_block_size = hidden // expected_scales.size(-1)
         actual_scales = dispatch_out.quant.block_scales[row_begin:row_end]
         reference_scales = expected_scales[source_rank, source_tokens]
         torch.testing.assert_close(actual_scales, reference_scales, rtol=1e-6, atol=1e-7)
-        actual_dequantized = actual_tokens.float().reshape(recv_count, hidden // 128, 128) * actual_scales.unsqueeze(-1)
-        reference_tokens = all_x[source_rank, source_tokens].float().reshape(recv_count, hidden // 128, 128)
+        actual_dequantized = actual_tokens.float().reshape(
+            recv_count, hidden // scale_block_size, scale_block_size
+        ) * actual_scales.unsqueeze(-1)
+        reference_tokens = (
+            all_x[source_rank, source_tokens].float().reshape(recv_count, hidden // scale_block_size, scale_block_size)
+        )
         quant_error = (actual_dequantized - reference_tokens).abs()
         quant_error_bound = reference_scales.unsqueeze(-1) * 16.1 + 1e-6
         assert torch.all(quant_error <= quant_error_bound)
@@ -452,8 +464,20 @@ def main():
     }[args.output_layout]
     if output_layout == ep.DispatchLayout.TOKEN_MAJOR:
         assert combine_mode == ep.CombineMode.RANK_LOCAL_REDUCE, "token-major output requires rank-local combine"
-    dispatch_quant = ep.QuantConfig(format=ep.DispatchDataType.FP8_E4M3) if args.dispatch_dtype == "fp8_e4m3" else None
+    dispatch_data_type = {
+        "bf16": ep.DispatchDataType.BF16,
+        "fp8_e4m3": ep.DispatchDataType.FP8_E4M3,
+        "mxfp8_e4m3": ep.DispatchDataType.MXFP8_E4M3,
+    }[args.dispatch_dtype]
+    dispatch_quant = (
+        None if dispatch_data_type == ep.DispatchDataType.BF16 else ep.QuantConfig(format=dispatch_data_type)
+    )
     dispatch_dtype = torch.float8_e4m3fn if dispatch_quant is not None else torch.bfloat16
+    scale_block_size = 0
+    if dispatch_data_type == ep.DispatchDataType.FP8_E4M3:
+        scale_block_size = 128
+    elif dispatch_data_type == ep.DispatchDataType.MXFP8_E4M3:
+        scale_block_size = 32
 
     torch.manual_seed(0xB3C4 + rank)
     random.seed(0xB3C4 + rank)
@@ -555,16 +579,16 @@ def main():
         dist.all_gather_into_tensor(all_x, x, group=group)
     if dispatch_quant is not None:
         assert dispatch_out.quant is not None
-        assert dispatch_out.quant.format == ep.DispatchDataType.FP8_E4M3
+        assert dispatch_out.quant.format == dispatch_data_type
         assert dispatch_out.quant.block_scales is not None
         expected_scale_shape = (
-            (num_local_experts, num_ranks * num_tokens, hidden // 128)
+            (num_local_experts, num_ranks * num_tokens, hidden // scale_block_size)
             if output_layout == ep.DispatchLayout.EXPERT_MAJOR
-            else (num_ranks * num_tokens, hidden // 128)
+            else (num_ranks * num_tokens, hidden // scale_block_size)
         )
         assert dispatch_out.quant.block_scales.shape == expected_scale_shape
         assert all_x is not None
-        expected_scales = fp8_e4m3_block128_scales(all_x)
+        expected_scales = fp8_e4m3_scales(all_x, scale_block_size)
 
     if output_layout == ep.DispatchLayout.EXPERT_MAJOR:
         assert packed_recv_layout_range is not None
@@ -792,7 +816,7 @@ def main():
     # sends one copy per dispatched token back to its owner, so the bytes on
     # the wire match dispatch. Using num_tokens × hidden here would under-count
     # the actual send payload by ~num_topk×.
-    dispatch_bytes_per_token = hidden * 2 if dispatch_quant is None else hidden + hidden // 128 * 4
+    dispatch_bytes_per_token = hidden * 2 if dispatch_quant is None else hidden + hidden // scale_block_size * 4
     disp_bytes = recv_tokens * dispatch_bytes_per_token
     comb_bytes = recv_tokens * hidden * 2
 


### PR DESCRIPTION
Support E4M3 payloads with FP32 scales per 32 elements, return global token-major expert IDs with num_experts sentinels, and simplify QuantConfig.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 59760d2a-e65f-44b6-b2e6-9c271b834d7e