### PR TITLE
Improve Python bootstrap thread and process-group handling

### DIFF
--- a/python/csrc/core_py.cpp
+++ b/python/csrc/core_py.cpp
@@ -63,20 +63,20 @@ void register_core(nb::module_& m) {
             void* data = reinterpret_cast<void*>(ptr);
             self->send(data, size, peer, tag);
           },
-          nb::arg("data"), nb::arg("size"), nb::arg("peer"), nb::arg("tag"))
+          nb::arg("data"), nb::arg("size"), nb::arg("peer"), nb::arg("tag"), nb::call_guard<nb::gil_scoped_release>())
       .def(
           "recv",
           [](Bootstrap* self, uintptr_t ptr, size_t size, int peer, int tag) {
             void* data = reinterpret_cast<void*>(ptr);
             self->recv(data, size, peer, tag);
           },
-          nb::arg("data"), nb::arg("size"), nb::arg("peer"), nb::arg("tag"))
+          nb::arg("data"), nb::arg("size"), nb::arg("peer"), nb::arg("tag"), nb::call_guard<nb::gil_scoped_release>())
       .def("all_gather", &Bootstrap::allGather, nb::arg("allData"), nb::arg("size"))
       .def("barrier", &Bootstrap::barrier)
       .def("send", static_cast<void (Bootstrap::*)(const std::vector<char>&, int, int)>(&Bootstrap::send),
-           nb::arg("data"), nb::arg("peer"), nb::arg("tag"))
+           nb::arg("data"), nb::arg("peer"), nb::arg("tag"), nb::call_guard<nb::gil_scoped_release>())
       .def("recv", static_cast<void (Bootstrap::*)(std::vector<char>&, int, int)>(&Bootstrap::recv), nb::arg("data"),
-           nb::arg("peer"), nb::arg("tag"));
+           nb::arg("peer"), nb::arg("tag"), nb::call_guard<nb::gil_scoped_release>());
 
   nb::class_<UniqueId>(m, "CppUniqueId")
       .def(nb::init<>())

--- a/python/mscclpp/_core/comm.py
+++ b/python/mscclpp/_core/comm.py
@@ -20,7 +20,6 @@ from mscclpp._mscclpp import (
     CppTransportFlags,
 )
 import numpy as np
-import pickle
 
 from mscclpp.utils import is_torch_tensor
 
@@ -54,14 +53,12 @@ class CommGroup:
                 import torch
                 import torch.distributed as dist
 
-                if rank == 0:
-                    uniq_id_global = uniq_id
-                    pickled_data = pickle.dumps(uniq_id)
-                    data_tensor = torch.frombuffer(bytearray(pickled_data), dtype=torch.uint8).clone()
-                else:
-                    data_tensor = torch.zeros(256, dtype=torch.uint8)
-                dist.broadcast(data_tensor, group=torch_group, group_src=0)
-                uniq_id_global = pickle.loads(data_tensor.numpy().tobytes())
+                backend = str(dist.get_backend(torch_group)).lower()
+                device = torch.device("cuda", torch.cuda.current_device()) if "nccl" in backend else torch.device("cpu")
+                object_list = [uniq_id]
+                group_root = dist.get_global_rank(torch_group, 0)
+                dist.broadcast_object_list(object_list, src=group_root, group=torch_group, device=device)
+                uniq_id_global = object_list[0]
             self.bootstrap.initialize(uniq_id_global)
         elif not interfaceIpPortTrio == "":
             assert rank >= 0 and size >= 1

--- a/python/mscclpp/_core/comm.py
+++ b/python/mscclpp/_core/comm.py
@@ -50,14 +50,11 @@ class CommGroup:
 
                 uniq_id_global = mpi_comm.bcast(uniq_id, 0)
             else:
-                import torch
                 import torch.distributed as dist
 
-                backend = str(dist.get_backend(torch_group)).lower()
-                device = torch.device("cuda", torch.cuda.current_device()) if "nccl" in backend else torch.device("cpu")
                 object_list = [uniq_id]
                 group_root = dist.get_global_rank(torch_group, 0)
-                dist.broadcast_object_list(object_list, src=group_root, group=torch_group, device=device)
+                dist.broadcast_object_list(object_list, src=group_root, group=torch_group)
                 uniq_id_global = object_list[0]
             self.bootstrap.initialize(uniq_id_global)
         elif not interfaceIpPortTrio == "":


### PR DESCRIPTION
## Summary
- release the Python GIL around both pointer and vector bootstrap `send`/`recv` bindings
- broadcast bootstrap unique IDs through the specified Torch process group instead of a fixed-size serialized tensor
- rely on Torch to select the process-group-compatible broadcast device

This isolates the non-EP bootstrap changes from #852.

## Validation
- `./tools/lint.sh`
- `cmake --build build --target mscclpp_py -j$(nproc)`
- `python3 -m py_compile python/mscclpp/_core/comm.py`