### PR TITLE
Proxy FIFO latency improvement

### DIFF
--- a/include/mscclpp/fifo.hpp
+++ b/include/mscclpp/fifo.hpp
@@ -16,15 +16,21 @@ constexpr size_t DEFAULT_FIFO_SIZE = 512;
 class Fifo {
  public:
   /// Constructor.
-  /// @param size Number of entries (default: DEFAULT_FIFO_SIZE).
+  /// @param size Number of entries. Must be a power of two (default: DEFAULT_FIFO_SIZE).
+  /// @throws Error with ErrorCode::InvalidUsage if size is not a positive power of two.
   Fifo(int size = DEFAULT_FIFO_SIZE);
 
   /// Destructor.
   ~Fifo();
 
-  /// Poll and get the trigger at the head.
-  /// @return ProxyTrigger at the head of the FIFO.
-  ProxyTrigger poll();
+  /// Poll for the trigger at the head.
+  ///
+  /// A trigger carries no reserved payload value, so readiness is reported separately rather than
+  /// encoded in the trigger itself.
+  ///
+  /// @param trigger Set to the trigger at the head if one is ready. Untouched otherwise.
+  /// @return True if a trigger was ready and written to @p trigger.
+  bool poll(ProxyTrigger& trigger);
 
   /// Remove the head trigger.
   void pop();

--- a/include/mscclpp/fifo_device.hpp
+++ b/include/mscclpp/fifo_device.hpp
@@ -49,8 +49,8 @@ union alignas(16) ProxyTrigger {
     uint64_t dstMemoryId : TriggerBitsMemoryId;
     uint64_t type : TriggerBitsType;
     uint64_t semaphoreId : TriggerBitsSemaphoreId;
-    uint64_t : (64 - TriggerBitsOffset - TriggerBitsMemoryId - TriggerBitsMemoryId - TriggerBitsType -
-                TriggerBitsSemaphoreId - TriggerBitsFifoReserved);  // ensure 64-bit alignment
+    // The fields above use 63 bits; the commit bit occupies bit 63. Do not insert a zero-width
+    // bitfield here: C++ uses it to start a new allocation unit, moving reserved out of snd.
     uint64_t reserved : TriggerBitsFifoReserved;
   } fields;
 
@@ -93,6 +93,8 @@ union alignas(16) ProxyTrigger {
   }
 #endif  // defined(MSCCLPP_DEVICE_COMPILE)
 };
+
+static_assert(sizeof(ProxyTrigger) == 16, "ProxyTrigger must be exactly two 64-bit words");
 
 /// Concurrent FIFO where multiple device threads (the number of threads should not exceed the FIFO size) to push
 /// Head pointer is on device, tail pointer is on host (readable by device).

--- a/include/mscclpp/fifo_device.hpp
+++ b/include/mscclpp/fifo_device.hpp
@@ -25,6 +25,8 @@ constexpr unsigned int TriggerBitsOffset = 32;
 constexpr unsigned int TriggerBitsMemoryId = 9;
 constexpr unsigned int TriggerBitsType = 3;
 constexpr unsigned int TriggerBitsSemaphoreId = 10;
+// The FIFO uses the reserved bit to mark a slot as written, so a trigger must not carry data
+// there. See FifoDeviceHandle::push().
 constexpr unsigned int TriggerBitsFifoReserved = 1;
 
 /// Pair of 64-bit unsigned integers used as a trigger for the proxy.
