### PR TITLE
Add MNNVL-only MemoryChannel all-reduce

### DIFF
--- a/include/mscclpp/algorithm.hpp
+++ b/include/mscclpp/algorithm.hpp
@@ -112,6 +112,25 @@ class Algorithm {
                              const std::unordered_map<std::string, uintptr_t>& extras = {},
                              DataType accumDtype = DataType::AUTO) = 0;
 
+  /// Prepare an exact DSL executor context before graph capture.
+  virtual CommResult prepareDsl(std::shared_ptr<Communicator>, const void*, void*, size_t, size_t, DataType,
+                                std::shared_ptr<Executor>, PacketType = PacketType::LL16) {
+    return CommResult::CommInvalidUsage;
+  }
+
+  /// Launch only an exact prepared DSL executor context.
+  virtual CommResult executePreparedDsl(std::shared_ptr<Communicator>, const void*, void*, size_t, size_t, DataType,
+                                        std::shared_ptr<Executor>, cudaStream_t,
+                                        PacketType = PacketType::LL16) {
+    return CommResult::CommInvalidUsage;
+  }
+
+  /// Release one exact prepared DSL executor context.
+  virtual bool releasePreparedDsl(std::shared_ptr<Communicator>, const void*, void*, size_t, size_t, DataType,
+                                  std::shared_ptr<Executor>, PacketType = PacketType::LL16) {
+    return false;
+  }
+
   /// Reset the algorithm state, clearing any cached contexts.
   virtual void reset() = 0;
 };
@@ -292,15 +311,41 @@ class DslAlgorithm : public Algorithm, public AlgorithmBuilder, public std::enab
                      DataType accumDtype = DataType::AUTO) override;
   AlgorithmType type() const override { return AlgorithmType::DSL; }
   Constraint constraint() const override;
+  CommResult prepareDsl(std::shared_ptr<Communicator> comm, const void* input, void* output, size_t inputSize,
+                        size_t outputSize, DataType dtype, std::shared_ptr<Executor> executor,
+                        PacketType packetType = PacketType::LL16) override;
+  CommResult executePreparedDsl(std::shared_ptr<Communicator> comm, const void* input, void* output,
+                                size_t inputSize, size_t outputSize, DataType dtype,
+                                std::shared_ptr<Executor> executor, cudaStream_t stream,
+                                PacketType packetType = PacketType::LL16) override;
+  bool releasePreparedDsl(std::shared_ptr<Communicator> comm, const void* input, void* output, size_t inputSize,
+                          size_t outputSize, DataType dtype, std::shared_ptr<Executor> executor,
+                          PacketType packetType = PacketType::LL16) override;
   void reset() override;
+  size_t preparedContextCount() const;
+  std::vector<uint64_t> preparedContextIds() const;
+  size_t preparedResourceBytes() const;
 
   std::shared_ptr<Algorithm> build() override;
 
  private:
+  struct PreparedDslContext {
+    uint64_t id;
+    std::shared_ptr<ExecutionPlan> plan;
+    std::shared_ptr<Executor> executor;
+  };
+
+  std::string preparedKey(std::shared_ptr<Communicator> comm, const void* input, void* output, size_t inputSize,
+                          size_t outputSize, DataType dtype, PacketType packetType) const;
+  std::string pointerKey(std::shared_ptr<Communicator> comm, const void* input, void* output) const;
+
   ExecutionPlan plan_;
   std::string id_;
   std::unordered_map<std::string, uint64_t> tags_;
   Constraint constraint_;
+  std::unordered_map<std::string, PreparedDslContext> preparedContexts_;
+  std::unordered_map<std::string, std::string> preparedPointerOwners_;
+  uint64_t nextPreparedContextId_ = 1;
 };
 
 /// Request parameters for selecting and executing a collective operation.

