### PR TITLE
Harden LL token metadata handling

### DIFF
--- a/python/mscclpp/ep/README.md
+++ b/python/mscclpp/ep/README.md
@@ -65,6 +65,7 @@ class MoECommunicatorConfig:
     mode: MoEMode = MoEMode.LOW_LATENCY
     output_layout: Optional[DispatchLayout] = None  # default is derived from mode
     token_major_init_padding: bool = False
+    invalid_token_expert_id: Optional[int] = None  # defaults to num_experts
 
     # Quantization defaults
     quant: Optional[QuantConfig] = None
@@ -138,6 +139,7 @@ a later version can add an explicit `expert_map` for arbitrary placement.
 | `mode` | Backend selection (`MoEMode.LOW_LATENCY` or `MoEMode.HIGH_THROUGHPUT`) |
 | `output_layout` | MLP input layout returned by dispatch |
 | `token_major_init_padding` | Initialize token-major padding metadata for fixed-capacity Triton kernels |
+| `invalid_token_expert_id` | Sentinel for token-major non-local and padding entries; defaults to `num_experts` |
 | `max_tokens_per_rank` | dispatch capacity |
 | scratch buffers | internally sized from mode, capacity, topology, and shape |
 | `num_sms` | backend launch/resource tuning |
@@ -529,8 +531,9 @@ end = dispatch_out.layout.offsets[r + 1]
 Rows after `offsets[-1]` are padding. Set
 `token_major_init_padding=True` when a fixed-capacity Triton kernel should
 process the entire allocation: padding `topk_ids` are then initialized to
-`num_experts` and weights to `0`, so the kernel can skip a row when all expert
-IDs equal `num_experts`.
+`invalid_token_expert_id` and weights to `0`, so the kernel can skip a row when
+all expert IDs equal the configured sentinel. The sentinel defaults to
+`num_experts`.
 The option defaults to `False` to avoid initialization overhead when the MLP
 uses the compact valid length.
 
