### PR TITLE
fix(ep-bench): strip C++ template args in kineto kernel-name match

### DIFF
--- a/test/python/ep/run_ep_bench_python.py
+++ b/test/python/ep/run_ep_bench_python.py
@@ -273,7 +273,13 @@ def _kineto_kernel_us(
         matched = False
         sub = substr.lower()
         for e in ka:
-            if sub in e.key.lower() and int(e.count) > 0:
+            # Match on the function name with C++ template arguments stripped, so a
+            # combine kernel templated on DispatchLayout (e.g. combineKernel<..,
+            # DispatchLayout::RANK_MAJOR>) is NOT mis-counted into the 'dispatch'
+            # bucket (and vice-versa). The dispatch/combine word lives in the
+            # function name, which always precedes the first '<'.
+            name = e.key.split("<", 1)[0].lower()
+            if sub in name and int(e.count) > 0:
                 total_us += float(e.self_device_time_total) / int(e.count)
                 matched = True
         return total_us if matched else 0.0


### PR DESCRIPTION
The kineto per-kernel attribution in _kineto_kernel_us matched the "dispatch"/"combine" substring against the full demangled kernel name. The rank-major combineKernel is templated on DispatchLayout (combineKernel<.., DispatchLayout::RANK_MAJOR>), so its name contains the substring "dispatch" and was wrongly summed into the dispatch bucket. This only surfaced under --cuda-graph, where the combine kernel also appears in the dispatch profiling pass, doubling the reported dispatch kernel time (e.g. 16->32 us at 1 node). Match on the function name with template arguments stripped (text before the first "<") so DispatchLayout / CombineMode template params no longer collide.