### PR TITLE
Use latest ROCm 7 tag for RCCL tests

### DIFF
--- a/.azure-pipelines/templates/rccl-test.yml
+++ b/.azure-pipelines/templates/rccl-test.yml
@@ -32,13 +32,18 @@ steps:
     name: InstallRcclTests
     displayName: Install RCCL Tests
     remoteScript: |
-      LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ROCm/rocm-systems/releases/latest | grep tag_name | cut -d\" -f4)
-      if [ -z "$LATEST_TAG" ]; then
-        echo "Failed to fetch latest ROCm Systems tag"
+      RCCL_TESTS_TAG=$(
+        git ls-remote --refs --tags https://github.com/ROCm/rocm-systems.git 'refs/tags/therock-7.*' |
+          awk '$2 ~ /^refs\/tags\/therock-7(\.[0-9]+)+$/ {sub(/^refs\/tags\//, "", $2); print $2}' |
+          sort -V |
+          tail -n 1
+      )
+      if [ -z "$RCCL_TESTS_TAG" ]; then
+        echo "Failed to find a therock-7.x ROCm Systems tag"
         exit 1
       fi
       cd
-      git clone --filter=blob:none --no-checkout --branch $LATEST_TAG https://github.com/ROCm/rocm-systems.git
+      git clone --depth 1 --filter=blob:none --no-checkout --branch "$RCCL_TESTS_TAG" https://github.com/ROCm/rocm-systems.git
       cd rocm-systems
       git sparse-checkout init --cone
       git sparse-checkout set projects/rccl-tests


### PR DESCRIPTION
## Summary
- select the highest-versioned `therock-7.x` tag instead of GitHub’s global latest release
- prevent ROCm 6.2 and 7.2 jobs from consuming the incompatible `therock-10.0` tests
- use a shallow sparse clone for the selected release

## Validation
- current tag selection resolves to `therock-7.14.1`
- `./tools/lint.sh`