@@ -577,7 +580,7 @@ dispatch_out.weights           # [world_size * max_tokens_per_rank, K], float32
 ```
 
 Only the prefix ending at `dispatch_out.layout.offsets[-1]` contains valid
-tokens. Non-local entries use expert ID `num_experts` and weight `0`; padding
+tokens. Non-local entries use `invalid_token_expert_id` and weight `0`; padding
 uses the same sentinel when
 `token_major_init_padding=True`. Per-source-rank counts are returned in
 `dispatch_out.layout.num_tokens_per_rank`.

--- a/python/mscclpp/ep/high_throughput.py
+++ b/python/mscclpp/ep/high_throughput.py
@@ -273,6 +273,8 @@ class HighThroughputBackend:
 
         if self.output_layout != DispatchLayout.TOKEN_MAJOR:
             raise NotImplementedError("HT mode currently supports only DispatchLayout.TOKEN_MAJOR")
+        if config.invalid_token_expert_id is not None:
+            raise ValueError("invalid_token_expert_id is only supported in low-latency mode")
 
         self.num_local_experts, self.local_expert_start = resolve_expert_placement(
             num_experts=self.num_experts,

--- a/python/mscclpp/ep/low_latency.py
+++ b/python/mscclpp/ep/low_latency.py
@@ -113,6 +113,9 @@ class LowLatencyBackend:
         self.num_sms = self.num_blocks - 2
         self.combine_mode = config.low_latency_combine_mode
         self.token_major_init_padding = config.token_major_init_padding
+        self.invalid_token_expert_id = (
+            self.num_experts if config.invalid_token_expert_id is None else config.invalid_token_expert_id
+        )
         self.enable_overlap = config.enable_overlap
 
         if self.output_layout not in (DispatchLayout.EXPERT_MAJOR, DispatchLayout.TOKEN_MAJOR):
@@ -125,6 +128,12 @@ class LowLatencyBackend:
             raise TypeError("low_latency_combine_mode must be a CombineMode")
         if not isinstance(self.token_major_init_padding, bool):
             raise TypeError("token_major_init_padding must be a bool")
+        if type(self.invalid_token_expert_id) is not int:
+            raise TypeError("invalid_token_expert_id must be an int or None")
+        if not -(1 << 31) <= self.invalid_token_expert_id < (1 << 31):
+            raise ValueError("invalid_token_expert_id must fit in int32")
+        if 0 <= self.invalid_token_expert_id < self.num_experts:
+            raise ValueError("invalid_token_expert_id must not overlap a valid global expert ID")
         if self.token_major_init_padding and self.output_layout != DispatchLayout.TOKEN_MAJOR:
             raise ValueError("token_major_init_padding requires TOKEN_MAJOR output")
         if self.output_layout == DispatchLayout.TOKEN_MAJOR and self.combine_mode != CombineMode.RANK_LOCAL_REDUCE:
@@ -199,6 +208,7 @@ class LowLatencyBackend:
             self.topk,
             self.max_tokens_per_rank,
             self.num_experts,
+            self.invalid_token_expert_id,
             self.output_layout,
             self.dispatch_data_type,
             self.num_blocks,

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -52,6 +52,8 @@ class MoECommunicatorConfig:
     mode: MoEMode = MoEMode.LOW_LATENCY
     output_layout: Optional[DispatchLayout] = None
     token_major_init_padding: bool = False
+    # LL token-major sentinel; None resolves to num_experts.
+    invalid_token_expert_id: Optional[int] = None
 
     # Quantization defaults
     quant: Optional[QuantConfig] = None

--- a/src/ext/ep/README.md
+++ b/src/ext/ep/README.md
@@ -36,10 +36,11 @@ LL dispatch supports two user-visible layouts:
 - `TOKEN_MAJOR`: one row per `(token, destination rank)`, plus global top-k expert
   IDs, routing weights, source-token IDs, per-source-rank counts, and exclusive
   offsets. Valid rows occupy a compact prefix of the caller-provided capacity
-  buffer. Entries not owned by the destination rank use expert ID `num_experts`
-  and weight `0`. With `token_major_init_padding=True`, padding rows use the
-  same sentinel, allowing fixed-capacity Triton kernels to skip them without a
-  CPU count synchronization. The option is disabled by default. The caller must
+  buffer. Entries not owned by the destination rank use
+  `invalid_token_expert_id` and weight `0`; the sentinel defaults to
+  `num_experts`. With `token_major_init_padding=True`, padding rows use the same
+  sentinel, allowing fixed-capacity Triton kernels to skip them without a CPU
+  count synchronization. The option is disabled by default. The caller must
   produce one pre-weighted local partial per valid row before combine.
 
 LL quantized dispatch supports E4M3 payloads with FP32 scales per 128 hidden

--- a/src/ext/ep/bindings.cpp
+++ b/src/ext/ep/bindings.cpp
@@ -67,22 +67,23 @@ NB_MODULE(mscclpp_ep_cpp, m) {
           [](mscclpp::ep::MoERuntime& self, uintptr_t inputPtr, uintptr_t topkIdxPtr, uintptr_t topkWeightsPtr,
              uintptr_t outputPtr, uintptr_t outputScalesPtr, uintptr_t outputSrcInfoPtr, uintptr_t outputTopkIdxPtr,
              uintptr_t outputTopkWeightsPtr, uintptr_t outputLayoutRangePtr, uintptr_t outputCountPtr, int numTokens,
-             int hidden, int numTopk, int maxTokensPerRank, int numExperts, mscclpp::ep::DispatchLayout dispatchLayout,
-             mscclpp::ep::low_latency::DispatchDataType dispatchDataType, int numBlocks, uintptr_t streamPtr) {
+             int hidden, int numTopk, int maxTokensPerRank, int numExperts, int invalidTokenExpertId,
+             mscclpp::ep::DispatchLayout dispatchLayout, mscclpp::ep::low_latency::DispatchDataType dispatchDataType,
+             int numBlocks, uintptr_t streamPtr) {
             self.dispatch(
                 ptr(outputPtr), ptr(outputScalesPtr), reinterpret_cast<int*>(ptr(outputSrcInfoPtr)),
                 reinterpret_cast<int*>(ptr(outputTopkIdxPtr)), reinterpret_cast<float*>(ptr(outputTopkWeightsPtr)),
                 reinterpret_cast<int64_t*>(ptr(outputLayoutRangePtr)), reinterpret_cast<int*>(ptr(outputCountPtr)),
                 ptr(inputPtr), reinterpret_cast<int64_t*>(ptr(topkIdxPtr)),
                 reinterpret_cast<float*>(ptr(topkWeightsPtr)), numTokens, hidden, numTopk, maxTokensPerRank, numExperts,
-                dispatchLayout, dispatchDataType, numBlocks, stream(streamPtr));
+                invalidTokenExpertId, dispatchLayout, dispatchDataType, numBlocks, stream(streamPtr));
           },
           nb::arg("input_ptr"), nb::arg("topk_idx_ptr"), nb::arg("topk_weights_ptr"), nb::arg("output_ptr"),
           nb::arg("output_scales_ptr"), nb::arg("output_src_info_ptr"), nb::arg("output_topk_idx_ptr"),
           nb::arg("output_topk_weights_ptr"), nb::arg("output_layout_range_ptr"), nb::arg("output_count_ptr"),
           nb::arg("num_tokens"), nb::arg("hidden"), nb::arg("num_topk"), nb::arg("max_tokens_per_rank"),
-          nb::arg("num_experts"), nb::arg("dispatch_layout"), nb::arg("dispatch_data_type"), nb::arg("num_blocks"),
-          nb::arg("stream_ptr"))
+          nb::arg("num_experts"), nb::arg("invalid_token_expert_id"), nb::arg("dispatch_layout"),
+          nb::arg("dispatch_data_type"), nb::arg("num_blocks"), nb::arg("stream_ptr"))
       .def(
           "combine",
           [](mscclpp::ep::MoERuntime& self, uintptr_t expertOutputPtr, uintptr_t topkIdxPtr, uintptr_t topkWeightsPtr,

--- a/src/ext/ep/include/api.cuh
+++ b/src/ext/ep/include/api.cuh
@@ -109,6 +109,8 @@ struct Workload {
   int numTopk_;
   /// Total number of experts.
   int numExperts_;
+  /// Sentinel used for token-major entries that do not name a valid expert.
+  int invalidTokenExpertId_;
   /// Maximum tokens per rank in the packed layout.
   int maxTokensPerRank_;
   /// User-visible dispatch output layout.
@@ -151,7 +153,7 @@ size_t workspaceSize(int numRanks, int numExperts);
 /// @param[out] outputScales Layout-matched FP32 scales for FP8_E4M3, UE8M0 bytes for MXFP8_E4M3, or nullptr for BF16.
 /// @param[out] outputSrcInfo Original source-token index for every output row.
 /// @param[out] outputTopkIdx Token-major global expert indices [num_ranks * max_tokens_per_rank, num_topk], or nullptr.
-/// Non-local and padding entries use numExperts as the sentinel.
+/// Non-local and padding entries use Workload::invalidTokenExpertId_.
 /// @param[out] outputTopkWeights Token-major routing weights
 /// [num_ranks * max_tokens_per_rank, num_topk], or nullptr.
 /// @param[out] outputLayout Per-[local expert, source rank] packed count and offset for expert-major output, or

--- a/src/ext/ep/include/quantization.cuh
+++ b/src/ext/ep/include/quantization.cuh
@@ -26,6 +26,13 @@ MSCCLPP_DEVICE_INLINE uint8_t encodeUe8m0RoundUp(float value) {
 #endif
 }
 
+MSCCLPP_DEVICE_INLINE float inverseUe8m0Scale(uint8_t scale) {
+  // UE8M0 code E represents 2^(E - 127), so its inverse is
+  // 2^(127 - E). E=254 requires the float32 subnormal 2^-127.
+  if (scale == 254) return __uint_as_float(0x00400000u);
+  return __uint_as_float(static_cast<uint32_t>(254 - scale) << 23);
+}
+
 MSCCLPP_DEVICE_INLINE float maxAbsF32x8(const mscclpp::f32x8& values, float seed) {
   float maxAbs = seed;
 #pragma unroll
@@ -103,8 +110,7 @@ MSCCLPP_DEVICE_INLINE mscclpp::f8_e4m3x8 quantizeBf16x8ToMxFp8E4M3(const mscclpp
     *scaleOut = scale;
   }
 
-  const float decodedScale = __uint_as_float(static_cast<uint32_t>(scale) << 23);
-  const float inverseScale = scale == 0 ? 1.0f : reciprocalApproximateFtz(decodedScale);
+  const float inverseScale = inverseUe8m0Scale(scale);
   mscclpp::f32x8 scaledValues;
 #pragma unroll
   for (int element = 0; element < NumElements; ++element) {

--- a/src/ext/ep/low_latency/dispatch.cu
+++ b/src/ext/ep/low_latency/dispatch.cu
@@ -489,7 +489,7 @@ MSCCLPP_DEVICE_INLINE bool dispatchRecvTokenMajorOutput(void* output, void* outp
                                                         const DispatchPayloadView<DataType>& payloadView,
                                                         const void* sourcePayload, int routedExpertIdx,
                                                         int localExpertIdx, int outputRow, int sourceTokenIdx,
-                                                        int nExperts, int nTopk, uint8_t* sharedTile,
+                                                        int invalidTokenExpertId, int nTopk, uint8_t* sharedTile,
                                                         uint64_t* tmaBarrier, uint32_t& recvTmaPhase) {
   using OutputType = DispatchElementType<DataType>;
   constexpr size_t OutputBytes = static_cast<size_t>(Hidden) * sizeof(OutputType);
@@ -498,7 +498,8 @@ MSCCLPP_DEVICE_INLINE bool dispatchRecvTokenMajorOutput(void* output, void* outp
 
   if (laneId == 0) outputSrcInfo[outputRow] = sourceTokenIdx;
   if (laneId < nTopk) {
-    outputTopkIdx[static_cast<size_t>(outputRow) * nTopk + laneId] = localExpertIdx >= 0 ? routedExpertIdx : nExperts;
+    outputTopkIdx[static_cast<size_t>(outputRow) * nTopk + laneId] =
+        localExpertIdx >= 0 ? routedExpertIdx : invalidTokenExpertId;
     outputTopkWeights[static_cast<size_t>(outputRow) * nTopk + laneId] =
         localExpertIdx >= 0 ? payloadView.topKValues(sourcePayload)[laneId] : 0.0f;
   }
@@ -524,8 +525,9 @@ MSCCLPP_DEVICE_INLINE bool dispatchRecvTokenMajorOutput(void* output, void* outp
 template <int Hidden, DispatchDataType DataType, int ScaleBlockSize, DispatchLayout Layout>
 MSCCLPP_DEVICE_INLINE void dispatchRecvWorker(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
                                               float* outputTopkWeights, int64_t* outputLayout, int nExperts, int rank,
-                                              int nRanks, int nTopk, int maxTokensPerRank, void* recvBuffer,
-                                              void* workspace, uint32_t dispatchEpoch, int* sharedMem) {
+                                              int nRanks, int nTopk, int invalidTokenExpertId, int maxTokensPerRank,
+                                              void* recvBuffer, void* workspace, uint32_t dispatchEpoch,
+                                              int* sharedMem) {
 #if defined(__CUDA_ARCH__)
   static_assert(__CUDA_ARCH__ >= 900, "TMA recv requires SM90 or newer");
 #endif
@@ -586,8 +588,8 @@ MSCCLPP_DEVICE_INLINE void dispatchRecvWorker(void* output, void* outputScales, 
           warpBroadcast(laneId == 0 ? static_cast<int>(outputLayout[sourceRank]) : 0, 0) + sourceTokenSlot;
       hasPendingStore = dispatchRecvTokenMajorOutput<Hidden, DataType, ScaleBlockSize>(
           output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, payloadView, sourcePayload,
-          routedExpertIdx, localExpertIdx, outputRow, sourceTokenIdx, nExperts, nTopk, sharedTile, tmaBarrier,
-          recvTmaPhase);
+          routedExpertIdx, localExpertIdx, outputRow, sourceTokenIdx, invalidTokenExpertId, nTopk, sharedTile,
+          tmaBarrier, recvTmaPhase);
     }
   }
 
@@ -610,6 +612,7 @@ __global__ __launch_bounds__(DispatchNThreads,
   const int nRanks = comm.numRanks_;
   const int nTokens = workload.numTokens_;
   const int nTopk = workload.numTopk_;
+  const int invalidTokenExpertId = workload.invalidTokenExpertId_;
   const int maxTokensPerRank = workload.maxTokensPerRank_;
   const TransportView transport(comm);
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
@@ -624,7 +627,7 @@ __global__ __launch_bounds__(DispatchNThreads,
     if constexpr (InitializeTokenMajorPadding) {
       const int nMetadataEntries = nRanks * maxTokensPerRank * nTopk;
       for (int idx = static_cast<int>(threadIdx.x); idx < nMetadataEntries; idx += static_cast<int>(blockDim.x)) {
-        outputTopkIdx[idx] = nExperts;
+        outputTopkIdx[idx] = invalidTokenExpertId;
         outputTopkWeights[idx] = 0.0f;
       }
       __syncthreads();
@@ -634,7 +637,7 @@ __global__ __launch_bounds__(DispatchNThreads,
   } else if (static_cast<int>(blockIdx.x) <= nWorkerBlocks) {
     dispatchRecvWorker<Hidden, DataType, ScaleBlockSize, Layout>(
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, nExperts, comm.rank_,
-        nRanks, nTopk, maxTokensPerRank, recvBuffer, workspace, dispatchEpoch, sharedMem);
+        nRanks, nTopk, invalidTokenExpertId, maxTokensPerRank, recvBuffer, workspace, dispatchEpoch, sharedMem);
   }
   if (blockIdx.x == 0 && threadIdx.x == 0) {
     *workspaceView.dispatchEpoch_ = dispatchEpoch;

--- a/src/ext/ep/moe_runtime.cc
+++ b/src/ext/ep/moe_runtime.cc
@@ -118,11 +118,12 @@ void MoERuntime::setup() {
 void MoERuntime::dispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
                           float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
                           const int64_t* topkIdx, const float* topkWeights, int numTokens, int hidden, int numTopk,
-                          int maxTokensPerRank, int numExperts, DispatchLayout dispatchLayout,
+                          int maxTokensPerRank, int numExperts, int invalidTokenExpertId, DispatchLayout dispatchLayout,
                           low_latency::DispatchDataType dispatchDataType, int numBlocks, cudaStream_t stream) {
   EP_HOST_ASSERT(available_);
   EP_HOST_ASSERT(numTokens <= maxTokensPerRank);
   EP_HOST_ASSERT(numExperts % numRanks_ == 0);
+  EP_HOST_ASSERT(invalidTokenExpertId < 0 || invalidTokenExpertId >= numExperts);
   EP_HOST_ASSERT(numBlocks - low_latency::DispatchControlBlocks >= numRanks_ &&
                  numBlocks <= low_latency::MaxDispatchBlocks);
 
@@ -134,6 +135,7 @@ void MoERuntime::dispatch(void* output, void* outputScales, int* outputSrcInfo, 
                                        .hidden_ = hidden,
                                        .numTopk_ = numTopk,
                                        .numExperts_ = numExperts,
+                                       .invalidTokenExpertId_ = invalidTokenExpertId,
                                        .maxTokensPerRank_ = maxTokensPerRank,
                                        .outputLayout_ = dispatchLayout,
                                        .initializeTokenMajorPadding_ = initializeTokenMajorPadding_,
@@ -163,6 +165,7 @@ void MoERuntime::combine(void* output, const void* input, const int64_t* topkIdx
                                        .hidden_ = hidden,
                                        .numTopk_ = numTopk,
                                        .numExperts_ = numExperts,
+                                       .invalidTokenExpertId_ = numExperts,
                                        .maxTokensPerRank_ = maxTokensPerRank,
                                        .outputLayout_ = dispatchLayout,
                                        .initializeTokenMajorPadding_ = false,

--- a/src/ext/ep/moe_runtime.hpp
+++ b/src/ext/ep/moe_runtime.hpp
@@ -30,8 +30,8 @@ class MoERuntime {
   void dispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx, float* outputTopkWeights,
                 int64_t* outputLayout, int* outputCount, const void* input, const int64_t* topkIdx,
                 const float* topkWeights, int numTokens, int hidden, int numTopk, int maxTokensPerRank, int numExperts,
-                DispatchLayout dispatchLayout, low_latency::DispatchDataType dispatchDataType, int numBlocks,
-                cudaStream_t stream);
+                int invalidTokenExpertId, DispatchLayout dispatchLayout, low_latency::DispatchDataType dispatchDataType,
+                int numBlocks, cudaStream_t stream);
 
   void combine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights, const int* srcInfo,
                const int64_t* layoutRange, int numTokens, int hidden, int numTopk, int maxTokensPerRank, int numExperts,

--- a/test/python/ep/ep_bench_ll.py
+++ b/test/python/ep/ep_bench_ll.py
@@ -147,6 +147,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="initialize unused token-major top-k IDs and weights for fixed-capacity kernels",
     )
+    p.add_argument(
+        "--invalid-token-expert-id",
+        type=int,
+        default=None,
+        help="sentinel for token-major non-local and padding expert IDs (default: num_experts)",
+    )
     p.add_argument("--num-blocks", type=int, default=130, help="total low-latency dispatch blocks")
     p.add_argument(
         "--no-kernel-timing",
@@ -325,6 +331,7 @@ def main() -> None:
     hidden = args.hidden
     num_topk = args.num_topk
     num_experts = args.num_experts
+    invalid_token_expert_id = num_experts if args.invalid_token_expert_id is None else args.invalid_token_expert_id
     warmup = args.num_warmup
     iters = args.num_iters
     assert num_experts % num_ranks == 0, "num_experts must be divisible by num_ranks"
@@ -415,6 +422,7 @@ def main() -> None:
         low_latency_combine_mode=combine_mode,
         output_layout=output_layout,
         token_major_init_padding=args.token_major_init_padding,
+        invalid_token_expert_id=invalid_token_expert_id,
         quant=dispatch_quant,
     )
     assert moe_comm.is_available()

--- a/test/python/ep/mscclpp_ep_bench.cu
+++ b/test/python/ep/mscclpp_ep_bench.cu
@@ -347,8 +347,8 @@ int main(int argc, char** argv) {
 
   auto dispatch = [&]() {
     rt.dispatch(d_recv, d_scales, d_srcinfo, nullptr, nullptr, d_layout, d_count, d_x, d_topk, d_weights, T, H, K,
-                /*maxTokensPerRank=*/T, E, mscclpp::ep::DispatchLayout::EXPERT_MAJOR, dispatchDataType, args.num_blocks,
-                stream);
+                /*maxTokensPerRank=*/T, E, /*invalidTokenExpertId=*/E, mscclpp::ep::DispatchLayout::EXPERT_MAJOR,
+                dispatchDataType, args.num_blocks, stream);
   };
   auto combine = [&]() {
     rt.combine(d_out, d_expert_output, d_topk, d_weights, d_srcinfo, d_layout, T, H, K,

--- a/test/python/ep/test_low_latency_multirank.py
+++ b/test/python/ep/test_low_latency_multirank.py
@@ -91,6 +91,12 @@ def parse_args():
         action="store_true",
         help="Initialize unused token-major top-k IDs to num_experts and weights to zero",
     )
+    parser.add_argument(
+        "--invalid-token-expert-id",
+        type=int,
+        default=None,
+        help="Sentinel for token-major non-local and padding expert IDs (default: num_experts)",
+    )
     parser.add_argument("--bench", action="store_true", help="Run dispatch/combine benchmark after correctness")
     parser.add_argument(
         "--cuda-graph",
@@ -132,8 +138,9 @@ def mxfp8_e4m3_scales(x):
 
 def decode_block_scales(scales):
     if scales.dtype == torch.uint8:
-        decoded = torch.exp2(scales.float() - 127.0)
-        return torch.where(scales == 0, torch.zeros_like(decoded), decoded)
+        bits = scales.to(torch.int32) << 23
+        bits = torch.where(scales == 0, torch.full_like(bits, 0x00400000), bits)
+        return bits.view(torch.float32)
     return scales.float()
 
 
@@ -247,15 +254,17 @@ def validate_expert_major_dispatch(
                 torch.testing.assert_close(actual_scales, reference_scales, rtol=1e-6, atol=1e-7)
             decoded_actual_scales = decode_block_scales(actual_scales)
             decoded_reference_scales = decode_block_scales(reference_scales)
-            actual_dequantized = actual_tokens.float().reshape(
-                source_count, hidden // scale_block_size, scale_block_size
-            ) * decoded_actual_scales.unsqueeze(-1)
-            reference_tokens = (
+            actual_blocks = actual_tokens.float().reshape(source_count, hidden // scale_block_size, scale_block_size)
+            reference_blocks = (
                 all_x[source_rank, source_tokens]
                 .float()
                 .reshape(source_count, hidden // scale_block_size, scale_block_size)
             )
-            quant_error = (actual_dequantized - reference_tokens).abs()
+            if actual_scales.dtype == torch.uint8:
+                tiny_nonzero_blocks = (reference_scales == 0) & (reference_blocks.abs().amax(dim=-1) > 0)
+                assert torch.all(actual_blocks.abs().amax(dim=-1)[tiny_nonzero_blocks] > 0)
+            actual_dequantized = actual_blocks * decoded_actual_scales.unsqueeze(-1)
+            quant_error = (actual_dequantized - reference_blocks).abs()
             quant_error_bound = decoded_reference_scales.unsqueeze(-1) * 16.1 + 1e-6
             max_scale_error = (quant_error / decoded_reference_scales.unsqueeze(-1)).max().item()
             assert torch.all(quant_error <= quant_error_bound), (
@@ -282,9 +291,9 @@ def validate_token_major_dispatch(
     all_x,
     expected_scales,
     initialize_padding,
+    invalid_token_expert_id,
 ):
     assert all_x is not None
-    num_experts = num_local_experts * num_ranks
     assert dispatch_out.topk_ids is not None
     assert dispatch_out.topk_ids.dtype == torch.int32
     assert dispatch_out.topk_ids.shape == (num_ranks * num_tokens, num_topk)
@@ -299,7 +308,7 @@ def validate_token_major_dispatch(
     total_recv_tokens = int(rank_offsets[-1].item())
     assert total_recv_tokens == int(packed_recv_count.sum().item())
     if initialize_padding:
-        assert torch.all(dispatch_out.topk_ids[total_recv_tokens:] == num_experts)
+        assert torch.all(dispatch_out.topk_ids[total_recv_tokens:] == invalid_token_expert_id)
         assert torch.all(dispatch_out.weights[total_recv_tokens:] == 0)
     local_expert_begin = rank * num_local_experts
     local_expert_end = local_expert_begin + num_local_experts
@@ -329,7 +338,7 @@ def validate_token_major_dispatch(
         expected_global_ids = all_topk_idx[source_rank, source_tokens]
         local_mask = (expected_global_ids >= local_expert_begin) & (expected_global_ids < local_expert_end)
         expected_output_ids = torch.where(
-            local_mask, expected_global_ids, torch.full_like(expected_global_ids, num_experts)
+            local_mask, expected_global_ids, torch.full_like(expected_global_ids, invalid_token_expert_id)
         )
         expected_weights = torch.where(
             local_mask, all_topk_weights[source_rank, source_tokens], torch.zeros_like(actual_weights)
@@ -353,13 +362,15 @@ def validate_token_major_dispatch(
             torch.testing.assert_close(actual_scales, reference_scales, rtol=1e-6, atol=1e-7)
         decoded_actual_scales = decode_block_scales(actual_scales)
         decoded_reference_scales = decode_block_scales(reference_scales)
-        actual_dequantized = actual_tokens.float().reshape(
-            recv_count, hidden // scale_block_size, scale_block_size
-        ) * decoded_actual_scales.unsqueeze(-1)
-        reference_tokens = (
+        actual_blocks = actual_tokens.float().reshape(recv_count, hidden // scale_block_size, scale_block_size)
+        reference_blocks = (
             all_x[source_rank, source_tokens].float().reshape(recv_count, hidden // scale_block_size, scale_block_size)
         )
-        quant_error = (actual_dequantized - reference_tokens).abs()
+        if actual_scales.dtype == torch.uint8:
+            tiny_nonzero_blocks = (reference_scales == 0) & (reference_blocks.abs().amax(dim=-1) > 0)
+            assert torch.all(actual_blocks.abs().amax(dim=-1)[tiny_nonzero_blocks] > 0)
+        actual_dequantized = actual_blocks * decoded_actual_scales.unsqueeze(-1)
+        quant_error = (actual_dequantized - reference_blocks).abs()
         quant_error_bound = decoded_reference_scales.unsqueeze(-1) * 16.1 + 1e-6
         assert torch.all(quant_error <= quant_error_bound)
 
@@ -477,6 +488,7 @@ def main():
     hidden = args.hidden
     num_topk = args.num_topk
     num_experts = args.num_experts
+    invalid_token_expert_id = num_experts if args.invalid_token_expert_id is None else args.invalid_token_expert_id
     assert num_experts % num_ranks == 0
     num_local_experts = num_experts // num_ranks
     combine_mode = {
@@ -518,6 +530,8 @@ def main():
         x[:, -128:] = torch.arange(num_tokens, device="cuda").to(torch.bfloat16).view(-1, 1)
     else:
         x = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda") * 8
+        if dispatch_data_type == ep.DispatchDataType.MXFP8_E4M3:
+            x[0, :32] = torch.finfo(torch.bfloat16).tiny
     scores = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda").abs() + 1
     if args.num_active_ranks:
         assert num_topk <= args.num_active_ranks * num_local_experts
@@ -543,6 +557,7 @@ def main():
         low_latency_combine_mode=combine_mode,
         output_layout=output_layout,
         token_major_init_padding=args.token_major_init_padding,
+        invalid_token_expert_id=invalid_token_expert_id,
         quant=dispatch_quant,
     )
     if rank == 0:
@@ -657,6 +672,7 @@ def main():
             all_x=all_x,
             expected_scales=expected_scales,
             initialize_padding=args.token_major_init_padding,
+            invalid_token_expert_id=invalid_token_expert_id,
         )
 
     if rank == 0:


### PR DESCRIPTION
Make the invalid token expert sentinel configurable and preserve tiny nonzero MXFP8 blocks for UE8M0 code zero.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 59760d2a-e65f-44b6-b2e6-9c271b834d7e