--- a/include/mscclpp/executor.hpp
+++ b/include/mscclpp/executor.hpp
@@ -32,6 +32,12 @@ class ExecutionPlan {
   /// Destructor.
   ~ExecutionPlan() = default;
 
+  /// Return the stable source path used to build this execution plan.
+  const std::string& path() const;
+
+  /// Return a stable hash of source identity and execution properties.
+  size_t identityHash() const;
+
   /// Return the human-readable name of the plan.
   const std::string& name() const;
 
@@ -86,6 +92,35 @@ class Executor {
   /// @param packetType Packet type used for low-latency transports (default: LL16).
   void execute(int rank, void* sendbuff, void* recvBuff, size_t sendBuffSize, size_t recvBuffSize, DataType dataType,
                const ExecutionPlan& plan, cudaStream_t stream, PacketType packetType = PacketType::LL16);
+
+  /// Prepare an exact graph-static DSL execution context before capture.
+  bool prepare(int rank, void* sendbuff, void* recvBuff, size_t sendBuffSize, size_t recvBuffSize, DataType dataType,
+               const ExecutionPlan& plan, PacketType packetType = PacketType::LL16);
+
+  /// Launch only an exactly prepared context. A miss returns false before launch.
+  bool executePrepared(int rank, void* sendbuff, void* recvBuff, size_t sendBuffSize, size_t recvBuffSize,
+                       DataType dataType, const ExecutionPlan& plan, cudaStream_t stream,
+                       PacketType packetType = PacketType::LL16);
+
+  /// Launch the sole context of an executor owned by one immutable DSL key.
+  bool executeSolePrepared(int rank, void* sendbuff, void* recvBuff, DataType dataType, cudaStream_t stream,
+                           PacketType packetType = PacketType::LL16);
+
+  /// Release one exact prepared context and all resources owned by it.
+  bool releasePrepared(int rank, void* sendbuff, void* recvBuff, size_t sendBuffSize, size_t recvBuffSize,
+                       DataType dataType, const ExecutionPlan& plan, PacketType packetType = PacketType::LL16);
+
+  /// Release all explicitly prepared contexts without touching legacy lazy contexts.
+  void resetPrepared();
+
+  /// Approximate GPU resource bytes owned by explicitly prepared contexts.
+  size_t preparedResourceBytes() const;
+
+  /// Release cached execution contexts while retaining the communicator and default scratch buffer.
+  ///
+  /// The caller must ensure that no execution is in flight and that all participating ranks reset collectively before
+  /// launching another execution.
+  void reset();
 
  private:
   struct Impl;

--- a/python/csrc/algorithm.cpp
+++ b/python/csrc/algorithm.cpp
@@ -86,6 +86,45 @@ void register_algorithm(nb::module_& m) {
               nb::arg("n_blocks") = 0, nb::arg("n_threads_per_block") = 0, nb::arg("symmetric_memory") = false,
               nb::arg("extras") = std::unordered_map<std::string, uintptr_t>(),
               nb::arg("accum_dtype") = static_cast<int32_t>(DataType::AUTO))
+          .def("prepare_dsl", [](Algorithm& self, std::shared_ptr<Communicator> comm, uintptr_t input,
+                                  uintptr_t output, size_t inputSize, size_t outputSize, DataType dtype,
+                                  std::shared_ptr<Executor> executor, PacketType packetType) {
+                return self.prepareDsl(comm, reinterpret_cast<const void*>(input), reinterpret_cast<void*>(output),
+                                       inputSize, outputSize, dtype, executor, packetType);
+              }, nb::arg("comm"), nb::arg("input"), nb::arg("output"), nb::arg("input_size"),
+              nb::arg("output_size"), nb::arg("dtype"), nb::arg("executor"),
+              nb::arg("packet_type") = PacketType::LL16)
+          .def("execute_prepared_dsl", [](Algorithm& self, std::shared_ptr<Communicator> comm, uintptr_t input,
+                                           uintptr_t output, size_t inputSize, size_t outputSize, DataType dtype,
+                                           std::shared_ptr<Executor> executor, uintptr_t stream,
+                                           PacketType packetType) {
+                return self.executePreparedDsl(comm, reinterpret_cast<const void*>(input),
+                                               reinterpret_cast<void*>(output), inputSize, outputSize, dtype,
+                                               executor, reinterpret_cast<cudaStream_t>(stream), packetType);
+              }, nb::arg("comm"), nb::arg("input"), nb::arg("output"), nb::arg("input_size"),
+              nb::arg("output_size"), nb::arg("dtype"), nb::arg("executor"), nb::arg("stream"),
+              nb::arg("packet_type") = PacketType::LL16)
+          .def("release_prepared_dsl", [](Algorithm& self, std::shared_ptr<Communicator> comm, uintptr_t input,
+                                           uintptr_t output, size_t inputSize, size_t outputSize, DataType dtype,
+                                           std::shared_ptr<Executor> executor, PacketType packetType) {
+                return self.releasePreparedDsl(comm, reinterpret_cast<const void*>(input),
+                                               reinterpret_cast<void*>(output), inputSize, outputSize, dtype,
+                                               executor, packetType);
+              }, nb::arg("comm"), nb::arg("input"), nb::arg("output"), nb::arg("input_size"),
+              nb::arg("output_size"), nb::arg("dtype"), nb::arg("executor"),
+              nb::arg("packet_type") = PacketType::LL16)
+          .def_prop_ro("prepared_context_count", [](Algorithm& self) {
+                auto* dsl = dynamic_cast<DslAlgorithm*>(&self);
+                return dsl == nullptr ? size_t{0} : dsl->preparedContextCount();
+              })
+          .def_prop_ro("prepared_context_ids", [](Algorithm& self) {
+                auto* dsl = dynamic_cast<DslAlgorithm*>(&self);
+                return dsl == nullptr ? std::vector<uint64_t>{} : dsl->preparedContextIds();
+              })
+          .def_prop_ro("prepared_resource_bytes", [](Algorithm& self) {
+                auto* dsl = dynamic_cast<DslAlgorithm*>(&self);
+                return dsl == nullptr ? size_t{0} : dsl->preparedResourceBytes();
+              })
           .def("reset", &Algorithm::reset);
 
   nb::class_<Algorithm::Constraint>(algorithmClass, "Constraint")

--- a/python/mscclpp/_core/algorithm.py
+++ b/python/mscclpp/_core/algorithm.py
@@ -220,6 +220,38 @@ class Algorithm:
             int(accum_dtype),
         )
 
+    def prepare_dsl(self, comm, input_buffer, output_buffer, input_size, output_size, dtype, executor, packet_type):
+        return self._algorithm.prepare_dsl(
+            comm, int(input_buffer), int(output_buffer), input_size, output_size, dtype, executor, packet_type
+        )
+
+    def execute_prepared_dsl(
+        self, comm, input_buffer, output_buffer, input_size, output_size, dtype, executor, stream, packet_type
+    ):
+        return self._algorithm.execute_prepared_dsl(
+            comm, int(input_buffer), int(output_buffer), input_size, output_size, dtype, executor, int(stream),
+            packet_type,
+        )
+
+    def release_prepared_dsl(
+        self, comm, input_buffer, output_buffer, input_size, output_size, dtype, executor, packet_type
+    ):
+        return self._algorithm.release_prepared_dsl(
+            comm, int(input_buffer), int(output_buffer), input_size, output_size, dtype, executor, packet_type
+        )
+
+    @property
+    def prepared_context_count(self):
+        return self._algorithm.prepared_context_count
+
+    @property
+    def prepared_context_ids(self):
+        return self._algorithm.prepared_context_ids
+
+    @property
+    def prepared_resource_bytes(self):
+        return self._algorithm.prepared_resource_bytes
+
     def reset(self):
         """Reset the internal state of the algorithm, if applicable."""
         self._algorithm.reset()

--- a/python/mscclpp/default_algos/__init__.py
+++ b/python/mscclpp/default_algos/__init__.py
@@ -3,5 +3,6 @@
 
 from mscclpp.default_algos.allgather_multi_nodes import allgather_multi_nodes
 from mscclpp.default_algos.allreduce_multi_nodes import allreduce_multi_nodes
+from mscclpp.default_algos.allreduce_mnnvl_only import allreduce_mnnvl_only
 
-__all__ = ["allgather_multi_nodes", "allreduce_multi_nodes"]
+__all__ = ["allgather_multi_nodes", "allreduce_multi_nodes", "allreduce_mnnvl_only"]

--- a/python/mscclpp/default_algos/allreduce_mnnvl_only.py
+++ b/python/mscclpp/default_algos/allreduce_mnnvl_only.py
@@ -1,0 +1,267 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""MNNVL-only hierarchical packet AllReduce.
+
+All data channels are ``MemoryChannel`` instances.  The executor maps memory
+channels exclusively to ``Transport::CudaIpc``; cross-node CudaIpc requires
+fabric-memory handles supplied by MNNVL/IMEX.  No alternate transport is
+constructed by this plan.
+"""
+
+from mscclpp.language.channel import MemoryChannel
+from mscclpp.language.collectives import AllReduce
+from mscclpp.language.program import CollectiveProgram
+from mscclpp.language.rank import Buffer, Rank
+from mscclpp.language.thread_block_group import ThreadBlockGroup
+from mscclpp.language.utils import AlgoSpec
+
+
+def allreduce_mnnvl_only(spec: AlgoSpec, thread_block_group_size: int) -> CollectiveProgram:
+    """Build the retained algorithm with CudaIpc/fabric memory channels only."""
+    if not isinstance(spec.collective, AllReduce):
+        raise ValueError("allreduce_mnnvl_only requires an AllReduce collective")
+    if spec.protocol != "LL":
+        raise ValueError("allreduce_mnnvl_only requires protocol='LL'")
+    if spec.world_size % spec.nranks_per_node != 0:
+        raise ValueError("world_size must be divisible by nranks_per_node")
+    if spec.world_size < spec.nranks_per_node:
+        raise ValueError("world_size must be at least nranks_per_node")
+    # Configuration constants
+    num_nodes = spec.world_size // spec.nranks_per_node
+    gpus_per_node = spec.nranks_per_node
+    total_gpus = num_nodes * gpus_per_node
+    packets_per_gpu = num_nodes
+
+    with CollectiveProgram.from_spec(spec) as prog:
+        # Initialize communication channels and buffers
+        intra_node_memory_channels = {}
+        inter_node_memory_channels = {}
+        scratch_buffers = []
+        thread_block_offset = 1
+        thread_block_groups = []
+        global_intra_node_tbg = ThreadBlockGroup(
+            tb_list=[
+                i
+                for i in range(thread_block_offset, thread_block_offset + (gpus_per_node - 1) * thread_block_group_size)
+            ]
+        )
+        for i in range(gpus_per_node - 1):
+            thread_block_groups.append(
+                ThreadBlockGroup(
+                    tb_list=[
+                        i
+                        for i in range(
+                            thread_block_offset + i * thread_block_group_size,
+                            thread_block_offset + (i + 1) * thread_block_group_size,
+                        )
+                    ]
+                )
+            )
+
+        # Scratch buffer layout (3 contiguous regions):
+        #   Region 1 [0, total_gpus):
+        #     Intra-node reduce-scatter. Each GPU receives chunks from gpus_per_node peers,
+        #     packets_per_gpu each → gpus_per_node * packets_per_gpu = total_gpus slots.
+        #   Region 2 [total_gpus, total_gpus + num_nodes * packets_per_gpu):
+        #     Inter-node exchange. Each GPU receives reduced chunks from num_nodes nodes,
+        #     packets_per_gpu each → num_nodes * packets_per_gpu slots.
+        #   Region 3 [total_gpus + num_nodes * packets_per_gpu, end):
+        #     Intra-node broadcast. Each GPU receives final reduced data from gpus_per_node peers,
+        #     packets_per_gpu each → gpus_per_node * packets_per_gpu = total_gpus slots.
+        # Total = 2 * total_gpus + num_nodes * packets_per_gpu
+        scratch_buffer_size = 2 * total_gpus + packets_per_gpu * num_nodes
+        for node_id in range(num_nodes):
+            for local_gpu_id in range(gpus_per_node):
+                current_rank_id = local_gpu_id + gpus_per_node * node_id
+                scratch_buffers.append(Buffer(current_rank_id, scratch_buffer_size))
+                for peer_gpu_id in range(gpus_per_node):
+                    if peer_gpu_id != local_gpu_id:
+                        peer_rank_id = peer_gpu_id + gpus_per_node * node_id
+                        intra_node_memory_channels[(peer_rank_id, current_rank_id)] = MemoryChannel(
+                            peer_rank_id, current_rank_id
+                        )
+                for peer_node_id in range(num_nodes):
+                    if peer_node_id != node_id:
+                        peer_node_rank_id = (local_gpu_id + gpus_per_node * peer_node_id) % total_gpus
+                        # MemoryChannel forces Executor::setupConnections to request
+                        # Transport::CudaIpc.  Across nodes that succeeds only through
+                        # MNNVL fabric-memory handles; there is no network fallback.
+                        inter_node_memory_channels[(current_rank_id, peer_node_rank_id)] = MemoryChannel(
+                            peer_node_rank_id, current_rank_id
+                        )
+
+        # AllReduce
+        for node_id in range(num_nodes):
+            for local_gpu_id in range(gpus_per_node):
+                current_rank_id = local_gpu_id + gpus_per_node * node_id
+                current_rank = Rank(current_rank_id)
+                input_buffer = current_rank.get_input_buffer()
+
+                # Intra Node Exchange Data
+                for peer_gpu_id in range(gpus_per_node):
+                    peer_rank_id = peer_gpu_id + gpus_per_node * node_id
+                    peer_data_offset = peer_gpu_id * packets_per_gpu
+                    tbg_id = peer_gpu_id if peer_gpu_id < local_gpu_id else peer_gpu_id - 1
+                    if peer_gpu_id != local_gpu_id:
+                        intra_node_memory_channels[(peer_rank_id, current_rank_id)].put_packets(
+                            scratch_buffers[peer_rank_id][
+                                local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu
+                            ],
+                            input_buffer[peer_data_offset : peer_data_offset + packets_per_gpu],
+                            tb_group=thread_block_groups[tbg_id],
+                        )
+
+                # Intra Node Reduce
+                other_gpu_data = [
+                    scratch_buffers[current_rank_id][
+                        packets_per_gpu * gpu_idx : packets_per_gpu * gpu_idx + packets_per_gpu
+                    ]
+                    for gpu_idx in range(gpus_per_node)
+                    if gpu_idx != local_gpu_id
+                ]
+                current_rank.reduce(
+                    input_buffer[local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu],
+                    other_gpu_data,
+                    tb_group=global_intra_node_tbg,
+                    packet=True,
+                )
+
+                current_rank.copy_packets(
+                    scratch_buffers[current_rank_id][
+                        local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu
+                    ],
+                    input_buffer[local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu],
+                    tb_group=global_intra_node_tbg,
+                )
+
+                current_rank.barrier(
+                    tb_list=[i for i in range(thread_block_offset + (gpus_per_node - 1) * thread_block_group_size)]
+                )
+
+                inter_node_offset = total_gpus
+                for peer_node_id in range(num_nodes):
+                    if peer_node_id != node_id:
+                        peer_node_rank_id = (local_gpu_id + gpus_per_node * peer_node_id) % total_gpus
+                        # The source slot was produced by copy_packets, so preserve
+                        # packet framing while writing it through mapped fabric memory.
+                        inter_node_memory_channels[(current_rank_id, peer_node_rank_id)].read_put_packets(
+                            scratch_buffers[peer_node_rank_id][
+                                inter_node_offset
+                                + node_id * packets_per_gpu : inter_node_offset
+                                + node_id * packets_per_gpu
+                                + packets_per_gpu
+                            ],
+                            scratch_buffers[current_rank_id][
+                                local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu
+                            ],
+                            tb=0,
+                        )
+
+                # Reduce Received Data from Remote Node
+                inter_node_data = [
+                    scratch_buffers[current_rank_id][
+                        inter_node_offset
+                        + peer_node_id * packets_per_gpu : inter_node_offset
+                        + peer_node_id * packets_per_gpu
+                        + packets_per_gpu
+                    ]
+                    for peer_node_id in range(num_nodes)
+                    if peer_node_id != node_id
+                ]
+                if inter_node_data:
+                    current_rank.reduce(
+                        input_buffer[
+                            local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu
+                        ],
+                        inter_node_data,
+                        tb_group=global_intra_node_tbg,
+                        packet=True,
+                    )
+
+                current_rank.copy_packets(
+                    scratch_buffers[current_rank_id][
+                        inter_node_offset
+                        + node_id * packets_per_gpu : inter_node_offset
+                        + node_id * packets_per_gpu
+                        + packets_per_gpu
+                    ],
+                    input_buffer[local_gpu_id * packets_per_gpu : local_gpu_id * packets_per_gpu + packets_per_gpu],
+                    tb_group=global_intra_node_tbg,
+                )
+
+                # Broadcast Reduced Data
+                broadcast_offset = total_gpus + packets_per_gpu * num_nodes
+                for peer_gpu_id in range(gpus_per_node):
+                    peer_rank_id = peer_gpu_id + gpus_per_node * node_id
+
+                    if peer_gpu_id != local_gpu_id:
+                        tbg_id = peer_gpu_id if peer_gpu_id < local_gpu_id else peer_gpu_id - 1
+                        intra_node_memory_channels[(peer_rank_id, current_rank_id)].read_put_packets(
+                            scratch_buffers[peer_rank_id][
+                                broadcast_offset
+                                + local_gpu_id * packets_per_gpu : broadcast_offset
+                                + local_gpu_id * packets_per_gpu
+                                + packets_per_gpu
+                            ],
+                            scratch_buffers[current_rank_id][
+                                inter_node_offset
+                                + node_id * packets_per_gpu : inter_node_offset
+                                + node_id * packets_per_gpu
+                                + packets_per_gpu
+                            ],
+                            tb_group=thread_block_groups[tbg_id],
+                        )
+
+                # Unpack Data Received from other GPUs in the same node
+                for peer_gpu_id in range(gpus_per_node):
+                    if peer_gpu_id != local_gpu_id:
+                        tbg_id = peer_gpu_id if peer_gpu_id < local_gpu_id else peer_gpu_id - 1
+                        current_rank.unpack_packets(
+                            input_buffer[
+                                peer_gpu_id * packets_per_gpu : peer_gpu_id * packets_per_gpu + packets_per_gpu
+                            ],
+                            scratch_buffers[current_rank_id][
+                                broadcast_offset
+                                + peer_gpu_id * packets_per_gpu : broadcast_offset
+                                + peer_gpu_id * packets_per_gpu
+                                + packets_per_gpu
+                            ],
+                            tb_group=thread_block_groups[tbg_id],
+                        )
+
+    return prog
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", type=str, help="name of the program")
+    parser.add_argument("--num_gpus", type=int, help="total number of gpus")
+    parser.add_argument("--gpus_per_node", type=int, help="number of gpus per node")
+    parser.add_argument("--tbg", type=int, default=1, help="thread block group size")
+    parser.add_argument("--num_threads_per_block", type=int, default=1024, help="number of threads per block")
+    parser.add_argument("--min_message_size", type=int, default=0, help="minimum message size")
+    parser.add_argument("--max_message_size", type=int, default=2**64 - 1, help="maximum message size")
+
+    args = parser.parse_args()
+
+    spec = AlgoSpec(
+        name=args.name,
+        collective=AllReduce(args.num_gpus, 1, True),
+        nranks_per_node=args.gpus_per_node,
+        world_size=args.num_gpus,
+        in_place=True,
+        instances=1,
+        protocol="LL",
+        auto_sync=False,
+        num_threads_per_block=args.num_threads_per_block,
+        reuse_resources=True,
+        use_double_scratch_buffer=True,
+        min_message_size=args.min_message_size,
+        max_message_size=args.max_message_size,
+    )
+
+    prog = allreduce_mnnvl_only(spec, args.tbg)
+    print(prog.to_json())

--- a/python/test/test_mnnvl_allreduce.py
+++ b/python/test/test_mnnvl_allreduce.py
@@ -1,0 +1,155 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Registered contract and multi-rank tests for the MNNVL-only all-reduce."""
+
+import inspect
+import os
+
+import cupy as cp
+import pytest
+
+import mscclpp
+from mscclpp import CommGroup, DataType, Executor, PacketType
+from mscclpp.default_algos import allreduce_mnnvl_only
+from mscclpp.language.collectives import AllReduce
+from mscclpp.language.utils import AlgoSpec
+
+from .mscclpp_mpi import MpiGroup, parametrize_mpi_groups
+
+
+ROWS = (16, 32, 64, 128, 192, 256, 384, 512)
+HIDDEN = 6144
+
+
+def test_mnnvl_plan_has_no_network_channel_fallback():
+    source = inspect.getsource(allreduce_mnnvl_only)
+    assert "MemoryChannel" in source
+    assert "read_put_packets" in source
+    assert "PortChannel" not in source
+    assert "Ib" not in source and "RDMA" not in source
+
+
+def _spec(world_size: int, ranks_per_node: int) -> AlgoSpec:
+    return AlgoSpec(
+        name="test_mnnvl_allreduce",
+        collective=AllReduce(world_size, 1, True),
+        nranks_per_node=ranks_per_node,
+        world_size=world_size,
+        in_place=True,
+        instances=1,
+        protocol="LL",
+        auto_sync=False,
+        num_threads_per_block=256,
+        reuse_resources=True,
+        use_double_scratch_buffer=True,
+        min_message_size=1 << 10,
+        max_message_size=8 << 20,
+        tags={"test": 1},
+    )
+
+
+@parametrize_mpi_groups(4, 8, 16)
+def test_mnnvl_exact_rows_graph_reuse_mismatch_and_cleanup(mpi_group: MpiGroup):
+    if os.environ.get("MSCCLPP_RUN_MNNVL_TESTS") != "1":
+        pytest.skip("set MSCCLPP_RUN_MNNVL_TESTS=1 on an MNNVL allocation")
+
+    world = mpi_group.comm.size
+    rank = mpi_group.comm.rank
+    ranks_per_node = int(os.environ.get("MSCCLPP_TEST_RANKS_PER_NODE", "4"))
+    if world % ranks_per_node:
+        pytest.skip("world size is not divisible by MSCCLPP_TEST_RANKS_PER_NODE")
+
+    group = CommGroup(mpi_group.comm)
+    executor = Executor(group.communicator)
+    algo = mscclpp.compile(
+        allreduce_mnnvl_only,
+        _spec(world, ranks_per_node),
+        rank,
+        thread_block_group_size=1,
+    )
+    stream = cp.cuda.Stream(non_blocking=True)
+    buffers = []
+
+    for rows in ROWS:
+        if rows % world:
+            continue
+        buf = cp.zeros((rows, HIDDEN), dtype=cp.float16)
+        local_rows = rows // world
+        buf[rank * local_rows : (rank + 1) * local_rows].fill(rank + 1)
+        rc = algo.prepare_dsl(
+            group.communicator,
+            buf.data.ptr,
+            buf.data.ptr,
+            buf.nbytes,
+            buf.nbytes,
+            DataType.float16,
+            executor,
+            PacketType.LL16,
+        )
+        assert int(rc) == 0
+        buffers.append(buf)
+
+    assert algo.prepared_context_count == len(buffers)
+    assert len(set(algo.prepared_context_ids)) == len(buffers)
+    assert algo.prepared_resource_bytes > 0
+
+    # An exact-key mismatch must fail before launching any kernel.
+    first = buffers[0]
+    mismatch = algo.execute_prepared_dsl(
+        group.communicator,
+        first.data.ptr,
+        first.data.ptr,
+        first.nbytes - 16,
+        first.nbytes,
+        DataType.float16,
+        executor,
+        stream.ptr,
+        PacketType.LL16,
+    )
+    assert int(mismatch) != 0
+
+    with stream:
+        stream.begin_capture()
+        for buf in buffers:
+            rc = algo.execute_prepared_dsl(
+                group.communicator,
+                buf.data.ptr,
+                buf.data.ptr,
+                buf.nbytes,
+                buf.nbytes,
+                DataType.float16,
+                executor,
+                stream.ptr,
+                PacketType.LL16,
+            )
+            assert int(rc) == 0
+        graph = stream.end_capture()
+        graph.launch(stream)
+    stream.synchronize()
+
+    def assert_exact_rows():
+        for buf in buffers:
+            expected = cp.repeat(
+                cp.arange(1, world + 1, dtype=cp.float16), buf.shape[0] // world
+            )[:, None]
+            assert bool(cp.all(buf == expected))
+
+    assert_exact_rows()
+    for buf in buffers:
+        buf.fill(0)
+        local_rows = buf.shape[0] // world
+        buf[rank * local_rows : (rank + 1) * local_rows].fill(rank + 1)
+    stream.synchronize()
+    graph.launch(stream)
+    stream.synchronize()
+    assert_exact_rows()
+
+    # Collective release while bootstrap/control peers are still alive.
+    mpi_group.comm.Barrier()
+    algo.reset()
+    assert algo.prepared_context_count == 0
+    assert algo.prepared_resource_bytes == 0
+    mpi_group.comm.Barrier()
+    del executor, algo, group
+    mpi_group.comm.Barrier()

--- a/src/core/algorithm.cc
+++ b/src/core/algorithm.cc
@@ -245,8 +245,97 @@ CommResult DslAlgorithm::execute(std::shared_ptr<Communicator> comm, const void*
 
 std::shared_ptr<Algorithm> DslAlgorithm::build() { return shared_from_this(); }
 
-// TODO: implement this
-void DslAlgorithm::reset() {}
+std::string DslAlgorithm::preparedKey(std::shared_ptr<Communicator> comm, const void* input, void* output,
+                                      size_t inputSize, size_t outputSize, DataType dtype,
+                                      PacketType packetType) const {
+  int device = -1;
+  if (cudaGetDevice(&device) != cudaSuccess) device = -1;
+  return std::to_string(reinterpret_cast<uintptr_t>(comm.get())) + ":" + std::to_string(device) + ":" +
+         std::to_string(reinterpret_cast<uintptr_t>(input)) + ":" +
+         std::to_string(reinterpret_cast<uintptr_t>(output)) + ":" + std::to_string(inputSize) + ":" +
+         std::to_string(outputSize) + ":" + std::to_string(static_cast<int>(dtype)) + ":" +
+         std::to_string(static_cast<int>(packetType)) + ":" + std::to_string(comm->bootstrap()->getNranks()) + ":" +
+         std::to_string(comm->bootstrap()->getNranksPerIpcDomain()) + ":" + std::to_string(plan_.identityHash());
+}
+
+std::string DslAlgorithm::pointerKey(std::shared_ptr<Communicator> comm, const void* input, void* output) const {
+  return std::to_string(reinterpret_cast<uintptr_t>(comm.get())) + ":" +
+         std::to_string(reinterpret_cast<uintptr_t>(input)) + ":" +
+         std::to_string(reinterpret_cast<uintptr_t>(output));
+}
+
+CommResult DslAlgorithm::prepareDsl(std::shared_ptr<Communicator> comm, const void* input, void* output,
+                                    size_t inputSize, size_t outputSize, DataType dtype,
+                                    [[maybe_unused]] std::shared_ptr<Executor> executor, PacketType packetType) {
+  if (!comm || (inputSize != 0 && input == nullptr) || (outputSize != 0 && output == nullptr))
+    return CommResult::CommInvalidUsage;
+  std::string key = preparedKey(comm, input, output, inputSize, outputSize, dtype, packetType);
+  if (preparedContexts_.find(key) != preparedContexts_.end()) return CommResult::CommSuccess;
+  std::string pointers = pointerKey(comm, input, output);
+  auto owner = preparedPointerOwners_.find(pointers);
+  if (owner != preparedPointerOwners_.end() && owner->second != key) return CommResult::CommInvalidUsage;
+
+  int rank = comm->bootstrap()->getRank();
+  auto contextPlan = std::make_shared<ExecutionPlan>(plan_.path(), rank);
+  auto contextExecutor = std::make_shared<Executor>(comm);
+  if (!contextExecutor->prepare(rank, const_cast<void*>(input), output, inputSize, outputSize, dtype, *contextPlan,
+                                packetType))
+    return CommResult::CommInvalidUsage;
+  preparedPointerOwners_[pointers] = key;
+  preparedContexts_.emplace(
+      key, PreparedDslContext{nextPreparedContextId_++, std::move(contextPlan), std::move(contextExecutor)});
+  return CommResult::CommSuccess;
+}
+
+CommResult DslAlgorithm::executePreparedDsl(std::shared_ptr<Communicator> comm, const void* input, void* output,
+                                            size_t inputSize, size_t outputSize, DataType dtype,
+                                            [[maybe_unused]] std::shared_ptr<Executor> executor, cudaStream_t stream,
+                                            PacketType packetType) {
+  if (!comm) return CommResult::CommInvalidUsage;
+  std::string key = preparedKey(comm, input, output, inputSize, outputSize, dtype, packetType);
+  auto context = preparedContexts_.find(key);
+  if (context == preparedContexts_.end()) return CommResult::CommInvalidUsage;
+  return context->second.executor->executeSolePrepared(
+             comm->bootstrap()->getRank(), const_cast<void*>(input), output, dtype, stream, packetType)
+             ? CommResult::CommSuccess
+             : CommResult::CommInvalidUsage;
+}
+
+bool DslAlgorithm::releasePreparedDsl(std::shared_ptr<Communicator> comm, const void* input, void* output,
+                                      size_t inputSize, size_t outputSize, DataType dtype,
+                                      [[maybe_unused]] std::shared_ptr<Executor> executor, PacketType packetType) {
+  if (!comm) return false;
+  std::string key = preparedKey(comm, input, output, inputSize, outputSize, dtype, packetType);
+  auto context = preparedContexts_.find(key);
+  if (context == preparedContexts_.end()) return false;
+  comm->bootstrap()->barrier();
+  context->second.executor->resetPrepared();
+  preparedPointerOwners_.erase(pointerKey(comm, input, output));
+  preparedContexts_.erase(context);
+  comm->bootstrap()->barrier();
+  return true;
+}
+
+void DslAlgorithm::reset() {
+  for (auto& context : preparedContexts_) context.second.executor->resetPrepared();
+  preparedContexts_.clear();
+  preparedPointerOwners_.clear();
+}
+
+size_t DslAlgorithm::preparedContextCount() const { return preparedContexts_.size(); }
+
+std::vector<uint64_t> DslAlgorithm::preparedContextIds() const {
+  std::vector<uint64_t> ids;
+  ids.reserve(preparedContexts_.size());
+  for (const auto& context : preparedContexts_) ids.push_back(context.second.id);
+  return ids;
+}
+
+size_t DslAlgorithm::preparedResourceBytes() const {
+  size_t bytes = 0;
+  for (const auto& context : preparedContexts_) bytes += context.second.executor->preparedResourceBytes();
+  return bytes;
+}
 
 static uint32_t* gDefaultFlagBuffer = nullptr;
 static std::weak_ptr<void> gDefaultFlagBufferWeak;

--- a/src/core/executor/execution_plan.cc
+++ b/src/core/executor/execution_plan.cc
@@ -689,6 +689,20 @@ void ExecutionPlan::Impl::operationsReset() { this->operations.clear(); }
 
 ExecutionPlan::ExecutionPlan(const std::string& planPath, int rank) : impl_(std::make_shared<Impl>(planPath, rank)) {}
 
+const std::string& ExecutionPlan::path() const { return this->impl_->planPath; }
+
+size_t ExecutionPlan::identityHash() const {
+  size_t seed = 42;
+  detail::hashCombine(seed, impl_->planPath);
+  detail::hashCombine(seed, impl_->name);
+  detail::hashCombine(seed, impl_->collective);
+  detail::hashCombine(seed, impl_->rank);
+  detail::hashCombine(seed, impl_->reuseResources);
+  detail::hashCombine(seed, impl_->doubleScratchBuffer);
+  detail::hashCombine(seed, impl_->nThreadsPerBlock);
+  return seed;
+}
+
 const std::string& ExecutionPlan::name() const { return this->impl_->name; }
 
 const std::string& ExecutionPlan::collective() const { return this->impl_->collective; }

--- a/src/core/executor/executor.cc
+++ b/src/core/executor/executor.cc
@@ -229,11 +229,11 @@ struct Executor::Impl {
             nranksPerIpcDomain};
   }
 
-  const ExecutionContext& setupExecutionContext(int rank, void* sendbuff, void* recvbuff, size_t inputMessageSize,
-                                                size_t outputMessageSize, size_t constSrcOffset, size_t constDstOffset,
-                                                size_t sendMemRange, size_t recvMemRange, const ExecutionPlan& plan,
-                                                std::shared_ptr<ProxyService> proxyService, bool forceExactKey = false,
-                                                DataType contextDtype = DataType::AUTO) {
+  ExecutionContext setupExecutionContext(int rank, void* sendbuff, void* recvbuff, size_t inputMessageSize,
+                                         size_t outputMessageSize, size_t constSrcOffset, size_t constDstOffset,
+                                         size_t sendMemRange, size_t recvMemRange, const ExecutionPlan& plan,
+                                         std::shared_ptr<ProxyService> proxyService, bool forceExactKey = false,
+                                         DataType contextDtype = DataType::AUTO) {
     ExecutionContextKey key = {sendbuff, recvbuff, sendMemRange, recvMemRange, plan.impl_->name};
     DeviceExecutionPlanKey devicePlanKey = {inputMessageSize, outputMessageSize, constSrcOffset, constDstOffset};
 
@@ -615,7 +615,7 @@ void Executor::execute(int rank, void* sendbuff, void* recvbuff, size_t sendBuff
   size_t offsetIn = (char*)sendbuff - (char*)sendBasePtr;
   size_t offsetOut = (char*)recvbuff - (char*)recvBasePtr;
 
-  const ExecutionContext& context = this->impl_->setupExecutionContext(
+  ExecutionContext context = this->impl_->setupExecutionContext(
       rank, (void*)sendBasePtr, (void*)recvBasePtr, sendBuffSize, recvBuffSize, offsetIn, offsetOut, sendMemRange,
       recvMemRange, plan, this->impl_->proxyService, false, dataType);
   this->impl_->launchKernel(context, rank, sendbuff, recvbuff, dataType, stream, packetType);

--- a/src/core/executor/executor.cc
+++ b/src/core/executor/executor.cc
@@ -51,6 +51,45 @@ struct DeviceExecutionPlanKey {
   }
 };
 
+struct PreparedExecutionKey {
+  int rank;
+  void* sendBuff;
+  void* recvBuff;
+  size_t sendBuffSize;
+  size_t recvBuffSize;
+  int dataType;
+  int packetType;
+  uintptr_t planIdentity;
+  size_t planHash;
+  int worldSize;
+  int ipcDomainSize;
+
+  bool operator==(const PreparedExecutionKey& other) const {
+    return rank == other.rank && sendBuff == other.sendBuff && recvBuff == other.recvBuff &&
+           sendBuffSize == other.sendBuffSize && recvBuffSize == other.recvBuffSize && dataType == other.dataType &&
+           packetType == other.packetType && planIdentity == other.planIdentity && planHash == other.planHash &&
+           worldSize == other.worldSize && ipcDomainSize == other.ipcDomainSize;
+  }
+};
+
+struct PreparedExecutionKeyHash {
+  size_t operator()(const PreparedExecutionKey& key) const {
+    size_t seed = 42;
+    detail::hashCombine(seed, key.rank);
+    detail::hashCombine(seed, key.sendBuff);
+    detail::hashCombine(seed, key.recvBuff);
+    detail::hashCombine(seed, key.sendBuffSize);
+    detail::hashCombine(seed, key.recvBuffSize);
+    detail::hashCombine(seed, key.dataType);
+    detail::hashCombine(seed, key.packetType);
+    detail::hashCombine(seed, key.planIdentity);
+    detail::hashCombine(seed, key.planHash);
+    detail::hashCombine(seed, key.worldSize);
+    detail::hashCombine(seed, key.ipcDomainSize);
+    return seed;
+  }
+};
+
 }  // namespace mscclpp
 
 namespace std {
@@ -144,6 +183,7 @@ struct Executor::Impl {
   std::shared_ptr<char> defaultScratchBuffer;
   std::shared_ptr<ProxyService> proxyService;
   std::unordered_map<ExecutionContextKey, ExecutionContext> contexts;
+  std::unordered_map<PreparedExecutionKey, ExecutionContextKey, PreparedExecutionKeyHash> preparedContexts;
 
   Impl(std::shared_ptr<Communicator> comm, std::shared_ptr<char> defaultScratchBuffer = nullptr)
       : comm(comm), defaultScratchBuffer(defaultScratchBuffer) {
@@ -153,18 +193,57 @@ struct Executor::Impl {
     this->proxyService = std::make_shared<ProxyService>();
     this->proxyService->startProxy(true);
   }
-  ~Impl() = default;
+  ~Impl() {
+    if (proxyService) proxyService->stopProxy();
+  }
 
-  ExecutionContext setupExecutionContext(int rank, void* sendbuff, void* recvbuff, size_t inputMessageSize,
-                                         size_t outputMessageSize, size_t constSrcOffset, size_t constDstOffset,
-                                         size_t sendMemRange, size_t recvMemRange, const ExecutionPlan& plan,
-                                         std::shared_ptr<ProxyService> proxyService) {
+  size_t planHash(const ExecutionPlan& plan) const {
+    size_t seed = 42;
+    detail::hashCombine(seed, plan.impl_->planPath);
+    detail::hashCombine(seed, plan.impl_->name);
+    detail::hashCombine(seed, plan.impl_->collective);
+    detail::hashCombine(seed, plan.impl_->rank);
+    detail::hashCombine(seed, plan.impl_->reuseResources);
+    detail::hashCombine(seed, plan.impl_->doubleScratchBuffer);
+    detail::hashCombine(seed, plan.impl_->nThreadsPerBlock);
+    return seed;
+  }
+
+  size_t preparedResourceBytes() const {
+    size_t bytes = 0;
+    for (const auto& prepared : preparedContexts) {
+      auto context = contexts.find(prepared.second);
+      if (context == contexts.end()) continue;
+      bytes += context->second.scratchBufferSize;
+      for (const auto& plan : context->second.deviceExecutionPlans)
+        bytes += plan.second.size() * sizeof(DeviceExecutionPlan);
+    }
+    return bytes;
+  }
+
+  PreparedExecutionKey preparedKey(int rank, void* sendbuff, void* recvbuff, size_t sendBuffSize,
+                                   size_t recvBuffSize, DataType dataType, const ExecutionPlan& plan,
+                                   PacketType packetType) const {
+    return {rank, sendbuff, recvbuff, sendBuffSize, recvBuffSize, static_cast<int>(dataType),
+            static_cast<int>(packetType), reinterpret_cast<uintptr_t>(plan.impl_.get()), planHash(plan), nranks,
+            nranksPerIpcDomain};
+  }
+
+  const ExecutionContext& setupExecutionContext(int rank, void* sendbuff, void* recvbuff, size_t inputMessageSize,
+                                                size_t outputMessageSize, size_t constSrcOffset, size_t constDstOffset,
+                                                size_t sendMemRange, size_t recvMemRange, const ExecutionPlan& plan,
+                                                std::shared_ptr<ProxyService> proxyService, bool forceExactKey = false,
+                                                DataType contextDtype = DataType::AUTO) {
     ExecutionContextKey key = {sendbuff, recvbuff, sendMemRange, recvMemRange, plan.impl_->name};
     DeviceExecutionPlanKey devicePlanKey = {inputMessageSize, outputMessageSize, constSrcOffset, constDstOffset};
 
     // The plan is not related to any specific input/output message size or memory address
-    if (plan.impl_->reuseResources) {
+    if (plan.impl_->reuseResources && !forceExactKey) {
       key = {nullptr, nullptr, 0, 0, plan.impl_->name};
+    } else if (forceExactKey) {
+      key.plan += "#prepared:" + std::to_string(inputMessageSize) + ":" + std::to_string(outputMessageSize) + ":" +
+                  std::to_string(constSrcOffset) + ":" + std::to_string(constDstOffset) + ":" +
+                  std::to_string(static_cast<int>(contextDtype));
     }
     if (this->contexts.find(key) != this->contexts.end()) {
       auto& devicePlans = this->contexts[key].deviceExecutionPlans;
@@ -536,10 +615,80 @@ void Executor::execute(int rank, void* sendbuff, void* recvbuff, size_t sendBuff
   size_t offsetIn = (char*)sendbuff - (char*)sendBasePtr;
   size_t offsetOut = (char*)recvbuff - (char*)recvBasePtr;
 
-  ExecutionContext context = this->impl_->setupExecutionContext(
+  const ExecutionContext& context = this->impl_->setupExecutionContext(
       rank, (void*)sendBasePtr, (void*)recvBasePtr, sendBuffSize, recvBuffSize, offsetIn, offsetOut, sendMemRange,
-      recvMemRange, plan, this->impl_->proxyService);
+      recvMemRange, plan, this->impl_->proxyService, false, dataType);
   this->impl_->launchKernel(context, rank, sendbuff, recvbuff, dataType, stream, packetType);
+}
+
+bool Executor::prepare(int rank, void* sendbuff, void* recvbuff, size_t sendBuffSize, size_t recvBuffSize,
+                       DataType dataType, const ExecutionPlan& plan, PacketType packetType) {
+  auto preparedKey = impl_->preparedKey(rank, sendbuff, recvbuff, sendBuffSize, recvBuffSize, dataType, plan, packetType);
+  if (impl_->preparedContexts.find(preparedKey) != impl_->preparedContexts.end()) return true;
+  if ((sendBuffSize != 0 && sendbuff == nullptr) || (recvBuffSize != 0 && recvbuff == nullptr)) return false;
+
+  CUdeviceptr sendBasePtr = 0, recvBasePtr = 0;
+  size_t sendMemRange = 0, recvMemRange = 0;
+  if (sendBuffSize != 0) MSCCLPP_CUTHROW(cuMemGetAddressRange(&sendBasePtr, &sendMemRange, (CUdeviceptr)sendbuff));
+  if (recvBuffSize != 0) MSCCLPP_CUTHROW(cuMemGetAddressRange(&recvBasePtr, &recvMemRange, (CUdeviceptr)recvbuff));
+  size_t offsetIn = sendBuffSize == 0 ? 0 : (char*)sendbuff - (char*)sendBasePtr;
+  size_t offsetOut = recvBuffSize == 0 ? 0 : (char*)recvbuff - (char*)recvBasePtr;
+
+  impl_->setupExecutionContext(rank, (void*)sendBasePtr, (void*)recvBasePtr, sendBuffSize, recvBuffSize, offsetIn,
+                               offsetOut, sendMemRange, recvMemRange, plan, impl_->proxyService, true, dataType);
+  ExecutionContextKey contextKey = {
+      (void*)sendBasePtr, (void*)recvBasePtr, sendMemRange, recvMemRange,
+      plan.impl_->name + "#prepared:" + std::to_string(sendBuffSize) + ":" + std::to_string(recvBuffSize) + ":" +
+          std::to_string(offsetIn) + ":" + std::to_string(offsetOut) + ":" +
+          std::to_string(static_cast<int>(dataType))};
+  impl_->preparedContexts.emplace(preparedKey, std::move(contextKey));
+  return true;
+}
+
+bool Executor::executePrepared(int rank, void* sendbuff, void* recvbuff, size_t sendBuffSize, size_t recvBuffSize,
+                               DataType dataType, const ExecutionPlan& plan, cudaStream_t stream,
+                               PacketType packetType) {
+  auto key = impl_->preparedKey(rank, sendbuff, recvbuff, sendBuffSize, recvBuffSize, dataType, plan, packetType);
+  auto prepared = impl_->preparedContexts.find(key);
+  if (prepared == impl_->preparedContexts.end()) return false;
+  auto context = impl_->contexts.find(prepared->second);
+  if (context == impl_->contexts.end()) return false;
+  impl_->launchKernel(context->second, rank, sendbuff, recvbuff, dataType, stream, packetType);
+  return true;
+}
+
+bool Executor::executeSolePrepared(int rank, void* sendbuff, void* recvbuff, DataType dataType, cudaStream_t stream,
+                                   PacketType packetType) {
+  if (impl_->preparedContexts.size() != 1) return false;
+  auto prepared = impl_->preparedContexts.begin();
+  auto context = impl_->contexts.find(prepared->second);
+  if (context == impl_->contexts.end()) return false;
+  impl_->launchKernel(context->second, rank, sendbuff, recvbuff, dataType, stream, packetType);
+  return true;
+}
+
+bool Executor::releasePrepared(int rank, void* sendbuff, void* recvbuff, size_t sendBuffSize, size_t recvBuffSize,
+                               DataType dataType, const ExecutionPlan& plan, PacketType packetType) {
+  auto key = impl_->preparedKey(rank, sendbuff, recvbuff, sendBuffSize, recvBuffSize, dataType, plan, packetType);
+  auto prepared = impl_->preparedContexts.find(key);
+  if (prepared == impl_->preparedContexts.end()) return false;
+  impl_->contexts.erase(prepared->second);
+  impl_->preparedContexts.erase(prepared);
+  return true;
+}
+
+void Executor::resetPrepared() {
+  for (const auto& entry : impl_->preparedContexts) impl_->contexts.erase(entry.second);
+  impl_->preparedContexts.clear();
+}
+
+size_t Executor::preparedResourceBytes() const { return impl_->preparedResourceBytes(); }
+
+void Executor::reset() {
+  this->impl_->proxyService->stopProxy();
+  this->impl_->contexts.clear();
+  this->impl_->proxyService = std::make_shared<ProxyService>();
+  this->impl_->proxyService->startProxy(true);
 }
 
 Executor::~Executor() = default;

--- a/test/deploy/pytest.sh
+++ b/test/deploy/pytest.sh
@@ -3,7 +3,7 @@ set -e
 
 if [[ $OMPI_COMM_WORLD_RANK == 0 ]]
 then
-  pytest /root/mscclpp/python/test/test_mscclpp.py -x -v
+  pytest /root/mscclpp/python/test/test_mscclpp.py /root/mscclpp/python/test/test_mnnvl_allreduce.py -x -v
 else
-  pytest /root/mscclpp/python/test/test_mscclpp.py -x 2>&1 >/dev/null
+  pytest /root/mscclpp/python/test/test_mscclpp.py /root/mscclpp/python/test/test_mnnvl_allreduce.py -x 2>&1 >/dev/null
 fi


### PR DESCRIPTION
## Repository placement

This PR owns the native/default MSCCL++ implementation and graph-static DSL lifecycle. It is based on the public runtime source pinned by the framework stack (`eb9625429ace31f984f83dbaa63ff85dab30bea5`).

## Semantics

- Uses `MemoryChannel` for intra- and inter-node edges.
- Uses `read_put_packets` for inter-node packet movement.
- Cross-node MemoryChannel resolves through CudaIpc/MNNVL fabric memory.
- The new plan has no PortChannel, IB, RDMA, or network fallback.
- Adds exact prepared-context keys, graph-only prepared execution, mismatch rejection, resource accounting, collective release, and proxy shutdown.

## Validation

- Corrected wheel built from this committed tree.
- Focused framework suite: 16 tests passed.
- Exact-row graph/correctness gates: TP4, TP8, and TP16 passed with every process/container exit code 0.
- Exact TP16 GLM-5.2 functional workload passed for 2,000 decode steps under the benchmark's documented forced-balanced routing mode.
- Natural-routing TP16 smoke passed separately.
- No performance promotion is claimed.

## Sanitized evidence

- Public evidence package SHA-256: `84c2713a007a4be6fbbec5dfaf270ea0ad703c1d1817d0e48b868dfbb6272b2c`
- MSCCL++ bundle SHA-256: `7e16d5564f797abc65e4264de452897c0b614eb4393db12f1ef544f53a60ac9b`
- Automated public-evidence denylist scan: 0 findings.

Private run manifests and logs are intentionally not published.

## Dependency

Base branch: `chhwang/glm52-version-b-runtime` at `eb9625429ace31f984f83dbaa63ff85dab30bea5`.