@@ -71,7 +73,6 @@ union alignas(16) ProxyTrigger {
     MSCCLPP_ASSERT_DEVICE(dstOffset < (1ULL << TriggerBitsOffset), "dstOffset is too large");
     MSCCLPP_ASSERT_DEVICE(srcId < (1ULL << TriggerBitsMemoryId), "srcId is too large");
     MSCCLPP_ASSERT_DEVICE(srcOffset < (1ULL << TriggerBitsOffset), "srcOffset is too large");
-    MSCCLPP_ASSERT_DEVICE(bytes != 0, "bytes must not be zero");
     MSCCLPP_ASSERT_DEVICE(bytes < (1ULL << TriggerBitsSize), "bytes is too large");
     MSCCLPP_ASSERT_DEVICE(semaphoreId < (1ULL << TriggerBitsSemaphoreId), "semaphoreId is too large");
     constexpr uint64_t maskSize = (1ULL << TriggerBitsSize) - 1;
@@ -106,29 +107,32 @@ struct FifoDeviceHandle {
   MSCCLPP_DEVICE_INLINE uint64_t push(ProxyTrigger trigger, int64_t maxSpinCount = 1000000) {
     uint64_t prevHead = atomicFetchAdd<uint64_t, scopeDevice>(head, 1, memoryOrderRelaxed);
 
-    // Flip the last bit for safe polling; host will revert.
-    constexpr uint64_t flipMask = uint64_t{1} << uint64_t{63};
-    trigger.snd ^= flipMask;
-
-    // Wait until the trigger is freed by the host.
+    // Wait until the slot's previous occupant has been consumed. Lap parity identifies a stale
+    // trigger but does not prevent overwriting a live one; this does.
     if (prevHead >= size + *tailCache) {
       sync(prevHead - size, maxSpinCount);
     }
 
-    ProxyTrigger* triggerPtr = &(triggers[prevHead % size]);
+    // Commit bit: the parity of the lap this slot is on, so that the value left by the previous
+    // lap reads as stale. Lap 0 writes 1, which makes a zero-initialized buffer read as empty.
+    trigger.fields.reserved = ((prevHead >> sizeShift) & 1ULL) ^ 1ULL;
 
+    ProxyTrigger* triggerPtr = &(triggers[prevHead & sizeMask]);
+
+    // snd is the commit word: a consumer that observes this lap's parity must also observe the
+    // payload that goes with it.
 #if defined(MSCCLPP_DEVICE_CUDA)
-#if __CUDA_ARCH__ == 800
-    // This is faster than release for A100.
-    __threadfence_system();
-    asm volatile("st.global.relaxed.sys.v2.u64 [%0], {%1,%2};" ::"l"(triggerPtr), "l"(trigger.fst), "l"(trigger.snd));
-#else
+    // One 128-bit store publishes both words together, so no ordering is needed between them.
+    // The proxy already relies on this: a torn store would let it read a new fst against the
+    // previous lap's snd, and dispatch on a stale semaphoreId.
+    //
+    // sm_80 used __threadfence_system() plus a relaxed store here, which was once faster. On
+    // A100 with CUDA 12.9 it is no longer, according to `FifoTest.Fifo`.
     asm volatile("st.global.release.sys.v2.u64 [%0], {%1,%2};" ::"l"(triggerPtr), "l"(trigger.fst), "l"(trigger.snd));
-#endif
 #else   // !defined(MSCCLPP_DEVICE_CUDA)
-    // Store snd no later than fst.
-    atomicStore(&(triggerPtr->snd), trigger.snd, memoryOrderRelaxed);
-    atomicStore(&(triggerPtr->fst), trigger.fst, memoryOrderRelease);
+    // No vector store here, so order the payload ahead of the commit explicitly.
+    atomicStore(&(triggerPtr->fst), trigger.fst, memoryOrderRelaxed);
+    atomicStore(&(triggerPtr->snd), trigger.snd, memoryOrderRelease);
 #endif  // !defined(MSCCLPP_DEVICE_CUDA)
 
     return prevHead;
@@ -168,8 +172,12 @@ struct FifoDeviceHandle {
   uint64_t* tail;
   /// Cached tail value.
   uint64_t* tailCache;
-  /// FIFO size.
+  /// FIFO size. Always a power of two.
   int size;
+  /// size - 1, for mapping a position to a slot.
+  uint64_t sizeMask;
+  /// log2(size), for extracting the lap from a position.
+  uint64_t sizeShift;
 };
 
 }  // namespace mscclpp

--- a/include/mscclpp/port_channel_device.hpp
+++ b/include/mscclpp/port_channel_device.hpp
@@ -72,7 +72,7 @@ struct BasePortChannelDeviceHandle {
   }
 
   /// Push a TriggerFlag to the FIFO.
-  MSCCLPP_DEVICE_INLINE void signal() { fifo_.push({TriggerFlag, 0, 0, 0, 0, 1, semaphoreId_}); }
+  MSCCLPP_DEVICE_INLINE void signal() { fifo_.push({TriggerFlag, 0, 0, 0, 0, 0, semaphoreId_}); }
 
   /// Push a TriggerData and a TriggerFlag at the same time to the FIFO.
   /// @param dstId The ID of destination memory region.
@@ -122,7 +122,7 @@ struct BasePortChannelDeviceHandle {
   /// Push a TriggerSync to the FIFO.
   /// @param maxSpinCount The maximum number of spin counts before asserting. Never assert if negative.
   MSCCLPP_DEVICE_INLINE void flush(int64_t maxSpinCount = 1000000) {
-    uint64_t pos = fifo_.push({TriggerSync, 0, 0, 0, 0, 1, semaphoreId_});
+    uint64_t pos = fifo_.push({TriggerSync, 0, 0, 0, 0, 0, semaphoreId_});
     detail::waitFlush(flushDonePos_, pos, maxSpinCount);
   }
 

--- a/python/csrc/fifo_py.cpp
+++ b/python/csrc/fifo_py.cpp
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 
 #include <mscclpp/fifo.hpp>
+#include <optional>
 
 namespace nb = nanobind;
 using namespace mscclpp;
@@ -28,7 +30,12 @@ void register_fifo(nb::module_& m) {
 
   nb::class_<Fifo>(m, "CppFifo")
       .def(nb::init<int>(), nb::arg("size") = DEFAULT_FIFO_SIZE)
-      .def("poll", &Fifo::poll)
+      .def("poll",
+           [](Fifo& self) -> std::optional<ProxyTrigger> {
+             ProxyTrigger trigger;
+             if (!self.poll(trigger)) return std::nullopt;
+             return trigger;
+           })
       .def("pop", &Fifo::pop)
       .def("size", &Fifo::size)
       .def("device_handle", &Fifo::deviceHandle);

--- a/python/test/fifo_test.cu
+++ b/python/test/fifo_test.cu
@@ -6,5 +6,6 @@
 extern "C" __global__ void __launch_bounds__(1024, 1) fifo(mscclpp::FifoDeviceHandle fifo) {
   mscclpp::ProxyTrigger trigger;
   trigger.fst = 123;
+  trigger.snd = 0;
   fifo.push(trigger);
 }

--- a/python/test/test_mscclpp.py
+++ b/python/test/test_mscclpp.py
@@ -527,7 +527,7 @@ def test_fifo(
     poll_for = 100
     for _ in range(poll_for):
         trigger = fifo.poll()
-        if trigger.fst == 123:
+        if trigger is not None and trigger.fst == 123:
             return
         time.sleep(0.1)
     assert False

--- a/src/core/fifo.cc
+++ b/src/core/fifo.cc
@@ -8,8 +8,18 @@
 
 #include "api.h"
 #include "atomic.hpp"
+#include "logger.hpp"
 
 namespace mscclpp {
+
+namespace {
+// size is validated to be a positive power of two, so this is exact.
+uint64_t shiftOf(int size) {
+  uint64_t shift = 0;
+  while ((1 << shift) < size) shift++;
+  return shift;
+}
+}  // namespace
 
 struct Fifo::Impl {
   detail::UniqueGpuHostPtr<ProxyTrigger> triggers;
@@ -17,16 +27,23 @@ struct Fifo::Impl {
   detail::UniqueGpuHostPtr<uint64_t> tail;
   detail::UniqueGpuPtr<uint64_t> tailCache;
   const int size;
+  const uint64_t sizeMask;
+  const uint64_t sizeShift;
 
   Impl(int size)
       : triggers(detail::gpuCallocHostUnique<ProxyTrigger>(size)),
         head(detail::gpuCallocUnique<uint64_t>()),
         tail(detail::gpuCallocHostUnique<uint64_t>()),
         tailCache(detail::gpuCallocUnique<uint64_t>()),
-        size(size) {}
+        size(size),
+        sizeMask(uint64_t(size) - 1),
+        sizeShift(shiftOf(size)) {}
 };
 
 MSCCLPP_API_CPP Fifo::Fifo(int size) {
+  if (size <= 0 || (size & (size - 1)) != 0) {
+    THROW(GPU, Error, ErrorCode::InvalidUsage, "FIFO size must be a positive power of two, got ", size);
+  }
   int device;
   MSCCLPP_CUDATHROW(cudaGetDevice(&device));
   int numaNode = getDeviceNumaNode(device);
@@ -38,19 +55,26 @@ MSCCLPP_API_CPP Fifo::Fifo(int size) {
 
 MSCCLPP_API_CPP Fifo::~Fifo() = default;
 
-MSCCLPP_API_CPP ProxyTrigger Fifo::poll() {
-  ProxyTrigger trigger;
-  ProxyTrigger* ptr = &pimpl_->triggers.get()[*(pimpl_->tail) % pimpl_->size];
-  // we are loading fst first. if fst is non-zero then snd is also valid
-  trigger.fst = atomicLoad(&(ptr->fst), memoryOrderAcquire);
-  trigger.snd = ptr->snd;
-  return trigger;
+MSCCLPP_API_CPP bool Fifo::poll(ProxyTrigger& trigger) {
+  const uint64_t curTail = *(pimpl_->tail);
+  ProxyTrigger* ptr = &pimpl_->triggers.get()[curTail & pimpl_->sizeMask];
+
+  // snd is the commit word: the producer writes it last, with release, carrying the parity of the
+  // lap this slot is on. A match means the payload written before it is visible too.
+  const uint64_t expectedParity = ((curTail >> pimpl_->sizeShift) & 1ULL) ^ 1ULL;
+  ProxyTrigger candidate;
+  candidate.snd = atomicLoad(&(ptr->snd), memoryOrderAcquire);
+  if (candidate.fields.reserved != expectedParity) return false;
+
+  candidate.fields.reserved = 0;
+  candidate.fst = atomicLoad(&(ptr->fst), memoryOrderRelaxed);
+  trigger = candidate;
+  return true;
 }
 
 MSCCLPP_API_CPP void Fifo::pop() {
-  uint64_t curTail = *(pimpl_->tail);
-  pimpl_->triggers.get()[curTail % pimpl_->size].fst = 0;
-  atomicStore(pimpl_->tail.get(), curTail + 1, memoryOrderRelease);
+  // The slot is not cleared: the next lap's parity makes what it holds stale.
+  atomicStore(pimpl_->tail.get(), *(pimpl_->tail) + 1, memoryOrderRelease);
 }
 
 MSCCLPP_API_CPP uint64_t Fifo::tail() const { return *(pimpl_->tail); }
@@ -64,6 +88,8 @@ MSCCLPP_API_CPP FifoDeviceHandle Fifo::deviceHandle() const {
   deviceHandle.tail = pimpl_->tail.get();
   deviceHandle.tailCache = pimpl_->tailCache.get();
   deviceHandle.size = pimpl_->size;
+  deviceHandle.sizeMask = pimpl_->sizeMask;
+  deviceHandle.sizeShift = pimpl_->sizeShift;
   return deviceHandle;
 }
 

--- a/src/core/proxy.cc
+++ b/src/core/proxy.cc
@@ -71,11 +71,9 @@ MSCCLPP_API_CPP void Proxy::start(bool blocking) {
       if (progressHandler) progressHandler();
 
       // Poll to see if we are ready to send anything
-      trigger = fifo->poll();
-      if (trigger.fst == 0 || trigger.snd == 0) {  // TODO: this check is a potential pitfall for custom triggers
-        continue;                                  // there is one in progress
+      if (!fifo->poll(trigger)) {
+        continue;  // no trigger has been committed to this slot yet
       }
-      trigger.snd ^= (uint64_t{1} << uint64_t{63});  // this is where the last bit of snd is reverted.
 
       ProxyHandlerResult result = handler(trigger);
 

--- a/test/unit/fifo_perf_tests.cu
+++ b/test/unit/fifo_perf_tests.cu
@@ -36,14 +36,12 @@ static bool consumePerfTriggers(std::unique_ptr<mscclpp::Fifo>& hostFifo, int nu
   for (int i = 0; i < totalTriggers; ++i) {
     mscclpp::ProxyTrigger trigger;
     uint64_t spin = 0;
-    do {
-      trigger = hostFifo->poll();
+    while (!hostFifo->poll(trigger)) {
       if (spin++ > TIMEOUT_SPINS) {
         return false;
       }
-    } while (trigger.fst == 0 || trigger.snd == 0);
+    }
 
-    trigger.snd ^= ((uint64_t)1 << (uint64_t)63);
     trigger.snd = trigger.snd ^ trigger.fst;
     if (triggerCounts[trigger.snd] + 1 != trigger.fst) {
       return false;  // Validation failed

--- a/test/unit/fifo_tests.cu
+++ b/test/unit/fifo_tests.cu
@@ -17,7 +17,8 @@ __global__ void kernelFifoTest() {
 
   mscclpp::FifoDeviceHandle& fifo = gFifoTestFifoDeviceHandle;
   mscclpp::ProxyTrigger trigger;
-  for (uint64_t i = 1; i < ITER + 1; ++i) {
+  // Payloads start at 0: no trigger value is reserved by the FIFO any more.
+  for (uint64_t i = 0; i < ITER; ++i) {
     trigger.fst = i;
     trigger.snd = i;
     uint64_t curFifoHead = fifo.push(trigger);
@@ -45,24 +46,16 @@ TEST(FifoTest, Fifo) {
   MSCCLPP_CUDATHROW(cudaGetLastError());
 
   mscclpp::ProxyTrigger trigger;
-  trigger.fst = 0;
-  trigger.snd = 0;
-
   uint64_t spin = 0;
   mscclpp::Timer timer(3);
   for (uint64_t i = 0; i < ITER; ++i) {
-    trigger = hostFifo.poll();
-    while (trigger.fst == 0 || trigger.snd == 0) {
-      trigger = hostFifo.poll();
-
+    while (!hostFifo.poll(trigger)) {
       if (spin++ > 1000000) {
-        FAIL() << "Polling is stuck.";
+        FAIL() << "Polling is stuck at trigger " << i;
       }
     }
-    // see `src/proxy.cc` for the reason of this line
-    trigger.snd ^= ((uint64_t)1 << (uint64_t)63);
-    ASSERT_TRUE(trigger.fst == (i + 1));
-    ASSERT_TRUE(trigger.snd == (i + 1));
+    ASSERT_TRUE(trigger.fst == i);
+    ASSERT_TRUE(trigger.snd == i);
     hostFifo.pop();
     spin = 0;
   }
@@ -72,4 +65,97 @@ TEST(FifoTest, Fifo) {
   std::cout << ss.str();
 
   MSCCLPP_CUDATHROW(cudaDeviceSynchronize());
+}
+
+__constant__ mscclpp::FifoDeviceHandle gFifoZeroTestHandle;
+
+// A trigger whose words are both zero must round-trip. Under the old protocol a zero first word
+// meant "not yet written", so this trigger was invisible and the FIFO stalled on its slot.
+__global__ void kernelFifoZeroTrigger(int count) {
+  if (threadIdx.x + blockIdx.x * blockDim.x != 0) return;
+  mscclpp::FifoDeviceHandle& fifo = gFifoZeroTestHandle;
+  for (int i = 0; i < count; ++i) {
+    mscclpp::ProxyTrigger trigger;
+    trigger.fst = 0;
+    trigger.snd = 0;
+    fifo.push(trigger);
+  }
+}
+
+TEST(FifoTest, ZeroTrigger) {
+  const int count = 32;
+  mscclpp::Fifo hostFifo;
+  mscclpp::FifoDeviceHandle devFifo = hostFifo.deviceHandle();
+  MSCCLPP_CUDATHROW(cudaMemcpyToSymbol(gFifoZeroTestHandle, &devFifo, sizeof(devFifo)));
+
+  kernelFifoZeroTrigger<<<1, 1>>>(count);
+  MSCCLPP_CUDATHROW(cudaGetLastError());
+
+  mscclpp::ProxyTrigger trigger;
+  for (int i = 0; i < count; ++i) {
+    uint64_t spin = 0;
+    while (!hostFifo.poll(trigger)) {
+      if (spin++ > 1000000) {
+        FAIL() << "Polling is stuck on a zero-valued trigger " << i;
+      }
+    }
+    ASSERT_TRUE(trigger.fst == 0);
+    ASSERT_TRUE(trigger.snd == 0);
+    hostFifo.pop();
+  }
+  MSCCLPP_CUDATHROW(cudaDeviceSynchronize());
+}
+
+__constant__ mscclpp::FifoDeviceHandle gFifoWrapTestHandle;
+
+// Push exactly a whole number of laps. A parity polarity error shows up here: the consumer either
+// stalls at a lap boundary or accepts the previous lap's trigger a second time.
+__global__ void kernelFifoWrap(int laps, int fifoSize) {
+  if (threadIdx.x + blockIdx.x * blockDim.x != 0) return;
+  mscclpp::FifoDeviceHandle& fifo = gFifoWrapTestHandle;
+  for (int i = 0; i < laps * fifoSize; ++i) {
+    mscclpp::ProxyTrigger trigger;
+    trigger.fst = uint64_t(i);
+    trigger.snd = ~uint64_t(i);
+    trigger.fields.reserved = 0;  // the FIFO owns this bit
+    uint64_t head = fifo.push(trigger);
+    if ((i + 1) % fifoSize == 0) fifo.sync(head);
+  }
+}
+
+TEST(FifoTest, WrapAtLapBoundary) {
+  const int laps = 4;
+  mscclpp::Fifo hostFifo;
+  const int fifoSize = hostFifo.size();
+  mscclpp::FifoDeviceHandle devFifo = hostFifo.deviceHandle();
+  MSCCLPP_CUDATHROW(cudaMemcpyToSymbol(gFifoWrapTestHandle, &devFifo, sizeof(devFifo)));
+
+  kernelFifoWrap<<<1, 1>>>(laps, fifoSize);
+  MSCCLPP_CUDATHROW(cudaGetLastError());
+
+  mscclpp::ProxyTrigger trigger;
+  for (int i = 0; i < laps * fifoSize; ++i) {
+    uint64_t spin = 0;
+    while (!hostFifo.poll(trigger)) {
+      if (spin++ > 10000000) {
+        FAIL() << "Polling is stuck at position " << i << " (lap " << i / fifoSize << ")";
+      }
+    }
+    ASSERT_TRUE(trigger.fst == uint64_t(i));
+    mscclpp::ProxyTrigger expected;
+    expected.snd = ~uint64_t(i);
+    expected.fields.reserved = 0;
+    ASSERT_TRUE(trigger.snd == expected.snd);
+    hostFifo.pop();
+  }
+  MSCCLPP_CUDATHROW(cudaDeviceSynchronize());
+}
+
+TEST(FifoTest, RejectsNonPowerOfTwoSize) {
+  try {
+    mscclpp::Fifo fifo(500);
+    FAIL() << "Expected a non-power-of-two FIFO size to throw";
+  } catch (const mscclpp::Error& e) {
+    EXPECT_TRUE(e.getErrorCode() == mscclpp::ErrorCode::InvalidUsage);
+  }
 }

--- a/test/unit/fifo_tests.cu
+++ b/test/unit/fifo_tests.cu
@@ -46,18 +46,17 @@ TEST(FifoTest, Fifo) {
   MSCCLPP_CUDATHROW(cudaGetLastError());
 
   mscclpp::ProxyTrigger trigger;
-  uint64_t spin = 0;
   mscclpp::Timer timer(3);
   for (uint64_t i = 0; i < ITER; ++i) {
+    mscclpp::Timer pollTimer;
     while (!hostFifo.poll(trigger)) {
-      if (spin++ > 1000000) {
-        FAIL() << "Polling is stuck at trigger " << i;
+      if (pollTimer.elapsed() > 5'000'000) {
+        FAIL() << "Polling timed out at trigger " << i;
       }
     }
     ASSERT_TRUE(trigger.fst == i);
     ASSERT_TRUE(trigger.snd == i);
     hostFifo.pop();
-    spin = 0;
   }
 
   std::stringstream ss;
@@ -90,6 +89,8 @@ TEST(FifoTest, ZeroTrigger) {
 
   kernelFifoZeroTrigger<<<1, 1>>>(count);
   MSCCLPP_CUDATHROW(cudaGetLastError());
+  // count is below the FIFO capacity, so the producer cannot wait for the consumer here.
+  MSCCLPP_CUDATHROW(cudaDeviceSynchronize());
 
   mscclpp::ProxyTrigger trigger;
   for (int i = 0; i < count; ++i) {


### PR DESCRIPTION
## Summary

The FIFO now uses the reserved bit in `ProxyTrigger::snd` as a lap-parity commit bit instead of treating `fst != 0` as readiness.

- `push()` derives parity from the monotonic head position and FIFO size.
- CUDA publishes both words with one `st.global.release.sys.v2.u64`.
- ROCm writes `fst` relaxed, then commits with a release store to `snd`.
- `poll(ProxyTrigger&)` returns readiness separately, acquire-loads `snd`, validates parity, then reads `fst`.
- `pop()` advances `tail` without clearing the slot; the next lap's parity makes stale data invalid.
- FIFO size is now a positive power of two, so slot and lap calculations use a mask and shift.

This removes the payload sentinel and its workarounds: zero-valued triggers now round-trip, zero-byte trigger payloads are legal, and `signal()`/`flush()` no longer pass a dummy `bytes = 1`. It also fixes the custom-trigger hazard called out at the old `proxy.cc` TODO: readiness no longer depends on user payload.

New tests cover a fully zero trigger, exact lap-boundary wraparound, and invalid FIFO sizes. `FifoTest.Fifo` now starts at payload 0 instead of avoiding the sentinel.

## Performance

Same-node before/after runs, Release builds, three `FifoTest.Fifo` samples unless noted:

| GPU | `origin/main` | enhanced FIFO | Improvement |
|---|---:|---:|---:|
| H200, CUDA 12.9 | 2.083 us/iter | 1.973 us/iter | **5.3%** |
| A100-SXM4-80GB, CUDA 12.9 | 3.907 us/iter | 3.559 us/iter | **8.9%** |
| MI300X, ROCm 7.2 | 1.184 us/iter | 1.128 us/iter | **4.7%** |

H200 `PortChannelOneToOneTest.PingPongPerf` also improved within run-to-run variance: 19.38 us/iter baseline vs 19.02 us/iter enhanced. Packet ping-pong was unchanged at about 8.1 us/iter.

The A100 `__threadfence_system()` + relaxed-store special case is removed. Controlled sm_80 measurements show that plain `st.global.release.sys.v2.u64` is now faster:

| A100 code | fence + relaxed | release | Improvement |
|---|---:|---:|---:|
| `origin/main` FIFO | 3.907 us/iter | 3.687 us/iter | **5.6%** |
| enhanced FIFO | 3.687 us/iter | 3.559 us/iter | **3.5%** |

The throughput gain comes primarily from removing the host write that cleared `fst` in every `pop()`.

## Accuracy

- H200: `unit_tests` 37/37; `mp_unit_tests` 29/29.
- MI300X: 26 unit tests passed and 9 skipped, versus 23 passed and 9 skipped on baseline; the three added passes are the new FIFO tests.
- MI300X multiprocess results match baseline: both builds have the same four unrelated environment failures on the node without usable IB.

The custom allgather pattern remains compatible: handlers still receive clean trigger payloads, bit 63 of `snd` remains reserved, and raw triggers may now use `fst == 0` safely.