### PR TITLE
Allow defaults in EP block count pairs

### DIFF
--- a/python/mscclpp/ep/README.md
+++ b/python/mscclpp/ep/README.md
@@ -78,7 +78,8 @@ class MoECommunicatorConfig:
     # THROUGHPUT: dispatch/combine blocks; defaults to (20, 20)
     # Counts are total grid sizes.
     # A single value uses the mode-specific relation for both operations.
-    num_blocks: Optional[int | tuple[int, int]] = None
+    # Either tuple entry may be None to use its mode default.
+    num_blocks: Optional[int | tuple[Optional[int], Optional[int]]] = None
 
     # Overlap
     enable_overlap: bool = False
@@ -148,7 +149,7 @@ a later version can add an explicit `expert_map` for arbitrary placement.
 | `invalid_token_expert_id` | Sentinel for rank-major non-local and padding entries; defaults to `num_experts` |
 | `max_tokens_per_rank` | dispatch capacity |
 | scratch buffers | internally sized from mode, capacity, topology, and shape |
-| `num_blocks` | Total dispatch/combine grid sizes. A pair configures them independently. A single `N` resolves to `(N, N - 2)` in latency mode and `(N, N)` in throughput mode |
+| `num_blocks` | Total dispatch/combine grid sizes. A pair configures them independently, and `None` uses that entry's mode default. A single `N` resolves to `(N, N - 2)` in latency mode and `(N, N)` in throughput mode |
 | `dispatch_config`, `combine_config` | context-specific tuning configs |
 | `overlap_capability` | whether selected MLP/backend supports notify |
 

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -57,9 +57,10 @@ class MoECommunicatorConfig:
     # Quantization defaults
     quant: Optional[QuantConfig] = None
 
-    # Launch tuning. Accepts one count or a (dispatch, combine) pair.
+    # Launch tuning. Accepts one count or a (dispatch, combine) pair;
+    # either pair entry may be None to use its mode default.
     # Both values are total grid sizes.
-    num_blocks: Optional[Union[int, Tuple[int, int]]] = None
+    num_blocks: Optional[Union[int, Tuple[Optional[int], Optional[int]]]] = None
     combine_mode: CombineMode = CombineMode.RANK_LOCAL_REDUCE
     enable_overlap: bool = False
 

--- a/python/mscclpp/ep/utils.py
+++ b/python/mscclpp/ep/utils.py
@@ -15,7 +15,7 @@ from mscclpp.ep.types import QuantConfig
 
 
 def resolve_num_blocks(
-    num_blocks: Optional[Union[int, Tuple[int, int]]],
+    num_blocks: Optional[Union[int, Tuple[Optional[int], Optional[int]]]],
     *,
     default: Tuple[int, int],
     scalar_combine_offset: int,
@@ -29,9 +29,11 @@ def resolve_num_blocks(
         raise TypeError("num_blocks must be an int or a (dispatch, combine) tuple")
     if len(num_blocks) != 2:
         raise ValueError("num_blocks tuple must contain exactly (dispatch, combine)")
-    if any(type(value) is not int for value in num_blocks):
-        raise TypeError("num_blocks tuple values must be ints")
-    return num_blocks
+    if any(value is not None and type(value) is not int for value in num_blocks):
+        raise TypeError("num_blocks tuple values must be ints or None")
+    dispatch_blocks = default[0] if num_blocks[0] is None else num_blocks[0]
+    combine_blocks = default[1] if num_blocks[1] is None else num_blocks[1]
+    return dispatch_blocks, combine_blocks
 
 
 def resolve_dispatch_data_type(quant: Optional[QuantConfig]) -> DispatchDataType:


### PR DESCRIPTION
## Summary
- allow either entry in a `(dispatch, combine)` block-count pair to be `None`
- resolve `None` entries independently from the selected mode defaults
- document optional tuple entries in `MoECommunicatorConfig`

Examples:
- latency `(None, 32)` resolves to `(130, 32)`
- latency `(64, None)` resolves to `(64, 128)`
- throughput `(None, 8)` resolves to `(20, 8)`

## Validation
- `./tools/lint.sh`
- checked optional tuple and scalar resolution paths