### PR TITLE
Handle empty NVML fabric cluster UUID

### DIFF
--- a/src/core/utils_internal.cc
+++ b/src/core/utils_internal.cc
@@ -238,6 +238,10 @@ bool tryGetNvmlIpcDomainHash(uint64_t& ipcDomainHash) {
       fabricInfo.status != NVML_SUCCESS) {
     return false;
   }
+  const char emptyClusterUuid[NVML_GPU_FABRIC_UUID_LEN] = {};
+  if (std::memcmp(fabricInfo.clusterUuid, emptyClusterUuid, sizeof(emptyClusterUuid)) == 0) {
+    return false;
+  }
 
   ipcDomainHash = getFabricHash(fabricInfo);
   return true;


### PR DESCRIPTION
## Summary

- detect an empty NVML fabric cluster UUID
- fall back when NVML reports an all-zero UUID instead of deriving an invalid IPC-domain hash

## Testing

- Not run (NVML fabric topology required)