### PR TITLE
Port token-major latency EP path

### DIFF
--- a/include/mscclpp/ext/ep/types.hpp
+++ b/include/mscclpp/ext/ep/types.hpp
@@ -26,6 +26,8 @@ enum class MoEMode {
 enum class DispatchLayout {
   /// Rows grouped by local expert.
   EXPERT_MAJOR,
+  /// Compact expert-grouped rows for KI ragged matmul input.
+  KI_RAGGED,
   /// Dynamically sized token-major rows used by throughput mode.
   TOKEN_MAJOR,
   /// Fixed-stride rows grouped by source rank.
@@ -47,6 +49,8 @@ enum class CombineMode {
 enum class DispatchDataType {
   /// Unquantized BF16 payload.
   BF16,
+  /// Unquantized FP16 payload.
+  FP16,
   /// FP8 E4M3 payload with one floating-point scale per 128 hidden elements.
   FP8_E4M3
 };

--- a/include/mscclpp/ext/ep/types.hpp
+++ b/include/mscclpp/ext/ep/types.hpp
@@ -26,8 +26,6 @@ enum class MoEMode {
 enum class DispatchLayout {
   /// Rows grouped by local expert.
   EXPERT_MAJOR,
-  /// Compact expert-grouped rows for KI ragged matmul input.
-  KI_RAGGED,
   /// Dynamically sized token-major rows used by throughput mode.
   TOKEN_MAJOR,
   /// Fixed-stride rows grouped by source rank.

--- a/include/mscclpp/ext/ep/types.hpp
+++ b/include/mscclpp/ext/ep/types.hpp
@@ -29,7 +29,9 @@ enum class DispatchLayout {
   /// Dynamically sized token-major rows used by throughput mode.
   TOKEN_MAJOR,
   /// Fixed-stride rows grouped by source rank.
-  RANK_MAJOR
+  RANK_MAJOR,
+  /// Fixed-stride source-rank rows expanded by original token and top-k slot.
+  RANK_MAJOR_TOPK_EXPANDED
 };
 
 /// Combine algorithm.

--- a/include/mscclpp/ext/ep/types.hpp
+++ b/include/mscclpp/ext/ep/types.hpp
@@ -47,8 +47,6 @@ enum class CombineMode {
 enum class DispatchDataType {
   /// Unquantized BF16 payload.
   BF16,
-  /// Unquantized FP16 payload.
-  FP16,
   /// FP8 E4M3 payload with one floating-point scale per 128 hidden elements.
   FP8_E4M3
 };

--- a/python/mscclpp/ep/README.md
+++ b/python/mscclpp/ep/README.md
@@ -196,6 +196,7 @@ Use `DispatchLayout` instead of string literals for this field:
 | `DispatchLayout.TOKEN_MAJOR` | Throughput: `[total_recv_tokens, hidden]` |
 | `DispatchLayout.EXPERT_MAJOR` | `[num_local_experts, max_slots_per_expert, hidden]` |
 | `DispatchLayout.RANK_MAJOR` | Latency or throughput: `[world_size * max_tokens_per_rank, hidden]` |
+| `DispatchLayout.RANK_MAJOR_TOPK_EXPANDED` | Latency: `[world_size * max_tokens_per_rank * topk, hidden]` |
 
 ## MoECommunicator methods
 
@@ -288,6 +289,7 @@ class DispatchLayout(str, Enum):
     EXPERT_MAJOR = "expert_major"
     TOKEN_MAJOR = "token_major"
     RANK_MAJOR = "rank_major"
+    RANK_MAJOR_TOPK_EXPANDED = "rank_major_topk_expanded"
 
 
 @dataclass
@@ -647,11 +649,13 @@ dimension replaced by the scale dimension.
 Examples:
 
 ```text
-token-major tokens:   throughput [total_recv_tokens, H]; latency rank-major [world_size * max_tokens_per_rank, H]
-rank-major scales:    not yet supported
+token-major tokens:              throughput [total_recv_tokens, H]
+rank-major tokens:               latency/throughput [world_size * max_tokens_per_rank, H]
+rank-major-topk-expanded tokens: latency [world_size * max_tokens_per_rank * topk, H]
+rank-major scales:               not yet supported
 
-expert-major tokens:  [num_local_experts, max_slots, H]
-expert-major scales:  [num_local_experts, max_slots, S]
+expert-major tokens:             [num_local_experts, max_slots, H]
+expert-major scales:             [num_local_experts, max_slots, S]
 ```
 
 `S` is `H / 128` with FP32 values for `FP8_E4M3`.
@@ -660,18 +664,21 @@ expert-major scales:  [num_local_experts, max_slots, S]
 
 The MLP consumes `dispatch_out`, not the original token-major input.
 
-For token-major output, the local MLP consumes each token once, runs the local
+For rank-major output, the local MLP consumes each token once, runs the local
 experts selected by `topk_ids`, applies `weights`, and returns one pre-reduced
 rank partial in the same row:
 
 ```python
-rank_partial = token_major_mlp(
+rank_partial = rank_major_mlp(
     dispatch_out.tokens,
     dispatch_out.topk_ids,
     dispatch_out.weights,
     dispatch_out.quant,
 )
 ```
+
+For rank-major-top-k-expanded output, each valid top-k slot owns a fixed sparse
+row in `dispatch_out.tokens`, and combine applies the original routing weights.
 
 For padded expert-major output:
 
@@ -683,12 +690,14 @@ expert_output = expert_major_mlp(
 )
 ```
 
-The MLP must preserve the dispatch output layout and row/slot order. For
-token-major output, combine assumes each row is already weighted and reduced
-across all local experts. With rank-major output, `CombineMode.DIRECT_SEND`
-consumes weighted route rows and performs the full top-k reduction in combine.
-With expert-major output, it retains its existing expert-row direct-send
-behavior.
+The MLP must preserve the dispatch output layout and row/slot order.
+For rank-major `RANK_LOCAL_REDUCE`, combine assumes each row is already
+weighted and reduced across all local experts.
+For rank-major `DIRECT_SEND`, combine consumes weighted route rows and performs
+the full top-k reduction in combine.
+For rank-major-top-k-expanded output, combine consumes one row per top-k route
+and applies the original routing weights.
+With expert-major output, it retains its existing expert-row direct-send behavior.
 
 ## Combine API
 

--- a/python/mscclpp/ep/README.md
+++ b/python/mscclpp/ep/README.md
@@ -464,7 +464,7 @@ Requirements:
 | Shape | `[T, H]`, token-major |
 | Layout | contiguous row-major |
 | Device | CUDA tensor |
-| dtype | BF16, FP16, FP8, NVFP4, or another supported activation dtype |
+| dtype | BF16, or another supported activation dtype |
 | Ordering | original local token order; not expert sorted |
 
 The user should not expand `input` by top-k and should not convert it to
@@ -496,16 +496,17 @@ combine to reduce the `K` expert results for each token back to `[T, H]`.
 
 ### `quant`
 
-`quant` contains activation quantization metadata for `input`. It should be
-`None` for BF16/FP16 input. `quant.format` defines the tensor representation
-and scale layout.
+`quant` contains activation quantization metadata for dispatch output. It should
+be `None` for BF16 dispatch. `quant.format` defines the wire/output
+representation and scale layout; latency FP8 dispatch currently consumes BF16
+input and emits FP8 output.
 
 Examples:
 
 | Format | `input` | `quant.block_scales` |
 |---|---|---|
-| BF16/FP16 | `[T, H]` | `None` |
-| FP8 E4M3 | `[T, H]` FP8 | `[T, H / 128]` |
+| BF16 | `[T, H]` BF16 | `None` |
+| FP8 E4M3 | `[T, H]` BF16 input, FP8 output | `[T, H / 128]` |
 | NVFP4 | backend-defined packed/logical `[T, H]` | block scale tensor |
 
 The API should not assume quantization scale is a scalar. For FP8 paths in

--- a/python/mscclpp/ep/latency.py
+++ b/python/mscclpp/ep/latency.py
@@ -422,10 +422,14 @@ class LatencyRuntime(Runtime):
         )
         if type(resolved) is not int or not 0 < resolved <= mode_context.max_tokens_per_rank:
             raise ValueError("runtime_max_tokens_per_rank must be positive and not exceed max_tokens_per_rank")
-        if mode_context.output_layout not in (
-            DispatchLayout.RANK_MAJOR,
-            DispatchLayout.TOKEN_MAJOR,
-        ) and resolved != mode_context.max_tokens_per_rank:
+        if (
+            mode_context.output_layout
+            not in (
+                DispatchLayout.RANK_MAJOR,
+                DispatchLayout.TOKEN_MAJOR,
+            )
+            and resolved != mode_context.max_tokens_per_rank
+        ):
             raise ValueError("runtime_max_tokens_per_rank is only supported by rank-major dispatch")
         return resolved
 
@@ -607,7 +611,9 @@ class LatencyRuntime(Runtime):
         if handle.output_info.layout.kind in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
             assert mode_context.combine_input_buffer is not None
             if expert_output.data_ptr() != mode_context.combine_input_buffer.data_ptr():
-                raise ValueError(f"{handle.output_info.layout.kind} combine requires the runtime-owned combine input buffer")
+                raise ValueError(
+                    f"{handle.output_info.layout.kind} combine requires the runtime-owned combine input buffer"
+                )
         if out is not None:
             expected_out_shape = (context.num_tokens, mode_context.hidden_size)
             if tuple(out.shape) != expected_out_shape or out.dtype != expected_dtype or not out.is_contiguous():

--- a/python/mscclpp/ep/latency.py
+++ b/python/mscclpp/ep/latency.py
@@ -20,12 +20,15 @@ from mscclpp.ep.types import (
     QuantConfig,
     _ExpertMajorCombineContext,
     _RankMajorCombineContext,
+    _TokenMajorCombineContext,
 )
 from mscclpp.ep.utils import (
     DevicePointerArray,
+    combine_tensor_dtype,
     cuda_stream_ptr,
     dispatch_scale_block_size,
     dispatch_scale_dtype,
+    dispatch_tensor_dtype,
     resolve_expert_placement,
     resolve_dispatch_data_type,
     resolve_num_blocks,
@@ -73,6 +76,7 @@ class LatencyContext(Context):
         if self.output_layout not in (
             DispatchLayout.EXPERT_MAJOR,
             DispatchLayout.RANK_MAJOR,
+            DispatchLayout.TOKEN_MAJOR,
         ):
             raise NotImplementedError("unsupported latency output layout")
         if self.num_experts % self.world_size != 0:
@@ -97,6 +101,11 @@ class LatencyContext(Context):
                 raise ValueError("RANK_MAJOR output requires a supported combine mode")
             if self.enable_overlap:
                 raise NotImplementedError("RANK_MAJOR output does not support overlapping calls yet")
+        if self.output_layout == DispatchLayout.TOKEN_MAJOR:
+            if self.combine_mode != CombineMode.RANK_LOCAL_REDUCE:
+                raise ValueError("TOKEN_MAJOR output requires RANK_LOCAL_REDUCE combine")
+            if self.enable_overlap:
+                raise NotImplementedError("TOKEN_MAJOR output does not support overlapping calls yet")
 
         self.num_local_experts, self.local_expert_start = resolve_expert_placement(
             num_experts=self.num_experts,
@@ -109,6 +118,8 @@ class LatencyContext(Context):
         self.dispatch_data_type = resolve_dispatch_data_type(config.quant)
         if self.output_layout == DispatchLayout.RANK_MAJOR and self.dispatch_data_type != DispatchDataType.BF16:
             raise NotImplementedError("RANK_MAJOR output currently supports BF16 dispatch only")
+        if self.output_layout == DispatchLayout.TOKEN_MAJOR and self.dispatch_data_type != DispatchDataType.BF16:
+            raise NotImplementedError("TOKEN_MAJOR output currently supports BF16 dispatch only")
 
         self._dispatch_scales: Optional[torch.Tensor] = None
         self._dispatch_src_info: Optional[torch.Tensor] = None
@@ -213,12 +224,20 @@ class LatencyRuntime(Runtime):
                 kind=mode_context.output_layout,
                 num_tokens_per_rank=count,
             )
+        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            layout_info = DispatchLayoutInfo(
+                kind=mode_context.output_layout,
+                num_tokens_per_rank=count,
+            )
         else:
             raise ValueError(f"unsupported latency output layout: {mode_context.output_layout}")
         output_info = DispatchOutputInfo(layout=layout_info, quant=output_quant)
         combine_input_buffer = mode_context.combine_input_buffer
-        if mode_context.output_layout == DispatchLayout.RANK_MAJOR:
+        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
             assert combine_input_buffer is not None
+            rows = mode_context.world_size * active_capacity
+            if mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+                rows *= mode_context.topk
         dispatch_out = DispatchOutput(
             tokens=out_buf,
             quant=output_info.quant,
@@ -226,8 +245,8 @@ class LatencyRuntime(Runtime):
             topk_ids=recv_topk_ids,
             weights=recv_weights,
             combine_input_buffer=(
-                combine_input_buffer[: mode_context.world_size * active_capacity]
-                if mode_context.output_layout == DispatchLayout.RANK_MAJOR
+                combine_input_buffer[:rows]
+                if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR)
                 else None
             ),
         )
@@ -251,6 +270,18 @@ class LatencyRuntime(Runtime):
                 output_info=output_info,
                 _context=_RankMajorCombineContext(
                     topk_ids=topk_ids,
+                    num_experts=mode_context.num_experts,
+                    num_tokens=input.size(0),
+                    hidden_size=mode_context.hidden_size,
+                    max_tokens_per_rank=active_capacity,
+                ),
+            )
+        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            handle = DispatchHandle(
+                output_info=output_info,
+                _context=_TokenMajorCombineContext(
+                    topk_ids=topk_ids,
+                    weights=weights,
                     num_experts=mode_context.num_experts,
                     num_tokens=input.size(0),
                     hidden_size=mode_context.hidden_size,
@@ -283,12 +314,17 @@ class LatencyRuntime(Runtime):
             topk_weights = None
             src_info = None
             layout_range = None
+        elif isinstance(context, _TokenMajorCombineContext):
+            active_capacity = context.max_tokens_per_rank
+            topk_weights = context.weights
+            src_info = None
+            layout_range = None
         else:
             raise ValueError("DispatchHandle does not contain latency combine context")
         if out is None:
             out = torch.empty(
                 (context.num_tokens, mode_context.hidden_size),
-                dtype=torch.bfloat16,
+                dtype=combine_tensor_dtype(mode_context.dispatch_data_type),
                 device=expert_output.device,
             )
         self.cpp_runtime.combine(
@@ -328,10 +364,15 @@ class LatencyRuntime(Runtime):
                 context.world_size * context.max_tokens_per_rank,
                 context.hidden_size,
             )
+        elif context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            dispatch_shape = (
+                context.world_size * context.max_tokens_per_rank * context.topk,
+                context.hidden_size,
+            )
         else:
             dispatch_shape = (context.world_size * context.max_tokens_per_rank, context.hidden_size)
 
-        dispatch_dtype = torch.bfloat16 if context.dispatch_data_type == DispatchDataType.BF16 else torch.float8_e4m3fn
+        dispatch_dtype = dispatch_tensor_dtype(context.dispatch_data_type)
         context._dispatch_output_owner, context.dispatch_output_buffer = tensor_from_pointer(
             self.cpp_runtime.dispatch_output_buffer_ptr(),
             dispatch_shape,
@@ -340,7 +381,7 @@ class LatencyRuntime(Runtime):
             self.cpp_runtime,
         )
 
-        if context.output_layout != DispatchLayout.RANK_MAJOR:
+        if context.output_layout not in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
             return
 
         metadata_shape = (context.world_size * context.max_tokens_per_rank, context.topk)
@@ -381,7 +422,10 @@ class LatencyRuntime(Runtime):
         )
         if type(resolved) is not int or not 0 < resolved <= mode_context.max_tokens_per_rank:
             raise ValueError("runtime_max_tokens_per_rank must be positive and not exceed max_tokens_per_rank")
-        if mode_context.output_layout != DispatchLayout.RANK_MAJOR and resolved != mode_context.max_tokens_per_rank:
+        if mode_context.output_layout not in (
+            DispatchLayout.RANK_MAJOR,
+            DispatchLayout.TOKEN_MAJOR,
+        ) and resolved != mode_context.max_tokens_per_rank:
             raise ValueError("runtime_max_tokens_per_rank is only supported by rank-major dispatch")
         return resolved
 
@@ -424,6 +468,14 @@ class LatencyRuntime(Runtime):
                 mode_context._dispatch_weights = mode_context._output_topk_weights
                 mode_context._dispatch_layout_range = None
                 mode_context._dispatch_count = torch.empty((mode_context.world_size,), dtype=torch.int32, device=device)
+            elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+                mode_context._dispatch_src_info = None
+                assert mode_context._output_topk_ids is not None
+                assert mode_context._output_topk_weights is not None
+                mode_context._dispatch_topk_ids = mode_context._output_topk_ids
+                mode_context._dispatch_weights = mode_context._output_topk_weights
+                mode_context._dispatch_layout_range = None
+                mode_context._dispatch_count = torch.empty((mode_context.world_size,), dtype=torch.int32, device=device)
             else:
                 raise ValueError(f"unsupported latency output layout: {mode_context.output_layout}")
         assert mode_context._dispatch_count is not None
@@ -445,8 +497,9 @@ class LatencyRuntime(Runtime):
             )
         if input.dim() != 2 or not input.is_contiguous():
             raise ValueError("input must be a contiguous [num_tokens, hidden_size] tensor")
-        if input.device.type != "cuda" or input.dtype != torch.bfloat16:
-            raise ValueError("latency dispatch input must be a CUDA BF16 tensor")
+        expected_input_dtype = dispatch_tensor_dtype(mode_context.dispatch_data_type)
+        if input.device.type != "cuda" or input.dtype != expected_input_dtype:
+            raise ValueError(f"latency dispatch input must be a CUDA {expected_input_dtype} tensor")
         if input.size(1) != mode_context.hidden_size:
             raise ValueError(f"input hidden size {input.size(1)} does not match configured {mode_context.hidden_size}")
         if input.size(0) > active_capacity:
@@ -476,18 +529,21 @@ class LatencyRuntime(Runtime):
                 mode_context.world_size * mode_context.max_tokens_per_rank,
                 mode_context.hidden_size,
             )
+        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            expected_shape = (
+                mode_context.world_size * mode_context.max_tokens_per_rank * mode_context.topk,
+                mode_context.hidden_size,
+            )
         else:
             raise ValueError(f"unsupported latency output layout: {mode_context.output_layout}")
-        if mode_context.output_layout == DispatchLayout.RANK_MAJOR:
+        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
             assert mode_context.dispatch_output_buffer is not None
             if output_buffer.data_ptr() != mode_context.dispatch_output_buffer.data_ptr():
-                raise ValueError("RANK_MAJOR output uses the runtime-owned dispatch output buffer")
+                raise ValueError(f"{mode_context.output_layout} output uses the runtime-owned dispatch output buffer")
             return
         if output_buffer.dim() != len(expected_shape) or not output_buffer.is_contiguous():
             raise ValueError(f"output_buffer must be a contiguous {mode_context.output_layout} tensor")
-        expected_dtype = (
-            torch.bfloat16 if mode_context.dispatch_data_type == DispatchDataType.BF16 else torch.float8_e4m3fn
-        )
+        expected_dtype = dispatch_tensor_dtype(mode_context.dispatch_data_type)
         if output_buffer.device != input.device or output_buffer.dtype != expected_dtype:
             raise ValueError(f"output_buffer must be a {expected_dtype} CUDA tensor on the same device as input")
         if tuple(output_buffer.shape) != expected_shape:
@@ -496,7 +552,7 @@ class LatencyRuntime(Runtime):
     def _validate_combine(self, expert_output, handle, out) -> None:
         mode_context = self.context
         if not isinstance(handle, DispatchHandle) or not isinstance(
-            handle._context, (_ExpertMajorCombineContext, _RankMajorCombineContext)
+            handle._context, (_ExpertMajorCombineContext, _RankMajorCombineContext, _TokenMajorCombineContext)
         ):
             raise ValueError("DispatchHandle does not contain latency combine context")
         context = handle._context
@@ -510,7 +566,7 @@ class LatencyRuntime(Runtime):
             raise ValueError("DispatchHandle quantization does not match this MoECommunicator configuration")
         active_capacity = (
             context.max_tokens_per_rank
-            if isinstance(context, _RankMajorCombineContext)
+            if isinstance(context, (_RankMajorCombineContext, _TokenMajorCombineContext))
             else mode_context.max_tokens_per_rank
         )
         slots_per_expert = mode_context.world_size * active_capacity
@@ -534,19 +590,25 @@ class LatencyRuntime(Runtime):
                 mode_context.world_size * active_capacity,
                 mode_context.hidden_size,
             )
+        elif handle.output_info.layout.kind == DispatchLayout.TOKEN_MAJOR:
+            expected_shape = (
+                mode_context.world_size * active_capacity * mode_context.topk,
+                mode_context.hidden_size,
+            )
         else:
             raise ValueError(f"unsupported latency output layout: {handle.output_info.layout.kind}")
         if expert_output.dim() != len(expected_shape) or not expert_output.is_contiguous():
             raise ValueError("expert_output must keep dispatch output's contiguous layout")
         if tuple(expert_output.shape) != expected_shape:
             raise ValueError(f"expert_output shape must be {expected_shape}")
-        if expert_output.dtype != torch.bfloat16:
-            raise ValueError("expert_output must be BF16")
-        if handle.output_info.layout.kind == DispatchLayout.RANK_MAJOR:
+        expected_dtype = combine_tensor_dtype(mode_context.dispatch_data_type)
+        if expert_output.dtype != expected_dtype:
+            raise ValueError(f"expert_output must be {expected_dtype}")
+        if handle.output_info.layout.kind in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
             assert mode_context.combine_input_buffer is not None
             if expert_output.data_ptr() != mode_context.combine_input_buffer.data_ptr():
-                raise ValueError("RANK_MAJOR combine requires the runtime-owned combine input buffer")
+                raise ValueError(f"{handle.output_info.layout.kind} combine requires the runtime-owned combine input buffer")
         if out is not None:
             expected_out_shape = (context.num_tokens, mode_context.hidden_size)
-            if tuple(out.shape) != expected_out_shape or out.dtype != torch.bfloat16 or not out.is_contiguous():
-                raise ValueError(f"out must be a contiguous BF16 tensor with shape {expected_out_shape}")
+            if tuple(out.shape) != expected_out_shape or out.dtype != expected_dtype or not out.is_contiguous():
+                raise ValueError(f"out must be a contiguous {expected_dtype} tensor with shape {expected_out_shape}")

--- a/python/mscclpp/ep/latency.py
+++ b/python/mscclpp/ep/latency.py
@@ -558,7 +558,8 @@ class LatencyRuntime(Runtime):
     def _validate_combine(self, expert_output, handle, out) -> None:
         mode_context = self.context
         if not isinstance(handle, DispatchHandle) or not isinstance(
-            handle._context, (_ExpertMajorCombineContext, _RankMajorCombineContext, _RankMajorTopkExpandedCombineContext)
+            handle._context,
+            (_ExpertMajorCombineContext, _RankMajorCombineContext, _RankMajorTopkExpandedCombineContext),
         ):
             raise ValueError("DispatchHandle does not contain latency combine context")
         context = handle._context

--- a/python/mscclpp/ep/latency.py
+++ b/python/mscclpp/ep/latency.py
@@ -20,7 +20,7 @@ from mscclpp.ep.types import (
     QuantConfig,
     _ExpertMajorCombineContext,
     _RankMajorCombineContext,
-    _TokenMajorCombineContext,
+    _RankMajorTopkExpandedCombineContext,
 )
 from mscclpp.ep.utils import (
     DevicePointerArray,
@@ -76,7 +76,7 @@ class LatencyContext(Context):
         if self.output_layout not in (
             DispatchLayout.EXPERT_MAJOR,
             DispatchLayout.RANK_MAJOR,
-            DispatchLayout.TOKEN_MAJOR,
+            DispatchLayout.RANK_MAJOR_TOPK_EXPANDED,
         ):
             raise NotImplementedError("unsupported latency output layout")
         if self.num_experts % self.world_size != 0:
@@ -101,11 +101,11 @@ class LatencyContext(Context):
                 raise ValueError("RANK_MAJOR output requires a supported combine mode")
             if self.enable_overlap:
                 raise NotImplementedError("RANK_MAJOR output does not support overlapping calls yet")
-        if self.output_layout == DispatchLayout.TOKEN_MAJOR:
+        if self.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             if self.combine_mode != CombineMode.RANK_LOCAL_REDUCE:
-                raise ValueError("TOKEN_MAJOR output requires RANK_LOCAL_REDUCE combine")
+                raise ValueError("RANK_MAJOR_TOPK_EXPANDED output requires RANK_LOCAL_REDUCE combine")
             if self.enable_overlap:
-                raise NotImplementedError("TOKEN_MAJOR output does not support overlapping calls yet")
+                raise NotImplementedError("RANK_MAJOR_TOPK_EXPANDED output does not support overlapping calls yet")
 
         self.num_local_experts, self.local_expert_start = resolve_expert_placement(
             num_experts=self.num_experts,
@@ -118,8 +118,11 @@ class LatencyContext(Context):
         self.dispatch_data_type = resolve_dispatch_data_type(config.quant)
         if self.output_layout == DispatchLayout.RANK_MAJOR and self.dispatch_data_type != DispatchDataType.BF16:
             raise NotImplementedError("RANK_MAJOR output currently supports BF16 dispatch only")
-        if self.output_layout == DispatchLayout.TOKEN_MAJOR and self.dispatch_data_type != DispatchDataType.BF16:
-            raise NotImplementedError("TOKEN_MAJOR output currently supports BF16 dispatch only")
+        if (
+            self.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED
+            and self.dispatch_data_type != DispatchDataType.BF16
+        ):
+            raise NotImplementedError("RANK_MAJOR_TOPK_EXPANDED output currently supports BF16 dispatch only")
 
         self._dispatch_scales: Optional[torch.Tensor] = None
         self._dispatch_src_info: Optional[torch.Tensor] = None
@@ -224,7 +227,7 @@ class LatencyRuntime(Runtime):
                 kind=mode_context.output_layout,
                 num_tokens_per_rank=count,
             )
-        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+        elif mode_context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             layout_info = DispatchLayoutInfo(
                 kind=mode_context.output_layout,
                 num_tokens_per_rank=count,
@@ -233,10 +236,10 @@ class LatencyRuntime(Runtime):
             raise ValueError(f"unsupported latency output layout: {mode_context.output_layout}")
         output_info = DispatchOutputInfo(layout=layout_info, quant=output_quant)
         combine_input_buffer = mode_context.combine_input_buffer
-        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
+        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.RANK_MAJOR_TOPK_EXPANDED):
             assert combine_input_buffer is not None
             rows = mode_context.world_size * active_capacity
-            if mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            if mode_context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
                 rows *= mode_context.topk
         dispatch_out = DispatchOutput(
             tokens=out_buf,
@@ -246,7 +249,7 @@ class LatencyRuntime(Runtime):
             weights=recv_weights,
             combine_input_buffer=(
                 combine_input_buffer[:rows]
-                if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR)
+                if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.RANK_MAJOR_TOPK_EXPANDED)
                 else None
             ),
         )
@@ -276,10 +279,10 @@ class LatencyRuntime(Runtime):
                     max_tokens_per_rank=active_capacity,
                 ),
             )
-        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+        elif mode_context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             handle = DispatchHandle(
                 output_info=output_info,
-                _context=_TokenMajorCombineContext(
+                _context=_RankMajorTopkExpandedCombineContext(
                     topk_ids=topk_ids,
                     weights=weights,
                     num_experts=mode_context.num_experts,
@@ -314,7 +317,7 @@ class LatencyRuntime(Runtime):
             topk_weights = None
             src_info = None
             layout_range = None
-        elif isinstance(context, _TokenMajorCombineContext):
+        elif isinstance(context, _RankMajorTopkExpandedCombineContext):
             active_capacity = context.max_tokens_per_rank
             topk_weights = context.weights
             src_info = None
@@ -364,7 +367,7 @@ class LatencyRuntime(Runtime):
                 context.world_size * context.max_tokens_per_rank,
                 context.hidden_size,
             )
-        elif context.output_layout == DispatchLayout.TOKEN_MAJOR:
+        elif context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             dispatch_shape = (
                 context.world_size * context.max_tokens_per_rank * context.topk,
                 context.hidden_size,
@@ -381,7 +384,7 @@ class LatencyRuntime(Runtime):
             self.cpp_runtime,
         )
 
-        if context.output_layout not in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
+        if context.output_layout not in (DispatchLayout.RANK_MAJOR, DispatchLayout.RANK_MAJOR_TOPK_EXPANDED):
             return
 
         metadata_shape = (context.world_size * context.max_tokens_per_rank, context.topk)
@@ -426,7 +429,7 @@ class LatencyRuntime(Runtime):
             mode_context.output_layout
             not in (
                 DispatchLayout.RANK_MAJOR,
-                DispatchLayout.TOKEN_MAJOR,
+                DispatchLayout.RANK_MAJOR_TOPK_EXPANDED,
             )
             and resolved != mode_context.max_tokens_per_rank
         ):
@@ -472,7 +475,7 @@ class LatencyRuntime(Runtime):
                 mode_context._dispatch_weights = mode_context._output_topk_weights
                 mode_context._dispatch_layout_range = None
                 mode_context._dispatch_count = torch.empty((mode_context.world_size,), dtype=torch.int32, device=device)
-            elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+            elif mode_context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
                 mode_context._dispatch_src_info = None
                 assert mode_context._output_topk_ids is not None
                 assert mode_context._output_topk_weights is not None
@@ -532,14 +535,14 @@ class LatencyRuntime(Runtime):
                 mode_context.world_size * mode_context.max_tokens_per_rank,
                 mode_context.hidden_size,
             )
-        elif mode_context.output_layout == DispatchLayout.TOKEN_MAJOR:
+        elif mode_context.output_layout == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             expected_shape = (
                 mode_context.world_size * mode_context.max_tokens_per_rank * mode_context.topk,
                 mode_context.hidden_size,
             )
         else:
             raise ValueError(f"unsupported latency output layout: {mode_context.output_layout}")
-        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
+        if mode_context.output_layout in (DispatchLayout.RANK_MAJOR, DispatchLayout.RANK_MAJOR_TOPK_EXPANDED):
             assert mode_context.dispatch_output_buffer is not None
             if output_buffer.data_ptr() != mode_context.dispatch_output_buffer.data_ptr():
                 raise ValueError(f"{mode_context.output_layout} output uses the runtime-owned dispatch output buffer")
@@ -555,7 +558,7 @@ class LatencyRuntime(Runtime):
     def _validate_combine(self, expert_output, handle, out) -> None:
         mode_context = self.context
         if not isinstance(handle, DispatchHandle) or not isinstance(
-            handle._context, (_ExpertMajorCombineContext, _RankMajorCombineContext, _TokenMajorCombineContext)
+            handle._context, (_ExpertMajorCombineContext, _RankMajorCombineContext, _RankMajorTopkExpandedCombineContext)
         ):
             raise ValueError("DispatchHandle does not contain latency combine context")
         context = handle._context
@@ -569,7 +572,7 @@ class LatencyRuntime(Runtime):
             raise ValueError("DispatchHandle quantization does not match this MoECommunicator configuration")
         active_capacity = (
             context.max_tokens_per_rank
-            if isinstance(context, (_RankMajorCombineContext, _TokenMajorCombineContext))
+            if isinstance(context, (_RankMajorCombineContext, _RankMajorTopkExpandedCombineContext))
             else mode_context.max_tokens_per_rank
         )
         slots_per_expert = mode_context.world_size * active_capacity
@@ -593,7 +596,7 @@ class LatencyRuntime(Runtime):
                 mode_context.world_size * active_capacity,
                 mode_context.hidden_size,
             )
-        elif handle.output_info.layout.kind == DispatchLayout.TOKEN_MAJOR:
+        elif handle.output_info.layout.kind == DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
             expected_shape = (
                 mode_context.world_size * active_capacity * mode_context.topk,
                 mode_context.hidden_size,
@@ -607,7 +610,7 @@ class LatencyRuntime(Runtime):
         expected_dtype = combine_tensor_dtype(mode_context.dispatch_data_type)
         if expert_output.dtype != expected_dtype:
             raise ValueError(f"expert_output must be {expected_dtype}")
-        if handle.output_info.layout.kind in (DispatchLayout.RANK_MAJOR, DispatchLayout.TOKEN_MAJOR):
+        if handle.output_info.layout.kind in (DispatchLayout.RANK_MAJOR, DispatchLayout.RANK_MAJOR_TOPK_EXPANDED):
             assert mode_context.combine_input_buffer is not None
             if expert_output.data_ptr() != mode_context.combine_input_buffer.data_ptr():
                 raise ValueError(

--- a/python/mscclpp/ep/latency.py
+++ b/python/mscclpp/ep/latency.py
@@ -501,9 +501,8 @@ class LatencyRuntime(Runtime):
             )
         if input.dim() != 2 or not input.is_contiguous():
             raise ValueError("input must be a contiguous [num_tokens, hidden_size] tensor")
-        expected_input_dtype = dispatch_tensor_dtype(mode_context.dispatch_data_type)
-        if input.device.type != "cuda" or input.dtype != expected_input_dtype:
-            raise ValueError(f"latency dispatch input must be a CUDA {expected_input_dtype} tensor")
+        if input.device.type != "cuda" or input.dtype != torch.bfloat16:
+            raise ValueError("latency dispatch input must be a CUDA BF16 tensor")
         if input.size(1) != mode_context.hidden_size:
             raise ValueError(f"input hidden size {input.size(1)} does not match configured {mode_context.hidden_size}")
         if input.size(0) > active_capacity:

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -95,6 +95,9 @@ class DispatchOutput:
 
     ``RANK_MAJOR`` tensors alias runtime-owned registered buffers that are
     reused by every dispatch. Clone any result that must outlive the next call.
+    ``KI_RAGGED`` tensors are compact expert-grouped rows with capacity
+    ``world_size * max_tokens_per_rank * topk``; valid rows are described by
+    ``layout.num_tokens_per_expert``.
     """
 
     tokens: torch.Tensor
@@ -133,6 +136,18 @@ class _RankMajorCombineContext:
 
 
 @dataclass
+class _TokenMajorCombineContext:
+    """Combine context for fixed-stride token-major output."""
+
+    topk_ids: torch.Tensor
+    weights: Optional[torch.Tensor]
+    num_experts: int
+    num_tokens: int
+    hidden_size: int
+    max_tokens_per_rank: int
+
+
+@dataclass
 class _ThroughputCombineContext:
     """Combine context for throughput output."""
 
@@ -143,6 +158,7 @@ class _ThroughputCombineContext:
 _CombineContext = Union[
     _ExpertMajorCombineContext,
     _RankMajorCombineContext,
+    _TokenMajorCombineContext,
     _ThroughputCombineContext,
 ]
 

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -95,9 +95,6 @@ class DispatchOutput:
 
     ``RANK_MAJOR`` tensors alias runtime-owned registered buffers that are
     reused by every dispatch. Clone any result that must outlive the next call.
-    ``KI_RAGGED`` tensors are compact expert-grouped rows with capacity
-    ``world_size * max_tokens_per_rank * topk``; valid rows are described by
-    ``layout.num_tokens_per_expert``.
     """
 
     tokens: torch.Tensor

--- a/python/mscclpp/ep/types.py
+++ b/python/mscclpp/ep/types.py
@@ -133,8 +133,8 @@ class _RankMajorCombineContext:
 
 
 @dataclass
-class _TokenMajorCombineContext:
-    """Combine context for fixed-stride token-major output."""
+class _RankMajorTopkExpandedCombineContext:
+    """Combine context for fixed-stride source-rank/top-k-expanded output."""
 
     topk_ids: torch.Tensor
     weights: Optional[torch.Tensor]
@@ -155,7 +155,7 @@ class _ThroughputCombineContext:
 _CombineContext = Union[
     _ExpertMajorCombineContext,
     _RankMajorCombineContext,
-    _TokenMajorCombineContext,
+    _RankMajorTopkExpandedCombineContext,
     _ThroughputCombineContext,
 ]
 

--- a/python/mscclpp/ep/utils.py
+++ b/python/mscclpp/ep/utils.py
@@ -46,6 +46,10 @@ def resolve_dispatch_data_type(quant: Optional[QuantConfig]) -> DispatchDataType
         raise TypeError("quant.format must be a DispatchDataType")
     if quant_format is None:
         raise ValueError("quant.format is required")
+    if quant_format == DispatchDataType.FP16:
+        if quant.block_scales is not None:
+            raise ValueError("FP16 dispatch does not use block scales")
+        return quant_format
     if quant_format != DispatchDataType.FP8_E4M3:
         raise ValueError("unsupported dispatch quantization format")
     if quant.block_scales is not None:
@@ -64,7 +68,25 @@ def dispatch_scale_dtype(data_type: DispatchDataType) -> torch.dtype:
     """Return the scale dtype for a quantized dispatch format."""
     if data_type == DispatchDataType.FP8_E4M3:
         return torch.float32
-    raise ValueError("BF16 dispatch does not have block scales")
+    raise ValueError(f"{data_type} dispatch does not have block scales")
+
+
+def dispatch_tensor_dtype(data_type: DispatchDataType) -> torch.dtype:
+    """Return the tensor dtype for a dispatch payload format."""
+    if data_type == DispatchDataType.BF16:
+        return torch.bfloat16
+    if data_type == DispatchDataType.FP16:
+        return torch.float16
+    if data_type == DispatchDataType.FP8_E4M3:
+        return torch.float8_e4m3fn
+    raise ValueError(f"unsupported dispatch data type: {data_type}")
+
+
+def combine_tensor_dtype(data_type: DispatchDataType) -> torch.dtype:
+    """Return the tensor dtype expected by latency combine."""
+    if data_type == DispatchDataType.FP16:
+        return torch.float16
+    return torch.bfloat16
 
 
 def send_bytes(comm: Any, payload: bytes, peer: int, tag: int) -> None:
@@ -173,6 +195,7 @@ def tensor_from_pointer(
     """Create a zero-copy tensor view over runtime-owned CUDA memory."""
     storage_types = {
         torch.bfloat16: "<u2",
+        torch.float16: "<f2",
         torch.float8_e4m3fn: "|u1",
         torch.int32: "<i4",
         torch.float32: "<f4",

--- a/python/mscclpp/ep/utils.py
+++ b/python/mscclpp/ep/utils.py
@@ -46,10 +46,6 @@ def resolve_dispatch_data_type(quant: Optional[QuantConfig]) -> DispatchDataType
         raise TypeError("quant.format must be a DispatchDataType")
     if quant_format is None:
         raise ValueError("quant.format is required")
-    if quant_format == DispatchDataType.FP16:
-        if quant.block_scales is not None:
-            raise ValueError("FP16 dispatch does not use block scales")
-        return quant_format
     if quant_format != DispatchDataType.FP8_E4M3:
         raise ValueError("unsupported dispatch quantization format")
     if quant.block_scales is not None:
@@ -75,8 +71,6 @@ def dispatch_tensor_dtype(data_type: DispatchDataType) -> torch.dtype:
     """Return the tensor dtype for a dispatch payload format."""
     if data_type == DispatchDataType.BF16:
         return torch.bfloat16
-    if data_type == DispatchDataType.FP16:
-        return torch.float16
     if data_type == DispatchDataType.FP8_E4M3:
         return torch.float8_e4m3fn
     raise ValueError(f"unsupported dispatch data type: {data_type}")
@@ -84,8 +78,6 @@ def dispatch_tensor_dtype(data_type: DispatchDataType) -> torch.dtype:
 
 def combine_tensor_dtype(data_type: DispatchDataType) -> torch.dtype:
     """Return the tensor dtype expected by latency combine."""
-    if data_type == DispatchDataType.FP16:
-        return torch.float16
     return torch.bfloat16
 
 

--- a/src/ext/ep/bindings.cpp
+++ b/src/ext/ep/bindings.cpp
@@ -39,7 +39,6 @@ NB_MODULE(mscclpp_ep_cpp, m) {
 
   nb::enum_<mscclpp::ep::DispatchLayout>(m, "DispatchLayout")
       .value("EXPERT_MAJOR", mscclpp::ep::DispatchLayout::EXPERT_MAJOR)
-      .value("KI_RAGGED", mscclpp::ep::DispatchLayout::KI_RAGGED)
       .value("TOKEN_MAJOR", mscclpp::ep::DispatchLayout::TOKEN_MAJOR)
       .value("RANK_MAJOR", mscclpp::ep::DispatchLayout::RANK_MAJOR);
 

--- a/src/ext/ep/bindings.cpp
+++ b/src/ext/ep/bindings.cpp
@@ -39,6 +39,7 @@ NB_MODULE(mscclpp_ep_cpp, m) {
 
   nb::enum_<mscclpp::ep::DispatchLayout>(m, "DispatchLayout")
       .value("EXPERT_MAJOR", mscclpp::ep::DispatchLayout::EXPERT_MAJOR)
+      .value("KI_RAGGED", mscclpp::ep::DispatchLayout::KI_RAGGED)
       .value("TOKEN_MAJOR", mscclpp::ep::DispatchLayout::TOKEN_MAJOR)
       .value("RANK_MAJOR", mscclpp::ep::DispatchLayout::RANK_MAJOR);
 
@@ -47,6 +48,7 @@ NB_MODULE(mscclpp_ep_cpp, m) {
       .value("DIRECT_SEND", mscclpp::ep::CombineMode::DIRECT_SEND);
   nb::enum_<mscclpp::ep::DispatchDataType>(m, "DispatchDataType")
       .value("BF16", mscclpp::ep::DispatchDataType::BF16)
+      .value("FP16", mscclpp::ep::DispatchDataType::FP16)
       .value("FP8_E4M3", mscclpp::ep::DispatchDataType::FP8_E4M3);
 
   m.def("create_moe_runtime", &mscclpp::ep::createMoERuntime, nb::arg("comm"), nb::arg("mode"),

--- a/src/ext/ep/bindings.cpp
+++ b/src/ext/ep/bindings.cpp
@@ -40,7 +40,8 @@ NB_MODULE(mscclpp_ep_cpp, m) {
   nb::enum_<mscclpp::ep::DispatchLayout>(m, "DispatchLayout")
       .value("EXPERT_MAJOR", mscclpp::ep::DispatchLayout::EXPERT_MAJOR)
       .value("TOKEN_MAJOR", mscclpp::ep::DispatchLayout::TOKEN_MAJOR)
-      .value("RANK_MAJOR", mscclpp::ep::DispatchLayout::RANK_MAJOR);
+      .value("RANK_MAJOR", mscclpp::ep::DispatchLayout::RANK_MAJOR)
+      .value("RANK_MAJOR_TOPK_EXPANDED", mscclpp::ep::DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
 
   nb::enum_<mscclpp::ep::CombineMode>(m, "CombineMode")
       .value("RANK_LOCAL_REDUCE", mscclpp::ep::CombineMode::RANK_LOCAL_REDUCE)

--- a/src/ext/ep/bindings.cpp
+++ b/src/ext/ep/bindings.cpp
@@ -47,7 +47,6 @@ NB_MODULE(mscclpp_ep_cpp, m) {
       .value("DIRECT_SEND", mscclpp::ep::CombineMode::DIRECT_SEND);
   nb::enum_<mscclpp::ep::DispatchDataType>(m, "DispatchDataType")
       .value("BF16", mscclpp::ep::DispatchDataType::BF16)
-      .value("FP16", mscclpp::ep::DispatchDataType::FP16)
       .value("FP8_E4M3", mscclpp::ep::DispatchDataType::FP8_E4M3);
 
   m.def("create_moe_runtime", &mscclpp::ep::createMoERuntime, nb::arg("comm"), nb::arg("mode"),

--- a/src/ext/ep/combine/common.cuh
+++ b/src/ext/ep/combine/common.cuh
@@ -41,6 +41,18 @@ MSCCLPP_HOST_DEVICE_INLINE int directSendWorkerCount(int nLocalExperts) {
 
 template <int Hidden, CombineMode Mode, DispatchLayout Layout>
 MSCCLPP_HOST_DEVICE_INLINE size_t combineSharedBytes(int nLocalExperts, int nTopk) {
+  if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+    if (nTopk <= RankMajorTmaMaxNTopk) {
+      constexpr size_t RowsBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * Hidden * sizeof(Bf16);
+      constexpr size_t BarrierBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * sizeof(mscclpp::BulkBarrier);
+      constexpr size_t ValidBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * sizeof(int);
+      constexpr size_t WeightBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * sizeof(float);
+      constexpr size_t SharedBytes = configAlign<size_t>(RowsBytes + BarrierBytes + ValidBytes + WeightBytes, 128);
+      static_assert(SharedBytes <= OptimizedDynamicSharedMemoryBytes);
+      return SharedBytes;
+    }
+    return 0;
+  }
   if constexpr (Layout == DispatchLayout::RANK_MAJOR) {
     if (nTopk <= RankMajorTmaMaxNTopk) {
       constexpr size_t RowsBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * Hidden * sizeof(Bf16);
@@ -489,6 +501,162 @@ MSCCLPP_DEVICE_INLINE void recvRankMajorRemotePartials(void* output, const void*
   }
 }
 
+template <int HiddenInt4>
+MSCCLPP_DEVICE_INLINE int4 reduceRemoteTokenPartialsBf16x8(const void* expertOutput, const TransportView& transport,
+                                                           int destinationRankCandidate, float weightCandidate,
+                                                           int nTopk, int maxTokensPerRank, int tokenIdx,
+                                                           int hiddenIdx) {
+  constexpr int Bf16PairsPerInt4 = sizeof(int4) / sizeof(mscclpp::bf16x2);
+  float2 reduced[Bf16PairsPerInt4] = {};
+  for (int topkLane = 0; topkLane < nTopk; ++topkLane) {
+    const int destinationRank = warpBroadcast(destinationRankCandidate, topkLane);
+    if (destinationRank < 0) continue;
+    const float weight = warpBroadcast(weightCandidate, topkLane);
+    const auto* remoteExpertOutput =
+        reinterpret_cast<const int4*>(transport.mappedBuffer(const_cast<void*>(expertOutput), destinationRank));
+    const size_t rowIndex = (static_cast<size_t>(transport.rank_) * maxTokensPerRank + tokenIdx) * nTopk + topkLane;
+    const int4 packed = remoteExpertOutput[rowIndex * HiddenInt4 + hiddenIdx];
+    const auto* values = reinterpret_cast<const mscclpp::bf16x2*>(&packed);
+#pragma unroll
+    for (int pairIdx = 0; pairIdx < Bf16PairsPerInt4; ++pairIdx) {
+      const mscclpp::f32x2 value = mscclpp::to<mscclpp::f32x2>(values[pairIdx]);
+      reduced[pairIdx].x = fmaf(value.data[0], weight, reduced[pairIdx].x);
+      reduced[pairIdx].y = fmaf(value.data[1], weight, reduced[pairIdx].y);
+    }
+  }
+
+  int4 packedOutput;
+  auto* outputValues = reinterpret_cast<mscclpp::bf16x2*>(&packedOutput);
+#pragma unroll
+  for (int pairIdx = 0; pairIdx < Bf16PairsPerInt4; ++pairIdx) {
+    outputValues[pairIdx] = mscclpp::to<mscclpp::bf16x2>(mscclpp::f32x2(reduced[pairIdx]));
+  }
+  return packedOutput;
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void recvTokenMajorRemotePartials(void* output, const void* expertOutput,
+                                                        const int64_t* __restrict__ topkIndices,
+                                                        const float* __restrict__ topkWeights, int nTokens, int nTopk,
+                                                        int nExperts, int nRanks, int maxTokensPerRank,
+                                                        const TransportView& transport) {
+  constexpr int Bf16PerInt4 = sizeof(int4) / sizeof(Bf16);
+  constexpr int HiddenInt4 = Hidden / Bf16PerInt4;
+  const int threadId = static_cast<int>(threadIdx.x);
+  const int laneId = get_lane_id();
+  const int nLocalExperts = nExperts / nRanks;
+
+  for (int tokenIdx = static_cast<int>(blockIdx.x); tokenIdx < nTokens; tokenIdx += static_cast<int>(gridDim.x)) {
+    const int globalExpertIdx = laneId < nTopk ? static_cast<int>(topkIndices[tokenIdx * nTopk + laneId]) : -1;
+    const int destinationRank = globalExpertIdx >= 0 ? globalExpertIdx / nLocalExperts : -1;
+    const float weight =
+        laneId < nTopk ? (topkWeights == nullptr ? 1.0f : topkWeights[tokenIdx * nTopk + laneId]) : 0.0f;
+
+    for (int hiddenIdx = threadId; hiddenIdx < HiddenInt4; hiddenIdx += CombineNThreads) {
+      const int4 packed = reduceRemoteTokenPartialsBf16x8<HiddenInt4>(expertOutput, transport, destinationRank, weight,
+                                                                      nTopk, maxTokensPerRank, tokenIdx, hiddenIdx);
+      auto* outputRow = reinterpret_cast<int4*>(output) + static_cast<size_t>(tokenIdx) * HiddenInt4;
+      outputRow[hiddenIdx] = packed;
+    }
+  }
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void recvTokenMajorRemotePartialsTma(void* output, const void* expertOutput,
+                                                           const int64_t* __restrict__ topkIndices,
+                                                           const float* __restrict__ topkWeights, int nTokens,
+                                                           int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
+                                                           uint32_t epoch, const TransportView& transport,
+                                                           WorkspaceView& workspaceView, uint8_t* sharedMemory) {
+#if defined(__CUDA_ARCH__)
+  static_assert(__CUDA_ARCH__ >= 900, "TMA token-major combine requires SM90 or newer");
+#endif
+  static_assert(Hidden % (sizeof(int4) / sizeof(Bf16)) == 0);
+  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
+  constexpr int HiddenInt4 = HiddenBytes / sizeof(int4);
+  constexpr int Bf16PairsPerInt4 = sizeof(int4) / sizeof(mscclpp::bf16x2);
+  constexpr size_t RowsBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * HiddenBytes;
+  constexpr size_t BarrierBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * sizeof(mscclpp::BulkBarrier);
+  const int threadId = static_cast<int>(threadIdx.x);
+  const int warpId = threadId / WARP_SIZE;
+  const int laneId = get_lane_id();
+  const int nLocalExperts = nExperts / nRanks;
+  auto* sharedRows = reinterpret_cast<int4*>(sharedMemory);
+  auto* bulkBarriers = reinterpret_cast<mscclpp::BulkBarrier*>(sharedMemory + RowsBytes);
+  auto* validRows = reinterpret_cast<int*>(bulkBarriers + RankMajorTmaMaxNTopk);
+  auto* slotWeights = reinterpret_cast<float*>(validRows + RankMajorTmaMaxNTopk);
+  const int nWorkerBlocks = static_cast<int>(gridDim.x) - 1;
+  uint32_t bulkPhase = 0;
+
+  if (warpId == 0) {
+    if (laneId < RankMajorTmaMaxNTopk) bulkBarriers[laneId].init();
+    __syncwarp();
+  }
+
+  for (int tokenIdx = static_cast<int>(blockIdx.x) - 1; tokenIdx < nTokens; tokenIdx += nWorkerBlocks) {
+    if (warpId == 0) {
+      const int globalExpertIdx = laneId < nTopk ? static_cast<int>(topkIndices[tokenIdx * nTopk + laneId]) : -1;
+      const int destinationRank = globalExpertIdx >= 0 ? globalExpertIdx / nLocalExperts : -1;
+      const bool validRow = laneId < RankMajorTmaMaxNTopk && destinationRank >= 0;
+      if (laneId < RankMajorTmaMaxNTopk) {
+        validRows[laneId] = validRow;
+        slotWeights[laneId] =
+            validRow ? (topkWeights == nullptr ? 1.0f : topkWeights[tokenIdx * nTopk + laneId]) : 0.0f;
+      }
+      __syncwarp();
+
+      bool pending = validRow;
+      while (__any_sync(0xffffffff, pending)) {
+        const bool ready = pending && mscclpp::atomicLoad<uint32_t, mscclpp::scopeDevice>(
+                                          workspaceView.combineRankReadyEpochs_ + destinationRank,
+                                          mscclpp::memoryOrderRelaxed) == epoch;
+        if (pending && ready) {
+          const auto* remoteExpertOutput = reinterpret_cast<const uint8_t*>(
+              transport.mappedBuffer(const_cast<void*>(expertOutput), destinationRank));
+          const auto* source =
+              remoteExpertOutput +
+              ((static_cast<size_t>(transport.rank_) * maxTokensPerRank + tokenIdx) * nTopk + laneId) * HiddenBytes;
+          auto* sharedRow = reinterpret_cast<uint8_t*>(sharedRows) + static_cast<size_t>(laneId) * HiddenBytes;
+          bulkBarriers[laneId].arriveAndExpect(static_cast<uint32_t>(HiddenBytes));
+          mscclpp::bulkLoad(sharedRow, source, static_cast<uint32_t>(HiddenBytes), bulkBarriers[laneId]);
+          pending = false;
+        }
+      }
+      if (validRow) bulkBarriers[laneId].wait(bulkPhase);
+      __syncwarp();
+      if (laneId == 0) mscclpp::bulkFence();
+    }
+    __syncthreads();
+
+    for (int hiddenIdx = threadId; hiddenIdx < HiddenInt4; hiddenIdx += CombineNThreads) {
+      float2 reduced[Bf16PairsPerInt4] = {};
+#pragma unroll
+      for (int stage = 0; stage < RankMajorTmaMaxNTopk; ++stage) {
+        if (validRows[stage] == 0) continue;
+        const float weight = slotWeights[stage];
+        const int4 packed = sharedRows[stage * HiddenInt4 + hiddenIdx];
+        const auto* values = reinterpret_cast<const mscclpp::bf16x2*>(&packed);
+#pragma unroll
+        for (int pairIdx = 0; pairIdx < Bf16PairsPerInt4; ++pairIdx) {
+          const mscclpp::f32x2 value = mscclpp::to<mscclpp::f32x2>(values[pairIdx]);
+          reduced[pairIdx].x = fmaf(value.data[0], weight, reduced[pairIdx].x);
+          reduced[pairIdx].y = fmaf(value.data[1], weight, reduced[pairIdx].y);
+        }
+      }
+
+      int4 packedOutput;
+      auto* outputValues = reinterpret_cast<mscclpp::bf16x2*>(&packedOutput);
+#pragma unroll
+      for (int pairIdx = 0; pairIdx < Bf16PairsPerInt4; ++pairIdx) {
+        outputValues[pairIdx] = mscclpp::to<mscclpp::bf16x2>(mscclpp::f32x2(reduced[pairIdx]));
+      }
+      auto* outputRow = reinterpret_cast<int4*>(output) + static_cast<size_t>(tokenIdx) * HiddenInt4;
+      outputRow[hiddenIdx] = packedOutput;
+    }
+    __syncthreads();
+  }
+}
+
 template <int Hidden>
 MSCCLPP_DEVICE_INLINE void recvRankLocalPartials(void* output, const int64_t* __restrict__ topkIndices, int nTokens,
                                                  int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
@@ -621,6 +789,24 @@ MSCCLPP_DEVICE_INLINE void combineBody(void* output, const void* expertOutput, c
     recvRankMajorRemotePartials<Hidden, Mode>(output, expertOutput, topkIndices, nTokens, nTopk, nExperts, nRanks,
                                               maxTokensPerRank, transport, workspaceView);
     return;
+  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+    static_assert(Mode == CombineMode::RANK_LOCAL_REDUCE);
+    static_assert(DispatchType == DispatchDataType::BF16);
+    if (nTopk <= RankMajorTmaMaxNTopk) {
+      const uint32_t epoch = workload.epoch_;
+      if (blockIdx.x == 0) {
+        publishRankMajorCombineReady(transport, nRanks, epoch, workspaceView);
+      } else {
+        recvTokenMajorRemotePartialsTma<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens, nTopk,
+                                                nExperts, nRanks, maxTokensPerRank, epoch, transport, workspaceView,
+                                                sharedMemory);
+      }
+      return;
+    }
+    synchronizeRankMajorCombine(transport, nRanks, workload.epoch_, workspaceView);
+    recvTokenMajorRemotePartials<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens, nTopk, nExperts,
+                                         nRanks, maxTokensPerRank, transport);
+    return;
   } else if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
     sendRankReducedPartials<Hidden, DispatchType, ScaleBlockSize>(
         expertOutput, nExperts, nRanks, nTopk, maxTokensPerRank, combineRecvBuffer, dispatchRecvBuffer, transport,
@@ -661,12 +847,14 @@ inline void combineHiddenMode(void* output, const void* expertOutput, const int6
   auto combineFunc = KernelSelector::template get<Hidden, DispatchType, ScaleBlockSize, Layout>();
   const size_t sharedBytes = combineSharedBytes<Hidden, Mode, Layout>(nLocalExperts, workload.numTopk_);
   const bool useRankMajorTma = Layout == DispatchLayout::RANK_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
-  EP_HOST_ASSERT(!useRankMajorTma || numBlocks > 1);
+  const bool useTokenMajorTma = Layout == DispatchLayout::TOKEN_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
+  const int launchBlocks = numBlocks + ((useRankMajorTma || useTokenMajorTma) ? 1 : 0);
+  EP_HOST_ASSERT(!(useRankMajorTma || useTokenMajorTma) || launchBlocks > 1);
   static thread_local KernelConfigCache kernelConfig;
   const int residentBlocks = configureKernel(combineFunc, CombineNThreads, sharedBytes, context, kernelConfig);
-  EP_HOST_ASSERT(residentBlocks >= numBlocks);
+  EP_HOST_ASSERT(residentBlocks >= launchBlocks);
 
-  combineFunc<<<dim3(numBlocks), dim3(CombineNThreads), sharedBytes, stream>>>(
+  combineFunc<<<dim3(launchBlocks), dim3(CombineNThreads), sharedBytes, stream>>>(
       output, expertOutput, topkIndices, topkWeights, srcInfo, layoutRange, workload, recvBuffer, dispatchRecvBuffer,
       context.devicePtr_);
   CUDA_CHECK(cudaGetLastError());
@@ -681,6 +869,15 @@ inline void combineHidden(void* output, const void* expertOutput, const int64_t*
     return combineHiddenMode<Mode, Hidden, DispatchDataType::BF16, 0, DispatchLayout::RANK_MAJOR, KernelSelector>(
         output, expertOutput, topkIndices, topkWeights, srcInfo, layoutRange, workload, recvBuffer, dispatchRecvBuffer,
         context, numBlocks, stream);
+  }
+  if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
+    if (workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
+      EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
+      return combineHiddenMode<CombineMode::RANK_LOCAL_REDUCE, Hidden, DispatchDataType::BF16, 0,
+                               DispatchLayout::TOKEN_MAJOR, KernelSelector>(
+          output, expertOutput, topkIndices, topkWeights, srcInfo, layoutRange, workload, recvBuffer,
+          dispatchRecvBuffer, context, numBlocks, stream);
+    }
   }
   if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
     switch (workload.dispatchDataType_) {
@@ -739,10 +936,12 @@ inline void combineAlgorithm(void* output, const void* expertOutput, const int64
   EP_HOST_ASSERT(numBlocks > 0 && numBlocks <= MaxWorkerBlocks);
   static_assert(Mode == CombineMode::RANK_LOCAL_REDUCE || Mode == CombineMode::DIRECT_SEND);
   EP_HOST_ASSERT(workload.outputLayout_ == DispatchLayout::EXPERT_MAJOR ||
-                 workload.outputLayout_ == DispatchLayout::RANK_MAJOR);
+                 workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
+                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
   EP_HOST_ASSERT(isSupportedDispatchDataType(workload.dispatchDataType_));
   if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
-    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR) {
+    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
+        workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
       EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
     }
   } else {

--- a/src/ext/ep/combine/common.cuh
+++ b/src/ext/ep/combine/common.cuh
@@ -940,8 +940,7 @@ inline void combineAlgorithm(void* output, const void* expertOutput, const int64
                  workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
   EP_HOST_ASSERT(isSupportedDispatchDataType(workload.dispatchDataType_));
   if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
-    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
-        workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
+    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR || workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
       EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
     }
   } else {

--- a/src/ext/ep/combine/common.cuh
+++ b/src/ext/ep/combine/common.cuh
@@ -41,7 +41,7 @@ MSCCLPP_HOST_DEVICE_INLINE int directSendWorkerCount(int nLocalExperts) {
 
 template <int Hidden, CombineMode Mode, DispatchLayout Layout>
 MSCCLPP_HOST_DEVICE_INLINE size_t combineSharedBytes(int nLocalExperts, int nTopk) {
-  if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+  if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     if (nTopk <= RankMajorTmaMaxNTopk) {
       constexpr size_t RowsBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * Hidden * sizeof(Bf16);
       constexpr size_t BarrierBytes = static_cast<size_t>(RankMajorTmaMaxNTopk) * sizeof(mscclpp::BulkBarrier);
@@ -535,11 +535,10 @@ MSCCLPP_DEVICE_INLINE int4 reduceRemoteTokenPartialsBf16x8(const void* expertOut
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void recvTokenMajorRemotePartials(void* output, const void* expertOutput,
-                                                        const int64_t* __restrict__ topkIndices,
-                                                        const float* __restrict__ topkWeights, int nTokens, int nTopk,
-                                                        int nExperts, int nRanks, int maxTokensPerRank,
-                                                        const TransportView& transport) {
+MSCCLPP_DEVICE_INLINE void recvRankMajorTopkExpandedRemotePartials(
+    void* output, const void* expertOutput, const int64_t* __restrict__ topkIndices,
+    const float* __restrict__ topkWeights, int nTokens, int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
+    const TransportView& transport) {
   constexpr int Bf16PerInt4 = sizeof(int4) / sizeof(Bf16);
   constexpr int HiddenInt4 = Hidden / Bf16PerInt4;
   const int threadId = static_cast<int>(threadIdx.x);
@@ -562,14 +561,12 @@ MSCCLPP_DEVICE_INLINE void recvTokenMajorRemotePartials(void* output, const void
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void recvTokenMajorRemotePartialsTma(void* output, const void* expertOutput,
-                                                           const int64_t* __restrict__ topkIndices,
-                                                           const float* __restrict__ topkWeights, int nTokens,
-                                                           int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
-                                                           uint32_t epoch, const TransportView& transport,
-                                                           WorkspaceView& workspaceView, uint8_t* sharedMemory) {
+MSCCLPP_DEVICE_INLINE void recvRankMajorTopkExpandedRemotePartialsTma(
+    void* output, const void* expertOutput, const int64_t* __restrict__ topkIndices,
+    const float* __restrict__ topkWeights, int nTokens, int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
+    uint32_t epoch, const TransportView& transport, WorkspaceView& workspaceView, uint8_t* sharedMemory) {
 #if defined(__CUDA_ARCH__)
-  static_assert(__CUDA_ARCH__ >= 900, "TMA token-major combine requires SM90 or newer");
+  static_assert(__CUDA_ARCH__ >= 900, "TMA rank-major-topk-expanded combine requires SM90 or newer");
 #endif
   static_assert(Hidden % (sizeof(int4) / sizeof(Bf16)) == 0);
   constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
@@ -789,7 +786,7 @@ MSCCLPP_DEVICE_INLINE void combineBody(void* output, const void* expertOutput, c
     recvRankMajorRemotePartials<Hidden, Mode>(output, expertOutput, topkIndices, nTokens, nTopk, nExperts, nRanks,
                                               maxTokensPerRank, transport, workspaceView);
     return;
-  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+  } else if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     static_assert(Mode == CombineMode::RANK_LOCAL_REDUCE);
     static_assert(DispatchType == DispatchDataType::BF16);
     if (nTopk <= RankMajorTmaMaxNTopk) {
@@ -797,15 +794,15 @@ MSCCLPP_DEVICE_INLINE void combineBody(void* output, const void* expertOutput, c
       if (blockIdx.x == 0) {
         publishRankMajorCombineReady(transport, nRanks, epoch, workspaceView);
       } else {
-        recvTokenMajorRemotePartialsTma<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens, nTopk,
-                                                nExperts, nRanks, maxTokensPerRank, epoch, transport, workspaceView,
-                                                sharedMemory);
+        recvRankMajorTopkExpandedRemotePartialsTma<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens,
+                                                           nTopk, nExperts, nRanks, maxTokensPerRank, epoch, transport,
+                                                           workspaceView, sharedMemory);
       }
       return;
     }
     synchronizeRankMajorCombine(transport, nRanks, workload.epoch_, workspaceView);
-    recvTokenMajorRemotePartials<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens, nTopk, nExperts,
-                                         nRanks, maxTokensPerRank, transport);
+    recvRankMajorTopkExpandedRemotePartials<Hidden>(output, expertOutput, topkIndices, topkWeights, nTokens, nTopk,
+                                                    nExperts, nRanks, maxTokensPerRank, transport);
     return;
   } else if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
     sendRankReducedPartials<Hidden, DispatchType, ScaleBlockSize>(
@@ -847,8 +844,9 @@ inline void combineHiddenMode(void* output, const void* expertOutput, const int6
   auto combineFunc = KernelSelector::template get<Hidden, DispatchType, ScaleBlockSize, Layout>();
   const size_t sharedBytes = combineSharedBytes<Hidden, Mode, Layout>(nLocalExperts, workload.numTopk_);
   const bool useRankMajorTma = Layout == DispatchLayout::RANK_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
-  const bool useTokenMajorTma = Layout == DispatchLayout::TOKEN_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
-  const bool useTmaControlBlock = useRankMajorTma || useTokenMajorTma;
+  const bool useRankMajorTopkExpandedTma =
+      Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED && workload.numTopk_ <= RankMajorTmaMaxNTopk;
+  const bool useTmaControlBlock = useRankMajorTma || useRankMajorTopkExpandedTma;
   EP_HOST_ASSERT(!useTmaControlBlock || numBlocks > 1);
   static thread_local KernelConfigCache kernelConfig;
   const int residentBlocks = configureKernel(combineFunc, CombineNThreads, sharedBytes, context, kernelConfig);
@@ -871,10 +869,10 @@ inline void combineHidden(void* output, const void* expertOutput, const int64_t*
         context, numBlocks, stream);
   }
   if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
-    if (workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
+    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
       EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
       return combineHiddenMode<CombineMode::RANK_LOCAL_REDUCE, Hidden, DispatchDataType::BF16, 0,
-                               DispatchLayout::TOKEN_MAJOR, KernelSelector>(
+                               DispatchLayout::RANK_MAJOR_TOPK_EXPANDED, KernelSelector>(
           output, expertOutput, topkIndices, topkWeights, srcInfo, layoutRange, workload, recvBuffer,
           dispatchRecvBuffer, context, numBlocks, stream);
     }
@@ -937,10 +935,11 @@ inline void combineAlgorithm(void* output, const void* expertOutput, const int64
   static_assert(Mode == CombineMode::RANK_LOCAL_REDUCE || Mode == CombineMode::DIRECT_SEND);
   EP_HOST_ASSERT(workload.outputLayout_ == DispatchLayout::EXPERT_MAJOR ||
                  workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
-                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
+                 workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
   EP_HOST_ASSERT(isSupportedDispatchDataType(workload.dispatchDataType_));
   if constexpr (Mode == CombineMode::RANK_LOCAL_REDUCE) {
-    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR || workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
+    if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
+        workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
       EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
     }
   } else {

--- a/src/ext/ep/combine/common.cuh
+++ b/src/ext/ep/combine/common.cuh
@@ -848,13 +848,13 @@ inline void combineHiddenMode(void* output, const void* expertOutput, const int6
   const size_t sharedBytes = combineSharedBytes<Hidden, Mode, Layout>(nLocalExperts, workload.numTopk_);
   const bool useRankMajorTma = Layout == DispatchLayout::RANK_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
   const bool useTokenMajorTma = Layout == DispatchLayout::TOKEN_MAJOR && workload.numTopk_ <= RankMajorTmaMaxNTopk;
-  const int launchBlocks = numBlocks + ((useRankMajorTma || useTokenMajorTma) ? 1 : 0);
-  EP_HOST_ASSERT(!(useRankMajorTma || useTokenMajorTma) || launchBlocks > 1);
+  const bool useTmaControlBlock = useRankMajorTma || useTokenMajorTma;
+  EP_HOST_ASSERT(!useTmaControlBlock || numBlocks > 1);
   static thread_local KernelConfigCache kernelConfig;
   const int residentBlocks = configureKernel(combineFunc, CombineNThreads, sharedBytes, context, kernelConfig);
-  EP_HOST_ASSERT(residentBlocks >= launchBlocks);
+  EP_HOST_ASSERT(residentBlocks >= numBlocks);
 
-  combineFunc<<<dim3(launchBlocks), dim3(CombineNThreads), sharedBytes, stream>>>(
+  combineFunc<<<dim3(numBlocks), dim3(CombineNThreads), sharedBytes, stream>>>(
       output, expertOutput, topkIndices, topkWeights, srcInfo, layoutRange, workload, recvBuffer, dispatchRecvBuffer,
       context.devicePtr_);
   CUDA_CHECK(cudaGetLastError());

--- a/src/ext/ep/combine/common.cuh
+++ b/src/ext/ep/combine/common.cuh
@@ -535,10 +535,12 @@ MSCCLPP_DEVICE_INLINE int4 reduceRemoteTokenPartialsBf16x8(const void* expertOut
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void recvRankMajorTopkExpandedRemotePartials(
-    void* output, const void* expertOutput, const int64_t* __restrict__ topkIndices,
-    const float* __restrict__ topkWeights, int nTokens, int nTopk, int nExperts, int nRanks, int maxTokensPerRank,
-    const TransportView& transport) {
+MSCCLPP_DEVICE_INLINE void recvRankMajorTopkExpandedRemotePartials(void* output, const void* expertOutput,
+                                                                   const int64_t* __restrict__ topkIndices,
+                                                                   const float* __restrict__ topkWeights, int nTokens,
+                                                                   int nTopk, int nExperts, int nRanks,
+                                                                   int maxTokensPerRank,
+                                                                   const TransportView& transport) {
   constexpr int Bf16PerInt4 = sizeof(int4) / sizeof(Bf16);
   constexpr int HiddenInt4 = Hidden / Bf16PerInt4;
   const int threadId = static_cast<int>(threadIdx.x);

--- a/src/ext/ep/combine/rank_local_reduce_combine.cu
+++ b/src/ext/ep/combine/rank_local_reduce_combine.cu
@@ -53,5 +53,13 @@ void rankMajorGatherReduceCombine(void* output, const void* input, const int64_t
                      dispatchRecvBuffer, context, numBlocks, stream);
 }
 
+void tokenMajorGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
+                                   const Workload& workload, void* recvBuffer, void* dispatchRecvBuffer,
+                                   const DeviceContext& context, int numBlocks, cudaStream_t stream) {
+  EP_HOST_ASSERT(workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
+  runRankLocalReduce(output, input, topkIdx, topkWeights, nullptr, nullptr, workload, recvBuffer, dispatchRecvBuffer,
+                     context, numBlocks, stream);
+}
+
 }  // namespace ep
 }  // namespace mscclpp

--- a/src/ext/ep/combine/rank_local_reduce_combine.cu
+++ b/src/ext/ep/combine/rank_local_reduce_combine.cu
@@ -53,10 +53,11 @@ void rankMajorGatherReduceCombine(void* output, const void* input, const int64_t
                      dispatchRecvBuffer, context, numBlocks, stream);
 }
 
-void tokenMajorGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
-                                   const Workload& workload, void* recvBuffer, void* dispatchRecvBuffer,
-                                   const DeviceContext& context, int numBlocks, cudaStream_t stream) {
-  EP_HOST_ASSERT(workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
+void rankMajorTopkExpandedGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx,
+                                              const float* topkWeights, const Workload& workload, void* recvBuffer,
+                                              void* dispatchRecvBuffer, const DeviceContext& context, int numBlocks,
+                                              cudaStream_t stream) {
+  EP_HOST_ASSERT(workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
   runRankLocalReduce(output, input, topkIdx, topkWeights, nullptr, nullptr, workload, recvBuffer, dispatchRecvBuffer,
                      context, numBlocks, stream);
 }

--- a/src/ext/ep/common/latency.cuh
+++ b/src/ext/ep/common/latency.cuh
@@ -67,6 +67,12 @@ struct DispatchDataTypeTraits<DispatchDataType::BF16> {
 };
 
 template <>
+struct DispatchDataTypeTraits<DispatchDataType::FP16> {
+  using ElementType = __half;
+  using ScaleType = void;
+};
+
+template <>
 struct DispatchDataTypeTraits<DispatchDataType::FP8_E4M3> {
   using ElementType = Fp8E4M3;
   using ScaleType = float;
@@ -82,7 +88,8 @@ template <DispatchDataType DataType>
 using DispatchPayloadView = PayloadView<DispatchElementType<DataType>, DispatchScaleType<DataType>>;
 
 MSCCLPP_HOST_DEVICE_INLINE constexpr bool isSupportedDispatchDataType(DispatchDataType dataType) {
-  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP8_E4M3;
+  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP16 ||
+         dataType == DispatchDataType::FP8_E4M3;
 }
 
 template <DispatchDataType DataType>
@@ -94,6 +101,11 @@ MSCCLPP_HOST_DEVICE_INLINE size_t dispatchPayloadStride(int hidden, int nTopk, i
 MSCCLPP_HOST_DEVICE_INLINE constexpr int dispatchNWarpsPerGroup(int nTokens, int nBlocks) {
   return nTokens <= nBlocks ? DispatchNWarps
                             : (nTokens <= 2 * nBlocks ? DispatchNWarps / 2 : DispatchMinNWarpsPerGroup);
+}
+
+MSCCLPP_HOST_DEVICE_INLINE int dispatchSharedSendSlots(int nRanks) {
+  constexpr int NSendSlots = DispatchMaxNWarpGroups * WARP_SIZE;
+  return nRanks > NSendSlots ? nRanks : NSendSlots;
 }
 
 struct RecvTask {
@@ -188,7 +200,9 @@ MSCCLPP_HOST_DEVICE_INLINE size_t workspaceBytes(int nRanks, int nExperts, int m
 MSCCLPP_HOST_DEVICE_INLINE size_t dispatchSharedControlBytes(int nRanks) {
   constexpr int NSendSlots = DispatchMaxNWarpGroups * WARP_SIZE;
   const int nSlots = nRanks > NSendSlots ? nRanks : NSendSlots;
-  return configAlign<size_t>(static_cast<size_t>(nSlots) * sizeof(int), BufferAlignmentBytes);
+  const int nAggregatedCompletionSlots = DispatchMaxNWarpGroups * nRanks;
+  return configAlign<size_t>(static_cast<size_t>(nSlots + nAggregatedCompletionSlots) * sizeof(int),
+                             BufferAlignmentBytes);
 }
 
 template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>

--- a/src/ext/ep/common/latency.cuh
+++ b/src/ext/ep/common/latency.cuh
@@ -67,12 +67,6 @@ struct DispatchDataTypeTraits<DispatchDataType::BF16> {
 };
 
 template <>
-struct DispatchDataTypeTraits<DispatchDataType::FP16> {
-  using ElementType = __half;
-  using ScaleType = void;
-};
-
-template <>
 struct DispatchDataTypeTraits<DispatchDataType::FP8_E4M3> {
   using ElementType = Fp8E4M3;
   using ScaleType = float;
@@ -88,8 +82,7 @@ template <DispatchDataType DataType>
 using DispatchPayloadView = PayloadView<DispatchElementType<DataType>, DispatchScaleType<DataType>>;
 
 MSCCLPP_HOST_DEVICE_INLINE constexpr bool isSupportedDispatchDataType(DispatchDataType dataType) {
-  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP16 ||
-         dataType == DispatchDataType::FP8_E4M3;
+  return dataType == DispatchDataType::BF16 || dataType == DispatchDataType::FP8_E4M3;
 }
 
 template <DispatchDataType DataType>

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -109,8 +109,8 @@ MSCCLPP_DEVICE_INLINE void flushAggregatedDispatchCompletions(WorkspaceView& wor
   for (int dstRank = laneId; dstRank < nRanks; dstRank += WARP_SIZE) {
     const int nCompleted = completionCounts[dstRank];
     if (nCompleted > 0) {
-      (void)mscclpp::atomicFetchAdd<int, mscclpp::scopeDevice>(
-          workspaceView.dispatchRankPayloadCompletions_ + dstRank, nCompleted, mscclpp::memoryOrderRelease);
+      (void)mscclpp::atomicFetchAdd<int, mscclpp::scopeDevice>(workspaceView.dispatchRankPayloadCompletions_ + dstRank,
+                                                               nCompleted, mscclpp::memoryOrderRelease);
     }
   }
 }
@@ -198,8 +198,7 @@ MSCCLPP_DEVICE_INLINE void countTokenMajorRoutes(int* rankTokenCounts, const int
 
 MSCCLPP_DEVICE_INLINE void dispatchTokenMajorNotify(const TransportView& transport, int nExperts, int nRanks,
                                                     const int64_t* __restrict__ topkIndices, int nTokens, int nTopk,
-                                                    void* recvBuffer, void* workspace, uint32_t epoch,
-                                                    int* sharedMem) {
+                                                    void* recvBuffer, void* workspace, uint32_t epoch, int* sharedMem) {
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
   auto* rankTokenCounts = sharedMem;
   countTokenMajorRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -94,6 +94,33 @@ MSCCLPP_DEVICE_INLINE void completeRankMajorTokenStore(WorkspaceView& workspaceV
       workspaceView.dispatchRankPayloadCompletions_ + destinationRank, 1, mscclpp::memoryOrderRelease);
 }
 
+MSCCLPP_DEVICE_INLINE int* aggregatedDispatchCompletionCounts(int* sharedMem, int nRanks, int warpGroupId) {
+  return sharedMem + dispatchSharedSendSlots(nRanks) + static_cast<size_t>(warpGroupId) * nRanks;
+}
+
+MSCCLPP_DEVICE_INLINE void initAggregatedDispatchCompletions(int* completionCounts, int nRanks, int laneId) {
+  for (int dstRank = laneId; dstRank < nRanks; dstRank += WARP_SIZE) completionCounts[dstRank] = 0;
+  __syncwarp();
+}
+
+MSCCLPP_DEVICE_INLINE void flushAggregatedDispatchCompletions(WorkspaceView& workspaceView, int* completionCounts,
+                                                              int nRanks, int laneId) {
+  __syncwarp();
+  for (int dstRank = laneId; dstRank < nRanks; dstRank += WARP_SIZE) {
+    const int nCompleted = completionCounts[dstRank];
+    if (nCompleted > 0) {
+      (void)mscclpp::atomicFetchAdd<int, mscclpp::scopeDevice>(
+          workspaceView.dispatchRankPayloadCompletions_ + dstRank, nCompleted, mscclpp::memoryOrderRelease);
+    }
+  }
+}
+
+MSCCLPP_DEVICE_INLINE void writeRankMajorCounts(const TransportView& transport, const int* rankTokenCounts, int nRanks,
+                                                void* recvBuffer, uint32_t epoch);
+
+MSCCLPP_DEVICE_INLINE void publishDispatchPayloads(const TransportView& transport, const int* rankTokenCounts,
+                                                   int nRanks, WorkspaceView workspaceView);
+
 template <int Hidden>
 MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTopkIdx, float* outputTopkWeights,
                                                      const void* inputTokens, int nExperts, int nRanks,
@@ -150,6 +177,159 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTo
                           nLocalExperts, maxTokensPerRank, invalidTokenExpertId);
     completeRankMajorTokenStore(workspaceView, completionRank);
     if (tokenIdx + tokenStride < nTokens) __syncwarp();
+  }
+}
+
+MSCCLPP_DEVICE_INLINE void countTokenMajorRoutes(int* rankTokenCounts, const int64_t* __restrict__ topkIndices,
+                                                 int nTokens, int nTopk, int nRanks, int nExperts) {
+  const int threadId = static_cast<int>(threadIdx.x);
+  const int warpId = threadId / WARP_SIZE;
+  const int laneId = get_lane_id();
+  const int nLocalExperts = nExperts / nRanks;
+  for (int rankIdx = threadId; rankIdx < nRanks; rankIdx += blockDim.x) rankTokenCounts[rankIdx] = 0;
+  __syncthreads();
+  for (int tokenIdx = warpId; tokenIdx < nTokens; tokenIdx += DispatchNWarps) {
+    const int expert = laneId < nTopk ? static_cast<int>(topkIndices[tokenIdx * nTopk + laneId]) : -1;
+    const int dstRank = expert >= 0 ? expert / nLocalExperts : -1;
+    if (dstRank >= 0) atomicAdd_block(rankTokenCounts + dstRank, 1);
+  }
+  __syncthreads();
+}
+
+MSCCLPP_DEVICE_INLINE void dispatchTokenMajorNotify(const TransportView& transport, int nExperts, int nRanks,
+                                                    const int64_t* __restrict__ topkIndices, int nTokens, int nTopk,
+                                                    void* recvBuffer, void* workspace, uint32_t epoch,
+                                                    int* sharedMem) {
+  WorkspaceView workspaceView(workspace, nRanks, nExperts);
+  auto* rankTokenCounts = sharedMem;
+  countTokenMajorRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);
+  writeRankMajorCounts(transport, rankTokenCounts, nRanks, recvBuffer, epoch);
+  publishDispatchPayloads(transport, rankTokenCounts, nRanks, workspaceView);
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void issueTokenMajorTokenStore(void* output, const TransportView& transport, int destinationRank,
+                                                     size_t destIndex, void* stagedToken) {
+  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
+  void* destinationBuffer = transport.mappedBuffer(output, destinationRank);
+  auto* destinationRow = reinterpret_cast<uint8_t*>(destinationBuffer) + destIndex * HiddenBytes;
+  mscclpp::bulkStore(destinationRow, stagedToken, static_cast<uint32_t>(HiddenBytes));
+  mscclpp::bulkStoreCommit();
+}
+
+MSCCLPP_DEVICE_INLINE void sendTokenMajorMetadata(const TransportView& transport, int* outputTopkIdx,
+                                                  float* outputTopkWeights, int destinationRank, size_t destIndex,
+                                                  int expert, float weight) {
+  auto* destinationTopkIdx = reinterpret_cast<int*>(transport.mappedBuffer(outputTopkIdx, destinationRank));
+  auto* destinationTopkWeights = reinterpret_cast<float*>(transport.mappedBuffer(outputTopkWeights, destinationRank));
+  destinationTopkIdx[destIndex] = expert;
+  destinationTopkWeights[destIndex] = weight;
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputTopkIdx, float* outputTopkWeights,
+                                                      const void* inputTokens, int nExperts, int nRanks,
+                                                      const int64_t* __restrict__ topkIndices,
+                                                      const float* __restrict__ topkWeights, int nTokens, int nTopk,
+                                                      int maxTokensPerRank, const TransportView& transport,
+                                                      void* workspace, int nPayloadBlocks, int* sharedMem) {
+  if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return;
+
+  const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
+  const int laneId = get_lane_id();
+  const int senderBlockIdx = static_cast<int>(blockIdx.x) - 1;
+  const int nWarpsPerGroup = dispatchNWarpsPerGroup(nTokens, nPayloadBlocks);
+  const int nWarpGroups = DispatchNWarps / nWarpsPerGroup;
+  const int warpGroupId = warpId / nWarpsPerGroup;
+  const int subWarpId = warpId % nWarpsPerGroup;
+  if (subWarpId != 0) return;
+
+  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
+  constexpr int HiddenVectors = Hidden / mscclpp::bf16x8::Size;
+  const int nLocalExperts = nExperts / nRanks;
+  const size_t sharedTokenStride = dispatchPayloadStride<DispatchDataType::BF16>(Hidden, nTopk, 0);
+  auto* sharedTokenBase = reinterpret_cast<uint8_t*>(sharedMem) + dispatchSharedControlBytes(nRanks);
+  auto* bulkBarriers =
+      reinterpret_cast<mscclpp::BulkBarrier*>(sharedTokenBase + DispatchMaxNWarpGroups * sharedTokenStride);
+  WorkspaceView workspaceView(workspace, nRanks, nExperts);
+  auto* completionCounts = aggregatedDispatchCompletionCounts(sharedMem, nRanks, warpGroupId);
+
+  auto* stagedToken = sharedTokenBase + static_cast<size_t>(warpGroupId) * sharedTokenStride;
+  auto* bulkBarrier = bulkBarriers + warpGroupId;
+  const int tokenStride = nPayloadBlocks * nWarpGroups;
+  const int firstTokenIdx = senderBlockIdx * nWarpGroups + warpGroupId;
+  uint32_t sendBulkPhase = 0;
+  if (firstTokenIdx < nTokens && laneId == 0) bulkBarrier->init();
+  initAggregatedDispatchCompletions(completionCounts, nRanks, laneId);
+
+  for (int tokenIdx = firstTokenIdx; tokenIdx < nTokens; tokenIdx += tokenStride) {
+    const auto* inputData =
+        reinterpret_cast<const mscclpp::bf16x8*>(inputTokens) + static_cast<size_t>(tokenIdx) * HiddenVectors;
+    if (laneId == 0) {
+      bulkBarrier->arriveAndExpect(static_cast<uint32_t>(HiddenBytes));
+      mscclpp::bulkLoad(stagedToken, inputData, static_cast<uint32_t>(HiddenBytes), *bulkBarrier);
+    }
+
+    const int expert = laneId < nTopk ? static_cast<int>(topkIndices[tokenIdx * nTopk + laneId]) : -1;
+    const int dstRank = expert >= 0 ? expert / nLocalExperts : -1;
+    const float weight =
+        laneId < nTopk ? (topkWeights == nullptr ? 1.0f : topkWeights[tokenIdx * nTopk + laneId]) : 0.0f;
+    const size_t destIndex = (static_cast<size_t>(transport.rank_) * maxTokensPerRank + tokenIdx) * nTopk + laneId;
+
+    if (laneId == 0) bulkBarrier->wait(sendBulkPhase);
+    __syncwarp();
+    mscclpp::bulkFence();
+
+    if (dstRank >= 0) {
+      issueTokenMajorTokenStore<Hidden>(output, transport, dstRank, destIndex, stagedToken);
+      sendTokenMajorMetadata(transport, outputTopkIdx, outputTopkWeights, dstRank, destIndex, expert, weight);
+      mscclpp::bulkStoreWait();
+      atomicAdd_block(completionCounts + dstRank, 1);
+    }
+    __syncwarp();
+  }
+  flushAggregatedDispatchCompletions(workspaceView, completionCounts, nRanks, laneId);
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajor(void* output, int* outputTopkIdx, float* outputTopkWeights,
+                                                  const void* inputTokens, const TransportView& transport, int nExperts,
+                                                  int nRanks, const int64_t* __restrict__ topkIndices,
+                                                  const float* __restrict__ topkWeights, int nTokens, int nTopk,
+                                                  int maxTokensPerRank, void* recvBuffer, void* workspace,
+                                                  uint32_t epoch, int* sharedMem) {
+  const int nWorkerBlocks = static_cast<int>(gridDim.x) - DispatchControlBlocks;
+  if (static_cast<int>(blockIdx.x) > 0 && static_cast<int>(blockIdx.x) <= nWorkerBlocks) {
+    dispatchSendTokenMajorBf16<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts, nRanks,
+                                       topkIndices, topkWeights, nTokens, nTopk, maxTokensPerRank, transport, workspace,
+                                       nWorkerBlocks, sharedMem);
+  } else if (static_cast<int>(blockIdx.x) == nWorkerBlocks + 1) {
+    dispatchTokenMajorNotify(transport, nExperts, nRanks, topkIndices, nTokens, nTopk, recvBuffer, workspace, epoch,
+                             sharedMem);
+  }
+}
+
+MSCCLPP_DEVICE_INLINE void dispatchRecvTokenMajor(int* outputCount, const TransportView& transport, int nExperts,
+                                                  int nRanks, void* recvBuffer, void* workspace, uint32_t epoch,
+                                                  int* sharedMem) {
+  const int sourceRank = static_cast<int>(blockIdx.x);
+  if (sourceRank >= nRanks) return;
+  auto* rankTokenCounts = reinterpret_cast<mscclpp::LL8Packet*>(recvBuffer);
+  int nStores = 0;
+  if (threadIdx.x == 0) {
+    nStores = static_cast<int>(rankTokenCounts[sourceRank].read(epoch, -1));
+    outputCount[sourceRank] = nStores;
+    sharedMem[0] = nStores;
+  }
+  __syncthreads();
+  nStores = sharedMem[0];
+  WorkspaceView workspaceView(workspace, nRanks, nExperts);
+  if (threadIdx.x == 0 && nStores > 0) {
+    if (transport.isSelf(sourceRank)) {
+      workspaceView.dispatchLocalPayloadReady_->acquire();
+    } else {
+      transport.baseMemoryChannels_[sourceRank].wait(-1);
+    }
   }
 }
 
@@ -784,6 +964,11 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
     dispatchSendRankMajor<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks,
                                   topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId, maxTokensPerRank,
                                   recvBuffer, context->workspace_, epoch, sharedMem);
+  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+    static_assert(DataType == DispatchDataType::BF16);
+    dispatchSendTokenMajor<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks,
+                                   topkIndices, topkWeights, nTokens, nTopk, maxTokensPerRank, recvBuffer,
+                                   context->workspace_, epoch, sharedMem);
   } else {
     dispatchSend<Hidden, DataType, ScaleBlockSize>(inputTokens, transport, nExperts, nRanks, topkIndices, topkWeights,
                                                    nTokens, nTopk, maxTokensPerRank, recvBuffer, context->workspace_,
@@ -794,6 +979,11 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
     if (static_cast<int>(blockIdx.x) < nRanks) {
       dispatchRecvRankMajor(outputTopkIdx, outputTopkWeights, outputCount, transport, nExperts, nRanks, nTopk,
                             maxTokensPerRank, invalidTokenExpertId, recvBuffer, context->workspace_, epoch, sharedMem);
+    }
+  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+    if (static_cast<int>(blockIdx.x) < nRanks) {
+      dispatchRecvTokenMajor(outputCount, transport, nExperts, nRanks, recvBuffer, context->workspace_, epoch,
+                             sharedMem);
     }
   } else {
     if (static_cast<int>(blockIdx.x) == 0) {
@@ -843,6 +1033,11 @@ inline void dispatchHidden(void* output, void* outputScales, int* outputSrcInfo,
     return dispatchHiddenMode<Hidden, DispatchDataType::BF16, 0, Layout, KernelSelector>(
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
         topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
+  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+    EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
+    return dispatchHiddenMode<Hidden, DispatchDataType::BF16, 0, Layout, KernelSelector>(
+        output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
+        topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
   } else {
     switch (workload.dispatchDataType_) {
       case DispatchDataType::BF16:
@@ -873,6 +1068,11 @@ inline void dispatchLayout(void* output, void* outputScales, int* outputSrcInfo,
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
         topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
   }
+  if (workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
+    return dispatchHidden<Hidden, DispatchLayout::TOKEN_MAJOR>(
+        output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
+        topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
+  }
   EP_HOST_ASSERT(false && "unsupported dispatch layout");
 }
 
@@ -899,14 +1099,16 @@ inline void dispatchAlgorithm(void* output, void* outputScales, int* outputSrcIn
   EP_HOST_ASSERT(workload.outputLayout_ == Layout);
   EP_HOST_ASSERT(isSupportedDispatchDataType(workload.dispatchDataType_));
   EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16 || outputScales != nullptr);
-  EP_HOST_ASSERT(outputSrcInfo != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR);
+  EP_HOST_ASSERT(outputSrcInfo != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
+                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
   EP_HOST_ASSERT(outputCount != nullptr);
-  EP_HOST_ASSERT(outputLayout != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR);
-  if constexpr (Layout == DispatchLayout::RANK_MAJOR) {
+  EP_HOST_ASSERT(outputLayout != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
+                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
+  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::TOKEN_MAJOR) {
     EP_HOST_ASSERT(outputTopkIdx != nullptr);
     EP_HOST_ASSERT(outputTopkWeights != nullptr);
   }
-  if constexpr (Layout == DispatchLayout::RANK_MAJOR) {
+  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::TOKEN_MAJOR) {
     EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
   }
   EP_HOST_ASSERT(workload.numTokens_ == 0 || input != nullptr);

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -180,8 +180,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTo
   }
 }
 
-MSCCLPP_DEVICE_INLINE void countTokenMajorRoutes(int* rankTokenCounts, const int64_t* __restrict__ topkIndices,
-                                                 int nTokens, int nTopk, int nRanks, int nExperts) {
+MSCCLPP_DEVICE_INLINE void countRankMajorTopkExpandedRoutes(int* rankTokenCounts,
+                                                            const int64_t* __restrict__ topkIndices, int nTokens,
+                                                            int nTopk, int nRanks, int nExperts) {
   const int threadId = static_cast<int>(threadIdx.x);
   const int warpId = threadId / WARP_SIZE;
   const int laneId = get_lane_id();
@@ -196,9 +197,10 @@ MSCCLPP_DEVICE_INLINE void countTokenMajorRoutes(int* rankTokenCounts, const int
   __syncthreads();
 }
 
-MSCCLPP_DEVICE_INLINE void invalidateTokenMajorPadding(const TransportView& transport, int* outputTopkIdx,
-                                                       float* outputTopkWeights, int nRanks, int nTokens, int nTopk,
-                                                       int maxTokensPerRank, int invalidTokenExpertId) {
+MSCCLPP_DEVICE_INLINE void invalidateRankMajorTopkExpandedPadding(const TransportView& transport, int* outputTopkIdx,
+                                                                  float* outputTopkWeights, int nRanks, int nTokens,
+                                                                  int nTopk, int maxTokensPerRank,
+                                                                  int invalidTokenExpertId) {
   const int metadataEntriesPerRank = maxTokensPerRank * nTopk;
   for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
     auto* destinationTopkIdx = reinterpret_cast<int*>(transport.mappedBuffer(outputTopkIdx, destinationRank));
@@ -214,23 +216,23 @@ MSCCLPP_DEVICE_INLINE void invalidateTokenMajorPadding(const TransportView& tran
   __syncthreads();
 }
 
-MSCCLPP_DEVICE_INLINE void dispatchTokenMajorNotify(const TransportView& transport, int* outputTopkIdx,
-                                                    float* outputTopkWeights, int nExperts, int nRanks,
-                                                    const int64_t* __restrict__ topkIndices, int nTokens, int nTopk,
-                                                    int maxTokensPerRank, int invalidTokenExpertId, void* recvBuffer,
-                                                    void* workspace, uint32_t epoch, int* sharedMem) {
+MSCCLPP_DEVICE_INLINE void dispatchRankMajorTopkExpandedNotify(
+    const TransportView& transport, int* outputTopkIdx, float* outputTopkWeights, int nExperts, int nRanks,
+    const int64_t* __restrict__ topkIndices, int nTokens, int nTopk, int maxTokensPerRank, int invalidTokenExpertId,
+    void* recvBuffer, void* workspace, uint32_t epoch, int* sharedMem) {
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
   auto* rankTokenCounts = sharedMem;
-  countTokenMajorRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);
-  invalidateTokenMajorPadding(transport, outputTopkIdx, outputTopkWeights, nRanks, nTokens, nTopk, maxTokensPerRank,
-                              invalidTokenExpertId);
+  countRankMajorTopkExpandedRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);
+  invalidateRankMajorTopkExpandedPadding(transport, outputTopkIdx, outputTopkWeights, nRanks, nTokens, nTopk,
+                                         maxTokensPerRank, invalidTokenExpertId);
   writeRankMajorCounts(transport, rankTokenCounts, nRanks, recvBuffer, epoch);
   publishDispatchPayloads(transport, rankTokenCounts, nRanks, workspaceView);
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void issueTokenMajorTokenStore(void* output, const TransportView& transport, int destinationRank,
-                                                     size_t destIndex, void* stagedToken) {
+MSCCLPP_DEVICE_INLINE void issueRankMajorTopkExpandedTokenStore(void* output, const TransportView& transport,
+                                                                int destinationRank, size_t destIndex,
+                                                                void* stagedToken) {
   constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
   void* destinationBuffer = transport.mappedBuffer(output, destinationRank);
   auto* destinationRow = reinterpret_cast<uint8_t*>(destinationBuffer) + destIndex * HiddenBytes;
@@ -238,9 +240,9 @@ MSCCLPP_DEVICE_INLINE void issueTokenMajorTokenStore(void* output, const Transpo
   mscclpp::bulkStoreCommit();
 }
 
-MSCCLPP_DEVICE_INLINE void sendTokenMajorMetadata(const TransportView& transport, int* outputTopkIdx,
-                                                  float* outputTopkWeights, int destinationRank, size_t destIndex,
-                                                  int expert, float weight) {
+MSCCLPP_DEVICE_INLINE void sendRankMajorTopkExpandedMetadata(const TransportView& transport, int* outputTopkIdx,
+                                                             float* outputTopkWeights, int destinationRank,
+                                                             size_t destIndex, int expert, float weight) {
   auto* destinationTopkIdx = reinterpret_cast<int*>(transport.mappedBuffer(outputTopkIdx, destinationRank));
   auto* destinationTopkWeights = reinterpret_cast<float*>(transport.mappedBuffer(outputTopkWeights, destinationRank));
   destinationTopkIdx[destIndex] = expert;
@@ -248,13 +250,11 @@ MSCCLPP_DEVICE_INLINE void sendTokenMajorMetadata(const TransportView& transport
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputTopkIdx, float* outputTopkWeights,
-                                                      const void* inputTokens, int nExperts, int nRanks,
-                                                      const int64_t* __restrict__ topkIndices,
-                                                      const float* __restrict__ topkWeights, int nTokens, int nTopk,
-                                                      int invalidTokenExpertId, int maxTokensPerRank,
-                                                      const TransportView& transport, void* workspace,
-                                                      int nPayloadBlocks, int* sharedMem) {
+MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorTopkExpandedBf16(
+    void* output, int* outputTopkIdx, float* outputTopkWeights, const void* inputTokens, int nExperts, int nRanks,
+    const int64_t* __restrict__ topkIndices, const float* __restrict__ topkWeights, int nTokens, int nTopk,
+    int invalidTokenExpertId, int maxTokensPerRank, const TransportView& transport, void* workspace, int nPayloadBlocks,
+    int* sharedMem) {
   if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return;
 
   const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
@@ -305,13 +305,13 @@ MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputT
     if (laneId < nTopk) {
       for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
         const bool isLocal = destinationRank == dstRank;
-        sendTokenMajorMetadata(transport, outputTopkIdx, outputTopkWeights, destinationRank, destIndex,
-                               isLocal ? expert : invalidTokenExpertId, isLocal ? weight : 0.0f);
+        sendRankMajorTopkExpandedMetadata(transport, outputTopkIdx, outputTopkWeights, destinationRank, destIndex,
+                                          isLocal ? expert : invalidTokenExpertId, isLocal ? weight : 0.0f);
       }
     }
 
     if (dstRank >= 0) {
-      issueTokenMajorTokenStore<Hidden>(output, transport, dstRank, destIndex, stagedToken);
+      issueRankMajorTopkExpandedTokenStore<Hidden>(output, transport, dstRank, destIndex, stagedToken);
       mscclpp::bulkStoreWait();
       atomicAdd_block(completionCounts + dstRank, 1);
     }
@@ -321,26 +321,27 @@ MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputT
 }
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajor(void* output, int* outputTopkIdx, float* outputTopkWeights,
-                                                  const void* inputTokens, const TransportView& transport, int nExperts,
-                                                  int nRanks, const int64_t* __restrict__ topkIndices,
-                                                  const float* __restrict__ topkWeights, int nTokens, int nTopk,
-                                                  int invalidTokenExpertId, int maxTokensPerRank, void* recvBuffer,
-                                                  void* workspace, uint32_t epoch, int* sharedMem) {
+MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorTopkExpanded(
+    void* output, int* outputTopkIdx, float* outputTopkWeights, const void* inputTokens, const TransportView& transport,
+    int nExperts, int nRanks, const int64_t* __restrict__ topkIndices, const float* __restrict__ topkWeights,
+    int nTokens, int nTopk, int invalidTokenExpertId, int maxTokensPerRank, void* recvBuffer, void* workspace,
+    uint32_t epoch, int* sharedMem) {
   const int nWorkerBlocks = static_cast<int>(gridDim.x) - DispatchControlBlocks;
   if (static_cast<int>(blockIdx.x) > 0 && static_cast<int>(blockIdx.x) <= nWorkerBlocks) {
-    dispatchSendTokenMajorBf16<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts, nRanks,
-                                       topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId,
-                                       maxTokensPerRank, transport, workspace, nWorkerBlocks, sharedMem);
+    dispatchSendRankMajorTopkExpandedBf16<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts,
+                                                  nRanks, topkIndices, topkWeights, nTokens, nTopk,
+                                                  invalidTokenExpertId, maxTokensPerRank, transport, workspace,
+                                                  nWorkerBlocks, sharedMem);
   } else if (static_cast<int>(blockIdx.x) == nWorkerBlocks + 1) {
-    dispatchTokenMajorNotify(transport, outputTopkIdx, outputTopkWeights, nExperts, nRanks, topkIndices, nTokens,
-                             nTopk, maxTokensPerRank, invalidTokenExpertId, recvBuffer, workspace, epoch, sharedMem);
+    dispatchRankMajorTopkExpandedNotify(transport, outputTopkIdx, outputTopkWeights, nExperts, nRanks, topkIndices,
+                                        nTokens, nTopk, maxTokensPerRank, invalidTokenExpertId, recvBuffer, workspace,
+                                        epoch, sharedMem);
   }
 }
 
-MSCCLPP_DEVICE_INLINE void dispatchRecvTokenMajor(int* outputCount, const TransportView& transport, int nExperts,
-                                                  int nRanks, void* recvBuffer, void* workspace, uint32_t epoch,
-                                                  int* sharedMem) {
+MSCCLPP_DEVICE_INLINE void dispatchRecvRankMajorTopkExpanded(int* outputCount, const TransportView& transport,
+                                                             int nExperts, int nRanks, void* recvBuffer,
+                                                             void* workspace, uint32_t epoch, int* sharedMem) {
   const int sourceRank = static_cast<int>(blockIdx.x);
   if (sourceRank >= nRanks) return;
   auto* rankTokenCounts = reinterpret_cast<mscclpp::LL8Packet*>(recvBuffer);
@@ -993,11 +994,12 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
     dispatchSendRankMajor<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks,
                                   topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId, maxTokensPerRank,
                                   recvBuffer, context->workspace_, epoch, sharedMem);
-  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+  } else if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     static_assert(DataType == DispatchDataType::BF16);
-    dispatchSendTokenMajor<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks,
-                                   topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId, maxTokensPerRank,
-                                   recvBuffer, context->workspace_, epoch, sharedMem);
+    dispatchSendRankMajorTopkExpanded<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport,
+                                              nExperts, nRanks, topkIndices, topkWeights, nTokens, nTopk,
+                                              invalidTokenExpertId, maxTokensPerRank, recvBuffer, context->workspace_,
+                                              epoch, sharedMem);
   } else {
     dispatchSend<Hidden, DataType, ScaleBlockSize>(inputTokens, transport, nExperts, nRanks, topkIndices, topkWeights,
                                                    nTokens, nTopk, maxTokensPerRank, recvBuffer, context->workspace_,
@@ -1009,10 +1011,10 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
       dispatchRecvRankMajor(outputTopkIdx, outputTopkWeights, outputCount, transport, nExperts, nRanks, nTopk,
                             maxTokensPerRank, invalidTokenExpertId, recvBuffer, context->workspace_, epoch, sharedMem);
     }
-  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+  } else if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     if (static_cast<int>(blockIdx.x) < nRanks) {
-      dispatchRecvTokenMajor(outputCount, transport, nExperts, nRanks, recvBuffer, context->workspace_, epoch,
-                             sharedMem);
+      dispatchRecvRankMajorTopkExpanded(outputCount, transport, nExperts, nRanks, recvBuffer, context->workspace_,
+                                        epoch, sharedMem);
     }
   } else {
     if (static_cast<int>(blockIdx.x) == 0) {
@@ -1062,7 +1064,7 @@ inline void dispatchHidden(void* output, void* outputScales, int* outputSrcInfo,
     return dispatchHiddenMode<Hidden, DispatchDataType::BF16, 0, Layout, KernelSelector>(
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
         topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
-  } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
+  } else if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
     return dispatchHiddenMode<Hidden, DispatchDataType::BF16, 0, Layout, KernelSelector>(
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
@@ -1097,8 +1099,8 @@ inline void dispatchLayout(void* output, void* outputScales, int* outputSrcInfo,
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
         topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
   }
-  if (workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR) {
-    return dispatchHidden<Hidden, DispatchLayout::TOKEN_MAJOR>(
+  if (workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
+    return dispatchHidden<Hidden, DispatchLayout::RANK_MAJOR_TOPK_EXPANDED>(
         output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input,
         topkIdx, topkWeights, workload, recvBuffer, context, numBlocks, stream);
   }
@@ -1129,15 +1131,15 @@ inline void dispatchAlgorithm(void* output, void* outputScales, int* outputSrcIn
   EP_HOST_ASSERT(isSupportedDispatchDataType(workload.dispatchDataType_));
   EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16 || outputScales != nullptr);
   EP_HOST_ASSERT(outputSrcInfo != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
-                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
+                 workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
   EP_HOST_ASSERT(outputCount != nullptr);
   EP_HOST_ASSERT(outputLayout != nullptr || workload.outputLayout_ == DispatchLayout::RANK_MAJOR ||
-                 workload.outputLayout_ == DispatchLayout::TOKEN_MAJOR);
-  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::TOKEN_MAJOR) {
+                 workload.outputLayout_ == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
+  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(outputTopkIdx != nullptr);
     EP_HOST_ASSERT(outputTopkWeights != nullptr);
   }
-  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::TOKEN_MAJOR) {
+  if constexpr (Layout == DispatchLayout::RANK_MAJOR || Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(workload.dispatchDataType_ == DispatchDataType::BF16);
   }
   EP_HOST_ASSERT(workload.numTokens_ == 0 || input != nullptr);

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -122,6 +122,65 @@ MSCCLPP_DEVICE_INLINE void publishDispatchPayloads(const TransportView& transpor
                                                    int nRanks, WorkspaceView workspaceView);
 
 template <int Hidden>
+struct RankMajorSendState {
+  int laneId_;
+  int warpGroupId_;
+  int tokenStride_;
+  int firstTokenIdx_;
+  uint8_t* stagedToken_;
+  mscclpp::BulkBarrier* bulkBarrier_;
+  uint32_t bulkPhase_;
+};
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE bool initRankMajorSendState(RankMajorSendState<Hidden>& state, int nTokens, int nTopk,
+                                                  int nRanks, int nPayloadBlocks, int* sharedMem) {
+  if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return false;
+
+  const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
+  const int senderBlockIdx = static_cast<int>(blockIdx.x) - 1;
+  const int nWarpsPerGroup = dispatchNWarpsPerGroup(nTokens, nPayloadBlocks);
+  const int nWarpGroups = DispatchNWarps / nWarpsPerGroup;
+  const int subWarpId = warpId % nWarpsPerGroup;
+  if (subWarpId != 0) return false;
+
+  const size_t sharedTokenStride = dispatchPayloadStride<DispatchDataType::BF16>(Hidden, nTopk, 0);
+  auto* sharedTokenBase = reinterpret_cast<uint8_t*>(sharedMem) + dispatchSharedControlBytes(nRanks);
+  auto* bulkBarriers =
+      reinterpret_cast<mscclpp::BulkBarrier*>(sharedTokenBase + DispatchMaxNWarpGroups * sharedTokenStride);
+
+  state.laneId_ = get_lane_id();
+  state.warpGroupId_ = warpId / nWarpsPerGroup;
+  state.tokenStride_ = nPayloadBlocks * nWarpGroups;
+  state.firstTokenIdx_ = senderBlockIdx * nWarpGroups + state.warpGroupId_;
+  state.stagedToken_ = sharedTokenBase + static_cast<size_t>(state.warpGroupId_) * sharedTokenStride;
+  state.bulkBarrier_ = bulkBarriers + state.warpGroupId_;
+  state.bulkPhase_ = 0;
+  if (state.firstTokenIdx_ < nTokens && state.laneId_ == 0) state.bulkBarrier_->init();
+  return true;
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void stageRankMajorBf16Token(const void* inputTokens, int tokenIdx,
+                                                   RankMajorSendState<Hidden>& state) {
+  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
+  constexpr int HiddenVectors = Hidden / mscclpp::bf16x8::Size;
+  const auto* inputData =
+      reinterpret_cast<const mscclpp::bf16x8*>(inputTokens) + static_cast<size_t>(tokenIdx) * HiddenVectors;
+  if (state.laneId_ == 0) {
+    state.bulkBarrier_->arriveAndExpect(static_cast<uint32_t>(HiddenBytes));
+    mscclpp::bulkLoad(state.stagedToken_, inputData, static_cast<uint32_t>(HiddenBytes), *state.bulkBarrier_);
+  }
+}
+
+template <int Hidden>
+MSCCLPP_DEVICE_INLINE void waitRankMajorBf16Token(RankMajorSendState<Hidden>& state) {
+  if (state.laneId_ == 0) state.bulkBarrier_->wait(state.bulkPhase_);
+  __syncwarp();
+  mscclpp::bulkFence();
+}
+
+template <int Hidden>
 MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTopkIdx, float* outputTopkWeights,
                                                      const void* inputTokens, int nExperts, int nRanks,
                                                      const int64_t* __restrict__ topkIndices,
@@ -129,54 +188,27 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTo
                                                      int invalidTokenExpertId, int maxTokensPerRank,
                                                      const TransportView& transport, void* workspace,
                                                      int nPayloadBlocks, int* sharedMem) {
-  if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return;
+  RankMajorSendState<Hidden> sendState;
+  if (!initRankMajorSendState(sendState, nTokens, nTopk, nRanks, nPayloadBlocks, sharedMem)) return;
 
-  const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
-  const int laneId = get_lane_id();
-  const int senderBlockIdx = static_cast<int>(blockIdx.x) - 1;
-  const int nWarpsPerGroup = dispatchNWarpsPerGroup(nTokens, nPayloadBlocks);
-  const int nWarpGroups = DispatchNWarps / nWarpsPerGroup;
-  const int warpGroupId = warpId / nWarpsPerGroup;
-  const int subWarpId = warpId % nWarpsPerGroup;
-  if (subWarpId != 0) return;
-
-  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
-  constexpr int HiddenVectors = Hidden / mscclpp::bf16x8::Size;
+  const int laneId = sendState.laneId_;
   const int nLocalExperts = nExperts / nRanks;
-  const size_t sharedTokenStride = dispatchPayloadStride<DispatchDataType::BF16>(Hidden, nTopk, 0);
-  auto* sharedTokenBase = reinterpret_cast<uint8_t*>(sharedMem) + dispatchSharedControlBytes(nRanks);
-  auto* sendBulkBarriers =
-      reinterpret_cast<mscclpp::BulkBarrier*>(sharedTokenBase + DispatchMaxNWarpGroups * sharedTokenStride);
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
 
-  auto* stagedToken = sharedTokenBase + static_cast<size_t>(warpGroupId) * sharedTokenStride;
-  auto* bulkBarrier = sendBulkBarriers + warpGroupId;
-  const int tokenStride = nPayloadBlocks * nWarpGroups;
-  const int firstTokenIdx = senderBlockIdx * nWarpGroups + warpGroupId;
-  uint32_t sendBulkPhase = 0;
-  if (firstTokenIdx < nTokens && laneId == 0) bulkBarrier->init();
-
-  for (int tokenIdx = firstTokenIdx; tokenIdx < nTokens; tokenIdx += tokenStride) {
-    const auto* inputData =
-        reinterpret_cast<const mscclpp::bf16x8*>(inputTokens) + static_cast<size_t>(tokenIdx) * HiddenVectors;
-    if (laneId == 0) {
-      bulkBarrier->arriveAndExpect(static_cast<uint32_t>(HiddenBytes));
-      mscclpp::bulkLoad(stagedToken, inputData, static_cast<uint32_t>(HiddenBytes), *bulkBarrier);
-    }
+  for (int tokenIdx = sendState.firstTokenIdx_; tokenIdx < nTokens; tokenIdx += sendState.tokenStride_) {
+    stageRankMajorBf16Token(inputTokens, tokenIdx, sendState);
     const RankMajorRoute route =
         prepareRankMajorRoute(workspaceView, topkIndices, tokenIdx, nTopk, nLocalExperts, maxTokensPerRank, laneId);
-    if (laneId == 0) bulkBarrier->wait(sendBulkPhase);
-    __syncwarp();
-    mscclpp::bulkFence();
+    waitRankMajorBf16Token(sendState);
     const int completionRank = route.dstRank >= 0 && route.isLeader ? route.dstRank : -1;
     if (completionRank >= 0) {
-      issueRankMajorTokenStore<Hidden>(output, transport, route.destinationSlot, maxTokensPerRank, stagedToken,
+      issueRankMajorTokenStore<Hidden>(output, transport, route.destinationSlot, maxTokensPerRank, sendState.stagedToken_,
                                        route.dstRank);
     }
     sendRankMajorMetadata(transport, outputTopkIdx, outputTopkWeights, topkIndices, topkWeights, route, tokenIdx, nTopk,
                           nLocalExperts, maxTokensPerRank, invalidTokenExpertId);
     completeRankMajorTokenStore(workspaceView, completionRank);
-    if (tokenIdx + tokenStride < nTokens) __syncwarp();
+    if (tokenIdx + sendState.tokenStride_ < nTokens) __syncwarp();
   }
 }
 
@@ -255,54 +287,28 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorTopkExpandedBf16(
     const int64_t* __restrict__ topkIndices, const float* __restrict__ topkWeights, int nTokens, int nTopk,
     int invalidTokenExpertId, int maxTokensPerRank, const TransportView& transport, void* workspace, int nPayloadBlocks,
     int* sharedMem) {
-  if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return;
+  RankMajorSendState<Hidden> sendState;
+  if (!initRankMajorSendState(sendState, nTokens, nTopk, nRanks, nPayloadBlocks, sharedMem)) return;
 
-  const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
-  const int laneId = get_lane_id();
-  const int senderBlockIdx = static_cast<int>(blockIdx.x) - 1;
-  const int nWarpsPerGroup = dispatchNWarpsPerGroup(nTokens, nPayloadBlocks);
-  const int nWarpGroups = DispatchNWarps / nWarpsPerGroup;
-  const int warpGroupId = warpId / nWarpsPerGroup;
-  const int subWarpId = warpId % nWarpsPerGroup;
-  if (subWarpId != 0) return;
-
-  constexpr size_t HiddenBytes = static_cast<size_t>(Hidden) * sizeof(Bf16);
-  constexpr int HiddenVectors = Hidden / mscclpp::bf16x8::Size;
+  const int laneId = sendState.laneId_;
   const int nLocalExperts = nExperts / nRanks;
-  const size_t sharedTokenStride = dispatchPayloadStride<DispatchDataType::BF16>(Hidden, nTopk, 0);
-  auto* sharedTokenBase = reinterpret_cast<uint8_t*>(sharedMem) + dispatchSharedControlBytes(nRanks);
-  auto* bulkBarriers =
-      reinterpret_cast<mscclpp::BulkBarrier*>(sharedTokenBase + DispatchMaxNWarpGroups * sharedTokenStride);
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
-  auto* completionCounts = aggregatedDispatchCompletionCounts(sharedMem, nRanks, warpGroupId);
+  auto* completionCounts = aggregatedDispatchCompletionCounts(sharedMem, nRanks, sendState.warpGroupId_);
 
-  auto* stagedToken = sharedTokenBase + static_cast<size_t>(warpGroupId) * sharedTokenStride;
-  auto* bulkBarrier = bulkBarriers + warpGroupId;
-  const int tokenStride = nPayloadBlocks * nWarpGroups;
-  const int firstTokenIdx = senderBlockIdx * nWarpGroups + warpGroupId;
-  uint32_t sendBulkPhase = 0;
-  if (firstTokenIdx < nTokens && laneId == 0) bulkBarrier->init();
   initAggregatedDispatchCompletions(completionCounts, nRanks, laneId);
 
-  for (int tokenIdx = firstTokenIdx; tokenIdx < nTokens; tokenIdx += tokenStride) {
-    const auto* inputData =
-        reinterpret_cast<const mscclpp::bf16x8*>(inputTokens) + static_cast<size_t>(tokenIdx) * HiddenVectors;
-    if (laneId == 0) {
-      bulkBarrier->arriveAndExpect(static_cast<uint32_t>(HiddenBytes));
-      mscclpp::bulkLoad(stagedToken, inputData, static_cast<uint32_t>(HiddenBytes), *bulkBarrier);
-    }
-
+  for (int tokenIdx = sendState.firstTokenIdx_; tokenIdx < nTokens; tokenIdx += sendState.tokenStride_) {
+    stageRankMajorBf16Token(inputTokens, tokenIdx, sendState);
     const int expert = laneId < nTopk ? static_cast<int>(topkIndices[tokenIdx * nTopk + laneId]) : -1;
     const int dstRank = expert >= 0 ? expert / nLocalExperts : -1;
     const float weight =
         laneId < nTopk ? (topkWeights == nullptr ? 1.0f : topkWeights[tokenIdx * nTopk + laneId]) : 0.0f;
     const size_t destIndex = (static_cast<size_t>(transport.rank_) * maxTokensPerRank + tokenIdx) * nTopk + laneId;
 
-    if (laneId == 0) bulkBarrier->wait(sendBulkPhase);
-    __syncwarp();
-    mscclpp::bulkFence();
+    waitRankMajorBf16Token(sendState);
 
     if (laneId < nTopk) {
+      // Publish invalid metadata to non-destination ranks before the route completion is counted.
       for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
         const bool isLocal = destinationRank == dstRank;
         sendRankMajorTopkExpandedMetadata(transport, outputTopkIdx, outputTopkWeights, destinationRank, destIndex,
@@ -311,7 +317,7 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorTopkExpandedBf16(
     }
 
     if (dstRank >= 0) {
-      issueRankMajorTopkExpandedTokenStore<Hidden>(output, transport, dstRank, destIndex, stagedToken);
+      issueRankMajorTopkExpandedTokenStore<Hidden>(output, transport, dstRank, destIndex, sendState.stagedToken_);
       mscclpp::bulkStoreWait();
       atomicAdd_block(completionCounts + dstRank, 1);
     }

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -196,12 +196,34 @@ MSCCLPP_DEVICE_INLINE void countTokenMajorRoutes(int* rankTokenCounts, const int
   __syncthreads();
 }
 
-MSCCLPP_DEVICE_INLINE void dispatchTokenMajorNotify(const TransportView& transport, int nExperts, int nRanks,
+MSCCLPP_DEVICE_INLINE void invalidateTokenMajorPadding(const TransportView& transport, int* outputTopkIdx,
+                                                       float* outputTopkWeights, int nRanks, int nTokens, int nTopk,
+                                                       int maxTokensPerRank, int invalidTokenExpertId) {
+  const int metadataEntriesPerRank = maxTokensPerRank * nTopk;
+  for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
+    auto* destinationTopkIdx = reinterpret_cast<int*>(transport.mappedBuffer(outputTopkIdx, destinationRank));
+    auto* destinationTopkWeights =
+        reinterpret_cast<float*>(transport.mappedBuffer(outputTopkWeights, destinationRank));
+    for (int metadataIdx = nTokens * nTopk + static_cast<int>(threadIdx.x); metadataIdx < metadataEntriesPerRank;
+         metadataIdx += static_cast<int>(blockDim.x)) {
+      const size_t outputIdx = static_cast<size_t>(transport.rank_) * metadataEntriesPerRank + metadataIdx;
+      destinationTopkIdx[outputIdx] = invalidTokenExpertId;
+      destinationTopkWeights[outputIdx] = 0.0f;
+    }
+  }
+  __syncthreads();
+}
+
+MSCCLPP_DEVICE_INLINE void dispatchTokenMajorNotify(const TransportView& transport, int* outputTopkIdx,
+                                                    float* outputTopkWeights, int nExperts, int nRanks,
                                                     const int64_t* __restrict__ topkIndices, int nTokens, int nTopk,
-                                                    void* recvBuffer, void* workspace, uint32_t epoch, int* sharedMem) {
+                                                    int maxTokensPerRank, int invalidTokenExpertId, void* recvBuffer,
+                                                    void* workspace, uint32_t epoch, int* sharedMem) {
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
   auto* rankTokenCounts = sharedMem;
   countTokenMajorRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);
+  invalidateTokenMajorPadding(transport, outputTopkIdx, outputTopkWeights, nRanks, nTokens, nTopk, maxTokensPerRank,
+                              invalidTokenExpertId);
   writeRankMajorCounts(transport, rankTokenCounts, nRanks, recvBuffer, epoch);
   publishDispatchPayloads(transport, rankTokenCounts, nRanks, workspaceView);
 }
@@ -230,8 +252,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputT
                                                       const void* inputTokens, int nExperts, int nRanks,
                                                       const int64_t* __restrict__ topkIndices,
                                                       const float* __restrict__ topkWeights, int nTokens, int nTopk,
-                                                      int maxTokensPerRank, const TransportView& transport,
-                                                      void* workspace, int nPayloadBlocks, int* sharedMem) {
+                                                      int invalidTokenExpertId, int maxTokensPerRank,
+                                                      const TransportView& transport, void* workspace,
+                                                      int nPayloadBlocks, int* sharedMem) {
   if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return;
 
   const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
@@ -279,9 +302,16 @@ MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajorBf16(void* output, int* outputT
     __syncwarp();
     mscclpp::bulkFence();
 
+    if (laneId < nTopk) {
+      for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
+        const bool isLocal = destinationRank == dstRank;
+        sendTokenMajorMetadata(transport, outputTopkIdx, outputTopkWeights, destinationRank, destIndex,
+                               isLocal ? expert : invalidTokenExpertId, isLocal ? weight : 0.0f);
+      }
+    }
+
     if (dstRank >= 0) {
       issueTokenMajorTokenStore<Hidden>(output, transport, dstRank, destIndex, stagedToken);
-      sendTokenMajorMetadata(transport, outputTopkIdx, outputTopkWeights, dstRank, destIndex, expert, weight);
       mscclpp::bulkStoreWait();
       atomicAdd_block(completionCounts + dstRank, 1);
     }
@@ -295,16 +325,16 @@ MSCCLPP_DEVICE_INLINE void dispatchSendTokenMajor(void* output, int* outputTopkI
                                                   const void* inputTokens, const TransportView& transport, int nExperts,
                                                   int nRanks, const int64_t* __restrict__ topkIndices,
                                                   const float* __restrict__ topkWeights, int nTokens, int nTopk,
-                                                  int maxTokensPerRank, void* recvBuffer, void* workspace,
-                                                  uint32_t epoch, int* sharedMem) {
+                                                  int invalidTokenExpertId, int maxTokensPerRank, void* recvBuffer,
+                                                  void* workspace, uint32_t epoch, int* sharedMem) {
   const int nWorkerBlocks = static_cast<int>(gridDim.x) - DispatchControlBlocks;
   if (static_cast<int>(blockIdx.x) > 0 && static_cast<int>(blockIdx.x) <= nWorkerBlocks) {
     dispatchSendTokenMajorBf16<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts, nRanks,
-                                       topkIndices, topkWeights, nTokens, nTopk, maxTokensPerRank, transport, workspace,
-                                       nWorkerBlocks, sharedMem);
+                                       topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId,
+                                       maxTokensPerRank, transport, workspace, nWorkerBlocks, sharedMem);
   } else if (static_cast<int>(blockIdx.x) == nWorkerBlocks + 1) {
-    dispatchTokenMajorNotify(transport, nExperts, nRanks, topkIndices, nTokens, nTopk, recvBuffer, workspace, epoch,
-                             sharedMem);
+    dispatchTokenMajorNotify(transport, outputTopkIdx, outputTopkWeights, nExperts, nRanks, topkIndices, nTokens,
+                             nTopk, maxTokensPerRank, invalidTokenExpertId, recvBuffer, workspace, epoch, sharedMem);
   }
 }
 
@@ -966,8 +996,8 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
   } else if constexpr (Layout == DispatchLayout::TOKEN_MAJOR) {
     static_assert(DataType == DispatchDataType::BF16);
     dispatchSendTokenMajor<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks,
-                                   topkIndices, topkWeights, nTokens, nTopk, maxTokensPerRank, recvBuffer,
-                                   context->workspace_, epoch, sharedMem);
+                                   topkIndices, topkWeights, nTokens, nTopk, invalidTokenExpertId, maxTokensPerRank,
+                                   recvBuffer, context->workspace_, epoch, sharedMem);
   } else {
     dispatchSend<Hidden, DataType, ScaleBlockSize>(inputTokens, transport, nExperts, nRanks, topkIndices, topkWeights,
                                                    nTokens, nTopk, maxTokensPerRank, recvBuffer, context->workspace_,

--- a/src/ext/ep/dispatch/common.cuh
+++ b/src/ext/ep/dispatch/common.cuh
@@ -133,8 +133,8 @@ struct RankMajorSendState {
 };
 
 template <int Hidden>
-MSCCLPP_DEVICE_INLINE bool initRankMajorSendState(RankMajorSendState<Hidden>& state, int nTokens, int nTopk,
-                                                  int nRanks, int nPayloadBlocks, int* sharedMem) {
+MSCCLPP_DEVICE_INLINE bool initRankMajorSendState(RankMajorSendState<Hidden>& state, int nTokens, int nTopk, int nRanks,
+                                                  int nPayloadBlocks, int* sharedMem) {
   if (blockIdx.x == 0 || static_cast<int>(blockIdx.x) > nPayloadBlocks) return false;
 
   const int warpId = static_cast<int>(threadIdx.x) / WARP_SIZE;
@@ -202,8 +202,8 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorBf16(void* output, int* outputTo
     waitRankMajorBf16Token(sendState);
     const int completionRank = route.dstRank >= 0 && route.isLeader ? route.dstRank : -1;
     if (completionRank >= 0) {
-      issueRankMajorTokenStore<Hidden>(output, transport, route.destinationSlot, maxTokensPerRank, sendState.stagedToken_,
-                                       route.dstRank);
+      issueRankMajorTokenStore<Hidden>(output, transport, route.destinationSlot, maxTokensPerRank,
+                                       sendState.stagedToken_, route.dstRank);
     }
     sendRankMajorMetadata(transport, outputTopkIdx, outputTopkWeights, topkIndices, topkWeights, route, tokenIdx, nTopk,
                           nLocalExperts, maxTokensPerRank, invalidTokenExpertId);
@@ -236,8 +236,7 @@ MSCCLPP_DEVICE_INLINE void invalidateRankMajorTopkExpandedPadding(const Transpor
   const int metadataEntriesPerRank = maxTokensPerRank * nTopk;
   for (int destinationRank = 0; destinationRank < nRanks; ++destinationRank) {
     auto* destinationTopkIdx = reinterpret_cast<int*>(transport.mappedBuffer(outputTopkIdx, destinationRank));
-    auto* destinationTopkWeights =
-        reinterpret_cast<float*>(transport.mappedBuffer(outputTopkWeights, destinationRank));
+    auto* destinationTopkWeights = reinterpret_cast<float*>(transport.mappedBuffer(outputTopkWeights, destinationRank));
     for (int metadataIdx = nTokens * nTopk + static_cast<int>(threadIdx.x); metadataIdx < metadataEntriesPerRank;
          metadataIdx += static_cast<int>(blockDim.x)) {
       const size_t outputIdx = static_cast<size_t>(transport.rank_) * metadataEntriesPerRank + metadataIdx;
@@ -248,10 +247,12 @@ MSCCLPP_DEVICE_INLINE void invalidateRankMajorTopkExpandedPadding(const Transpor
   __syncthreads();
 }
 
-MSCCLPP_DEVICE_INLINE void dispatchRankMajorTopkExpandedNotify(
-    const TransportView& transport, int* outputTopkIdx, float* outputTopkWeights, int nExperts, int nRanks,
-    const int64_t* __restrict__ topkIndices, int nTokens, int nTopk, int maxTokensPerRank, int invalidTokenExpertId,
-    void* recvBuffer, void* workspace, uint32_t epoch, int* sharedMem) {
+MSCCLPP_DEVICE_INLINE void dispatchRankMajorTopkExpandedNotify(const TransportView& transport, int* outputTopkIdx,
+                                                               float* outputTopkWeights, int nExperts, int nRanks,
+                                                               const int64_t* __restrict__ topkIndices, int nTokens,
+                                                               int nTopk, int maxTokensPerRank,
+                                                               int invalidTokenExpertId, void* recvBuffer,
+                                                               void* workspace, uint32_t epoch, int* sharedMem) {
   WorkspaceView workspaceView(workspace, nRanks, nExperts);
   auto* rankTokenCounts = sharedMem;
   countRankMajorTopkExpandedRoutes(rankTokenCounts, topkIndices, nTokens, nTopk, nRanks, nExperts);
@@ -334,10 +335,9 @@ MSCCLPP_DEVICE_INLINE void dispatchSendRankMajorTopkExpanded(
     uint32_t epoch, int* sharedMem) {
   const int nWorkerBlocks = static_cast<int>(gridDim.x) - DispatchControlBlocks;
   if (static_cast<int>(blockIdx.x) > 0 && static_cast<int>(blockIdx.x) <= nWorkerBlocks) {
-    dispatchSendRankMajorTopkExpandedBf16<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts,
-                                                  nRanks, topkIndices, topkWeights, nTokens, nTopk,
-                                                  invalidTokenExpertId, maxTokensPerRank, transport, workspace,
-                                                  nWorkerBlocks, sharedMem);
+    dispatchSendRankMajorTopkExpandedBf16<Hidden>(
+        output, outputTopkIdx, outputTopkWeights, inputTokens, nExperts, nRanks, topkIndices, topkWeights, nTokens,
+        nTopk, invalidTokenExpertId, maxTokensPerRank, transport, workspace, nWorkerBlocks, sharedMem);
   } else if (static_cast<int>(blockIdx.x) == nWorkerBlocks + 1) {
     dispatchRankMajorTopkExpandedNotify(transport, outputTopkIdx, outputTopkWeights, nExperts, nRanks, topkIndices,
                                         nTokens, nTopk, maxTokensPerRank, invalidTokenExpertId, recvBuffer, workspace,
@@ -1002,10 +1002,9 @@ MSCCLPP_DEVICE_INLINE void dispatchBody(void* output, void* outputScales, int* o
                                   recvBuffer, context->workspace_, epoch, sharedMem);
   } else if constexpr (Layout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     static_assert(DataType == DispatchDataType::BF16);
-    dispatchSendRankMajorTopkExpanded<Hidden>(output, outputTopkIdx, outputTopkWeights, inputTokens, transport,
-                                              nExperts, nRanks, topkIndices, topkWeights, nTokens, nTopk,
-                                              invalidTokenExpertId, maxTokensPerRank, recvBuffer, context->workspace_,
-                                              epoch, sharedMem);
+    dispatchSendRankMajorTopkExpanded<Hidden>(
+        output, outputTopkIdx, outputTopkWeights, inputTokens, transport, nExperts, nRanks, topkIndices, topkWeights,
+        nTokens, nTopk, invalidTokenExpertId, maxTokensPerRank, recvBuffer, context->workspace_, epoch, sharedMem);
   } else {
     dispatchSend<Hidden, DataType, ScaleBlockSize>(inputTokens, transport, nExperts, nRanks, topkIndices, topkWeights,
                                                    nTokens, nTopk, maxTokensPerRank, recvBuffer, context->workspace_,

--- a/src/ext/ep/dispatch/rank_major_dispatch.cu
+++ b/src/ext/ep/dispatch/rank_major_dispatch.cu
@@ -32,5 +32,31 @@ void rankMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int
       topkWeights, workload, recvBuffer, context, numBlocks, stream);
 }
 
+template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
+__global__ __launch_bounds__(DispatchNThreads, 1) void tokenMajorDispatchKernel(
+    void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx, float* outputTopkWeights,
+    int64_t* outputLayout, int* outputCount, const int64_t* topkIndices, const float* topkWeights,
+    const void* inputTokens, Workload workload, void* recvBuffer, const DeviceContext* context) {
+  dispatchBody<Hidden, DataType, ScaleBlockSize, DispatchLayout::TOKEN_MAJOR>(
+      output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, topkIndices,
+      topkWeights, inputTokens, workload, recvBuffer, context);
+}
+
+struct TokenMajorDispatchKernelSelector {
+  template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
+  static auto get() {
+    return tokenMajorDispatchKernel<Hidden, DataType, ScaleBlockSize>;
+  }
+};
+
+void tokenMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
+                        float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
+                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
+                        const DeviceContext& context, int numBlocks, cudaStream_t stream) {
+  dispatchAlgorithm<DispatchLayout::TOKEN_MAJOR, TokenMajorDispatchKernelSelector>(
+      output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input, topkIdx,
+      topkWeights, workload, recvBuffer, context, numBlocks, stream);
+}
+
 }  // namespace ep
 }  // namespace mscclpp

--- a/src/ext/ep/dispatch/rank_major_dispatch.cu
+++ b/src/ext/ep/dispatch/rank_major_dispatch.cu
@@ -50,10 +50,9 @@ struct RankMajorTopkExpandedDispatchKernelSelector {
 };
 
 void rankMajorTopkExpandedDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
-                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount,
-                                   const void* input, const int64_t* topkIdx, const float* topkWeights,
-                                   const Workload& workload, void* recvBuffer, const DeviceContext& context,
-                                   int numBlocks, cudaStream_t stream) {
+                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
+                                   const int64_t* topkIdx, const float* topkWeights, const Workload& workload,
+                                   void* recvBuffer, const DeviceContext& context, int numBlocks, cudaStream_t stream) {
   dispatchAlgorithm<DispatchLayout::RANK_MAJOR_TOPK_EXPANDED, RankMajorTopkExpandedDispatchKernelSelector>(
       output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input, topkIdx,
       topkWeights, workload, recvBuffer, context, numBlocks, stream);

--- a/src/ext/ep/dispatch/rank_major_dispatch.cu
+++ b/src/ext/ep/dispatch/rank_major_dispatch.cu
@@ -33,27 +33,28 @@ void rankMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int
 }
 
 template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
-__global__ __launch_bounds__(DispatchNThreads, 1) void tokenMajorDispatchKernel(
+__global__ __launch_bounds__(DispatchNThreads, 1) void rankMajorTopkExpandedDispatchKernel(
     void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx, float* outputTopkWeights,
     int64_t* outputLayout, int* outputCount, const int64_t* topkIndices, const float* topkWeights,
     const void* inputTokens, Workload workload, void* recvBuffer, const DeviceContext* context) {
-  dispatchBody<Hidden, DataType, ScaleBlockSize, DispatchLayout::TOKEN_MAJOR>(
+  dispatchBody<Hidden, DataType, ScaleBlockSize, DispatchLayout::RANK_MAJOR_TOPK_EXPANDED>(
       output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, topkIndices,
       topkWeights, inputTokens, workload, recvBuffer, context);
 }
 
-struct TokenMajorDispatchKernelSelector {
+struct RankMajorTopkExpandedDispatchKernelSelector {
   template <int Hidden, DispatchDataType DataType, int ScaleBlockSize>
   static auto get() {
-    return tokenMajorDispatchKernel<Hidden, DataType, ScaleBlockSize>;
+    return rankMajorTopkExpandedDispatchKernel<Hidden, DataType, ScaleBlockSize>;
   }
 };
 
-void tokenMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
-                        float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
-                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
-                        const DeviceContext& context, int numBlocks, cudaStream_t stream) {
-  dispatchAlgorithm<DispatchLayout::TOKEN_MAJOR, TokenMajorDispatchKernelSelector>(
+void rankMajorTopkExpandedDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
+                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount,
+                                   const void* input, const int64_t* topkIdx, const float* topkWeights,
+                                   const Workload& workload, void* recvBuffer, const DeviceContext& context,
+                                   int numBlocks, cudaStream_t stream) {
+  dispatchAlgorithm<DispatchLayout::RANK_MAJOR_TOPK_EXPANDED, RankMajorTopkExpandedDispatchKernelSelector>(
       output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount, input, topkIdx,
       topkWeights, workload, recvBuffer, context, numBlocks, stream);
 }

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -154,6 +154,11 @@ MSCCLPP_HOST_DEVICE_INLINE size_t rankMajorTokenOffset(int numRanks, int numExpe
       rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk) + numEntries * sizeof(float), 128);
 }
 
+MSCCLPP_HOST_DEVICE_INLINE size_t tokenMajorTokenOffset(int numRanks, int numExperts, int maxTokensPerRank,
+                                                        int numTopk) {
+  return rankMajorTokenOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
+}
+
 struct LatencyStorageLayout {
   size_t totalBytes_;
   size_t dispatchRecvBufferBytes_;
@@ -163,13 +168,19 @@ struct LatencyStorageLayout {
   void* combineRecvBuffer_ = nullptr;
   void* rankMajorTopkIdsBuffer_ = nullptr;
   void* rankMajorTopkWeightsBuffer_ = nullptr;
+  void* rankMajorTokenBuffer_ = nullptr;
+  void* tokenMajorTokenBuffer_ = nullptr;
+  void* kiRaggedTokenBuffer_ = nullptr;
   void* dispatchOutputBuffer_ = nullptr;
 
   LatencyStorageLayout(void* symmetricBuffer, int maxTokensPerRank, int hidden, int numRanks, int numExperts,
                        int numTopk, DispatchLayout outputLayout, CombineMode combineMode) {
     const bool rankMajor = outputLayout == DispatchLayout::RANK_MAJOR;
+    const bool tokenMajor = outputLayout == DispatchLayout::TOKEN_MAJOR;
+    const bool kiRagged = outputLayout == DispatchLayout::KI_RAGGED;
     const bool rankMajorDirectSend = rankMajor && combineMode == CombineMode::DIRECT_SEND;
     const bool rankMajorLocalReduce = rankMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
+    const bool tokenMajorLocalReduce = tokenMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
     const PayloadView<Bf16> bf16Payload(hidden, numTopk);
     const PayloadView<Fp8E4M3, float> fp8Payload128(hidden, numTopk, 128);
     const size_t dispatchMetadataBytes =
@@ -184,25 +195,40 @@ struct LatencyStorageLayout {
     const size_t rankMajorDirectSendCombineInputBytes = rankMajorDispatchOutputBytes * numTopk;
     const size_t expertMajorDispatchOutputBytes =
         static_cast<size_t>(numExperts) * maxTokensPerRank * hidden * sizeof(Bf16);
+    const size_t tokenMajorTokenOffsetBytes = tokenMajorTokenOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
+    const size_t tokenMajorDispatchOutputBytes =
+        static_cast<size_t>(numRanks) * maxTokensPerRank * numTopk * hidden * sizeof(Bf16);
     const size_t rankMajorDispatchBufferBytes = rankMajorTokenOffsetBytes + rankMajorDispatchOutputBytes;
-    dispatchOutputBytes_ = rankMajor ? rankMajorDispatchOutputBytes : expertMajorDispatchOutputBytes;
+    const size_t tokenMajorDispatchBufferBytes = tokenMajorTokenOffsetBytes + tokenMajorDispatchOutputBytes;
+    const size_t kiRaggedTokenOffsetBytes = configAlign<size_t>(dispatchBufferBytes, BufferAlignmentBytes);
+    const size_t kiRaggedDispatchBufferBytes = kiRaggedTokenOffsetBytes + tokenMajorDispatchOutputBytes;
+    dispatchOutputBytes_ = rankMajor              ? rankMajorDispatchOutputBytes
+                           : (tokenMajor || kiRagged) ? tokenMajorDispatchOutputBytes
+                                                      : expertMajorDispatchOutputBytes;
     const size_t dispatchRecvBufferBytes =
-        std::max({dispatchBufferBytes, rankMajorDispatchBufferBytes, dispatchOutputBytes_});
+        std::max({dispatchBufferBytes, rankMajorDispatchBufferBytes, tokenMajorDispatchBufferBytes,
+                  kiRaggedDispatchBufferBytes, dispatchOutputBytes_});
     const size_t combineRecvBufferBytes = rankMajorDirectSend    ? rankMajorDirectSendCombineInputBytes
-                                          : rankMajorLocalReduce ? 0
+                                          : (rankMajorLocalReduce || tokenMajorLocalReduce) ? 0
                                                                  : dispatchOutputBytes_;
     dispatchRecvBufferBytes_ = configAlign<size_t>(dispatchRecvBufferBytes, BufferAlignmentBytes);
     combineRecvBufferBytes_ = configAlign<size_t>(combineRecvBufferBytes, BufferAlignmentBytes);
     totalBytes_ = dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +
-                  (rankMajor ? 0 : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
+                  ((rankMajor || tokenMajor || kiRagged) ? 0
+                                                         : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
 
     if (symmetricBuffer != nullptr) {
       auto* base = reinterpret_cast<uint8_t*>(symmetricBuffer);
       dispatchRecvBuffer_ = base;
       rankMajorTopkIdsBuffer_ = base + rankMajorTopkIdsOffset(numRanks, numExperts);
       rankMajorTopkWeightsBuffer_ = base + rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
-      dispatchOutputBuffer_ =
-          rankMajor ? base + rankMajorTokenOffsetBytes : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
+      rankMajorTokenBuffer_ = base + rankMajorTokenOffsetBytes;
+      tokenMajorTokenBuffer_ = base + tokenMajorTokenOffsetBytes;
+      kiRaggedTokenBuffer_ = base + kiRaggedTokenOffsetBytes;
+      dispatchOutputBuffer_ = rankMajor    ? rankMajorTokenBuffer_
+                              : tokenMajor ? tokenMajorTokenBuffer_
+                              : kiRagged   ? kiRaggedTokenBuffer_
+                                           : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
       combineRecvBuffer_ = rankMajorLocalReduce ? dispatchOutputBuffer_ : base + dispatchRecvBufferBytes_;
     }
   }

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -170,14 +170,12 @@ struct LatencyStorageLayout {
   void* rankMajorTopkWeightsBuffer_ = nullptr;
   void* rankMajorTokenBuffer_ = nullptr;
   void* tokenMajorTokenBuffer_ = nullptr;
-  void* kiRaggedTokenBuffer_ = nullptr;
   void* dispatchOutputBuffer_ = nullptr;
 
   LatencyStorageLayout(void* symmetricBuffer, int maxTokensPerRank, int hidden, int numRanks, int numExperts,
                        int numTopk, DispatchLayout outputLayout, CombineMode combineMode) {
     const bool rankMajor = outputLayout == DispatchLayout::RANK_MAJOR;
     const bool tokenMajor = outputLayout == DispatchLayout::TOKEN_MAJOR;
-    const bool kiRagged = outputLayout == DispatchLayout::KI_RAGGED;
     const bool rankMajorDirectSend = rankMajor && combineMode == CombineMode::DIRECT_SEND;
     const bool rankMajorLocalReduce = rankMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
     const bool tokenMajorLocalReduce = tokenMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
@@ -200,22 +198,19 @@ struct LatencyStorageLayout {
         static_cast<size_t>(numRanks) * maxTokensPerRank * numTopk * hidden * sizeof(Bf16);
     const size_t rankMajorDispatchBufferBytes = rankMajorTokenOffsetBytes + rankMajorDispatchOutputBytes;
     const size_t tokenMajorDispatchBufferBytes = tokenMajorTokenOffsetBytes + tokenMajorDispatchOutputBytes;
-    const size_t kiRaggedTokenOffsetBytes = configAlign<size_t>(dispatchBufferBytes, BufferAlignmentBytes);
-    const size_t kiRaggedDispatchBufferBytes = kiRaggedTokenOffsetBytes + tokenMajorDispatchOutputBytes;
     dispatchOutputBytes_ = rankMajor              ? rankMajorDispatchOutputBytes
-                           : (tokenMajor || kiRagged) ? tokenMajorDispatchOutputBytes
-                                                      : expertMajorDispatchOutputBytes;
+                           : tokenMajor           ? tokenMajorDispatchOutputBytes
+                                                  : expertMajorDispatchOutputBytes;
     const size_t dispatchRecvBufferBytes =
         std::max({dispatchBufferBytes, rankMajorDispatchBufferBytes, tokenMajorDispatchBufferBytes,
-                  kiRaggedDispatchBufferBytes, dispatchOutputBytes_});
+                  dispatchOutputBytes_});
     const size_t combineRecvBufferBytes = rankMajorDirectSend    ? rankMajorDirectSendCombineInputBytes
                                           : (rankMajorLocalReduce || tokenMajorLocalReduce) ? 0
                                                                  : dispatchOutputBytes_;
     dispatchRecvBufferBytes_ = configAlign<size_t>(dispatchRecvBufferBytes, BufferAlignmentBytes);
     combineRecvBufferBytes_ = configAlign<size_t>(combineRecvBufferBytes, BufferAlignmentBytes);
     totalBytes_ = dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +
-                  ((rankMajor || tokenMajor || kiRagged) ? 0
-                                                         : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
+                  ((rankMajor || tokenMajor) ? 0 : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
 
     if (symmetricBuffer != nullptr) {
       auto* base = reinterpret_cast<uint8_t*>(symmetricBuffer);
@@ -224,10 +219,8 @@ struct LatencyStorageLayout {
       rankMajorTopkWeightsBuffer_ = base + rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
       rankMajorTokenBuffer_ = base + rankMajorTokenOffsetBytes;
       tokenMajorTokenBuffer_ = base + tokenMajorTokenOffsetBytes;
-      kiRaggedTokenBuffer_ = base + kiRaggedTokenOffsetBytes;
       dispatchOutputBuffer_ = rankMajor    ? rankMajorTokenBuffer_
                               : tokenMajor ? tokenMajorTokenBuffer_
-                              : kiRagged   ? kiRaggedTokenBuffer_
                                            : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
       combineRecvBuffer_ = rankMajorLocalReduce ? dispatchOutputBuffer_ : base + dispatchRecvBufferBytes_;
     }

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -198,15 +198,14 @@ struct LatencyStorageLayout {
         static_cast<size_t>(numRanks) * maxTokensPerRank * numTopk * hidden * sizeof(Bf16);
     const size_t rankMajorDispatchBufferBytes = rankMajorTokenOffsetBytes + rankMajorDispatchOutputBytes;
     const size_t tokenMajorDispatchBufferBytes = tokenMajorTokenOffsetBytes + tokenMajorDispatchOutputBytes;
-    dispatchOutputBytes_ = rankMajor              ? rankMajorDispatchOutputBytes
-                           : tokenMajor           ? tokenMajorDispatchOutputBytes
-                                                  : expertMajorDispatchOutputBytes;
-    const size_t dispatchRecvBufferBytes =
-        std::max({dispatchBufferBytes, rankMajorDispatchBufferBytes, tokenMajorDispatchBufferBytes,
-                  dispatchOutputBytes_});
-    const size_t combineRecvBufferBytes = rankMajorDirectSend    ? rankMajorDirectSendCombineInputBytes
+    dispatchOutputBytes_ = rankMajor    ? rankMajorDispatchOutputBytes
+                           : tokenMajor ? tokenMajorDispatchOutputBytes
+                                        : expertMajorDispatchOutputBytes;
+    const size_t dispatchRecvBufferBytes = std::max(
+        {dispatchBufferBytes, rankMajorDispatchBufferBytes, tokenMajorDispatchBufferBytes, dispatchOutputBytes_});
+    const size_t combineRecvBufferBytes = rankMajorDirectSend ? rankMajorDirectSendCombineInputBytes
                                           : (rankMajorLocalReduce || tokenMajorLocalReduce) ? 0
-                                                                 : dispatchOutputBytes_;
+                                                                                            : dispatchOutputBytes_;
     dispatchRecvBufferBytes_ = configAlign<size_t>(dispatchRecvBufferBytes, BufferAlignmentBytes);
     combineRecvBufferBytes_ = configAlign<size_t>(combineRecvBufferBytes, BufferAlignmentBytes);
     totalBytes_ = dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -201,7 +201,7 @@ struct LatencyStorageLayout {
     const size_t rankMajorDispatchBufferBytes = rankMajorTokenOffsetBytes + rankMajorDispatchOutputBytes;
     const size_t rankMajorTopkExpandedDispatchBufferBytes =
         rankMajorTopkExpandedTokenOffsetBytes + rankMajorTopkExpandedDispatchOutputBytes;
-    dispatchOutputBytes_ = rankMajor ? rankMajorDispatchOutputBytes
+    dispatchOutputBytes_ = rankMajor               ? rankMajorDispatchOutputBytes
                            : rankMajorTopkExpanded ? rankMajorTopkExpandedDispatchOutputBytes
                                                    : expertMajorDispatchOutputBytes;
     const size_t selectedLayoutDispatchBufferBytes =
@@ -214,9 +214,9 @@ struct LatencyStorageLayout {
                                               : dispatchOutputBytes_;
     dispatchRecvBufferBytes_ = configAlign<size_t>(dispatchRecvBufferBytes, BufferAlignmentBytes);
     combineRecvBufferBytes_ = configAlign<size_t>(combineRecvBufferBytes, BufferAlignmentBytes);
-    totalBytes_ = dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +
-                  ((rankMajor || rankMajorTopkExpanded) ? 0
-                                                        : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
+    totalBytes_ =
+        dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +
+        ((rankMajor || rankMajorTopkExpanded) ? 0 : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
 
     if (symmetricBuffer != nullptr) {
       auto* base = reinterpret_cast<uint8_t*>(symmetricBuffer);
@@ -225,7 +225,7 @@ struct LatencyStorageLayout {
       rankMajorTopkWeightsBuffer_ = base + rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
       rankMajorTokenBuffer_ = base + rankMajorTokenOffsetBytes;
       rankMajorTopkExpandedTokenBuffer_ = base + rankMajorTopkExpandedTokenOffsetBytes;
-      dispatchOutputBuffer_ = rankMajor ? rankMajorTokenBuffer_
+      dispatchOutputBuffer_ = rankMajor               ? rankMajorTokenBuffer_
                               : rankMajorTopkExpanded ? rankMajorTopkExpandedTokenBuffer_
                                                       : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
       combineRecvBuffer_ = (rankMajorLocalReduce || rankMajorTopkExpandedLocalReduce) ? dispatchOutputBuffer_

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -201,8 +201,10 @@ struct LatencyStorageLayout {
     dispatchOutputBytes_ = rankMajor    ? rankMajorDispatchOutputBytes
                            : tokenMajor ? tokenMajorDispatchOutputBytes
                                         : expertMajorDispatchOutputBytes;
-    const size_t dispatchRecvBufferBytes = std::max(
-        {dispatchBufferBytes, rankMajorDispatchBufferBytes, tokenMajorDispatchBufferBytes, dispatchOutputBytes_});
+    const size_t selectedLayoutDispatchBufferBytes =
+        rankMajor ? rankMajorDispatchBufferBytes
+                  : (tokenMajor ? tokenMajorDispatchBufferBytes : dispatchOutputBytes_);
+    const size_t dispatchRecvBufferBytes = std::max(dispatchBufferBytes, selectedLayoutDispatchBufferBytes);
     const size_t combineRecvBufferBytes = rankMajorDirectSend ? rankMajorDirectSendCombineInputBytes
                                           : (rankMajorLocalReduce || tokenMajorLocalReduce) ? 0
                                                                                             : dispatchOutputBytes_;

--- a/src/ext/ep/include/config.hpp
+++ b/src/ext/ep/include/config.hpp
@@ -154,8 +154,8 @@ MSCCLPP_HOST_DEVICE_INLINE size_t rankMajorTokenOffset(int numRanks, int numExpe
       rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk) + numEntries * sizeof(float), 128);
 }
 
-MSCCLPP_HOST_DEVICE_INLINE size_t tokenMajorTokenOffset(int numRanks, int numExperts, int maxTokensPerRank,
-                                                        int numTopk) {
+MSCCLPP_HOST_DEVICE_INLINE size_t rankMajorTopkExpandedTokenOffset(int numRanks, int numExperts, int maxTokensPerRank,
+                                                                   int numTopk) {
   return rankMajorTokenOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
 }
 
@@ -169,16 +169,17 @@ struct LatencyStorageLayout {
   void* rankMajorTopkIdsBuffer_ = nullptr;
   void* rankMajorTopkWeightsBuffer_ = nullptr;
   void* rankMajorTokenBuffer_ = nullptr;
-  void* tokenMajorTokenBuffer_ = nullptr;
+  void* rankMajorTopkExpandedTokenBuffer_ = nullptr;
   void* dispatchOutputBuffer_ = nullptr;
 
   LatencyStorageLayout(void* symmetricBuffer, int maxTokensPerRank, int hidden, int numRanks, int numExperts,
                        int numTopk, DispatchLayout outputLayout, CombineMode combineMode) {
     const bool rankMajor = outputLayout == DispatchLayout::RANK_MAJOR;
-    const bool tokenMajor = outputLayout == DispatchLayout::TOKEN_MAJOR;
+    const bool rankMajorTopkExpanded = outputLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED;
     const bool rankMajorDirectSend = rankMajor && combineMode == CombineMode::DIRECT_SEND;
     const bool rankMajorLocalReduce = rankMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
-    const bool tokenMajorLocalReduce = tokenMajor && combineMode == CombineMode::RANK_LOCAL_REDUCE;
+    const bool rankMajorTopkExpandedLocalReduce =
+        rankMajorTopkExpanded && combineMode == CombineMode::RANK_LOCAL_REDUCE;
     const PayloadView<Bf16> bf16Payload(hidden, numTopk);
     const PayloadView<Fp8E4M3, float> fp8Payload128(hidden, numTopk, 128);
     const size_t dispatchMetadataBytes =
@@ -193,25 +194,29 @@ struct LatencyStorageLayout {
     const size_t rankMajorDirectSendCombineInputBytes = rankMajorDispatchOutputBytes * numTopk;
     const size_t expertMajorDispatchOutputBytes =
         static_cast<size_t>(numExperts) * maxTokensPerRank * hidden * sizeof(Bf16);
-    const size_t tokenMajorTokenOffsetBytes = tokenMajorTokenOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
-    const size_t tokenMajorDispatchOutputBytes =
+    const size_t rankMajorTopkExpandedTokenOffsetBytes =
+        rankMajorTopkExpandedTokenOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
+    const size_t rankMajorTopkExpandedDispatchOutputBytes =
         static_cast<size_t>(numRanks) * maxTokensPerRank * numTopk * hidden * sizeof(Bf16);
     const size_t rankMajorDispatchBufferBytes = rankMajorTokenOffsetBytes + rankMajorDispatchOutputBytes;
-    const size_t tokenMajorDispatchBufferBytes = tokenMajorTokenOffsetBytes + tokenMajorDispatchOutputBytes;
-    dispatchOutputBytes_ = rankMajor    ? rankMajorDispatchOutputBytes
-                           : tokenMajor ? tokenMajorDispatchOutputBytes
-                                        : expertMajorDispatchOutputBytes;
+    const size_t rankMajorTopkExpandedDispatchBufferBytes =
+        rankMajorTopkExpandedTokenOffsetBytes + rankMajorTopkExpandedDispatchOutputBytes;
+    dispatchOutputBytes_ = rankMajor ? rankMajorDispatchOutputBytes
+                           : rankMajorTopkExpanded ? rankMajorTopkExpandedDispatchOutputBytes
+                                                   : expertMajorDispatchOutputBytes;
     const size_t selectedLayoutDispatchBufferBytes =
         rankMajor ? rankMajorDispatchBufferBytes
-                  : (tokenMajor ? tokenMajorDispatchBufferBytes : dispatchOutputBytes_);
+                  : (rankMajorTopkExpanded ? rankMajorTopkExpandedDispatchBufferBytes : dispatchOutputBytes_);
     const size_t dispatchRecvBufferBytes = std::max(dispatchBufferBytes, selectedLayoutDispatchBufferBytes);
     const size_t combineRecvBufferBytes = rankMajorDirectSend ? rankMajorDirectSendCombineInputBytes
-                                          : (rankMajorLocalReduce || tokenMajorLocalReduce) ? 0
-                                                                                            : dispatchOutputBytes_;
+                                          : (rankMajorLocalReduce || rankMajorTopkExpandedLocalReduce)
+                                              ? 0
+                                              : dispatchOutputBytes_;
     dispatchRecvBufferBytes_ = configAlign<size_t>(dispatchRecvBufferBytes, BufferAlignmentBytes);
     combineRecvBufferBytes_ = configAlign<size_t>(combineRecvBufferBytes, BufferAlignmentBytes);
     totalBytes_ = dispatchRecvBufferBytes_ + combineRecvBufferBytes_ +
-                  ((rankMajor || tokenMajor) ? 0 : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
+                  ((rankMajor || rankMajorTopkExpanded) ? 0
+                                                        : configAlign<size_t>(dispatchOutputBytes_, BufferAlignmentBytes));
 
     if (symmetricBuffer != nullptr) {
       auto* base = reinterpret_cast<uint8_t*>(symmetricBuffer);
@@ -219,11 +224,12 @@ struct LatencyStorageLayout {
       rankMajorTopkIdsBuffer_ = base + rankMajorTopkIdsOffset(numRanks, numExperts);
       rankMajorTopkWeightsBuffer_ = base + rankMajorTopkWeightsOffset(numRanks, numExperts, maxTokensPerRank, numTopk);
       rankMajorTokenBuffer_ = base + rankMajorTokenOffsetBytes;
-      tokenMajorTokenBuffer_ = base + tokenMajorTokenOffsetBytes;
-      dispatchOutputBuffer_ = rankMajor    ? rankMajorTokenBuffer_
-                              : tokenMajor ? tokenMajorTokenBuffer_
-                                           : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
-      combineRecvBuffer_ = rankMajorLocalReduce ? dispatchOutputBuffer_ : base + dispatchRecvBufferBytes_;
+      rankMajorTopkExpandedTokenBuffer_ = base + rankMajorTopkExpandedTokenOffsetBytes;
+      dispatchOutputBuffer_ = rankMajor ? rankMajorTokenBuffer_
+                              : rankMajorTopkExpanded ? rankMajorTopkExpandedTokenBuffer_
+                                                      : base + dispatchRecvBufferBytes_ + combineRecvBufferBytes_;
+      combineRecvBuffer_ = (rankMajorLocalReduce || rankMajorTopkExpandedLocalReduce) ? dispatchOutputBuffer_
+                                                                                      : base + dispatchRecvBufferBytes_;
     }
   }
 };

--- a/src/ext/ep/include/kernels.hpp
+++ b/src/ext/ep/include/kernels.hpp
@@ -72,6 +72,11 @@ void rankMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int
                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
                        const DeviceContext& context, int numBlocks, cudaStream_t stream);
 
+void tokenMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
+                        float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
+                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
+                        const DeviceContext& context, int numBlocks, cudaStream_t stream);
+
 void expertMajorLocalReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
                                    const int* srcInfo, const int64_t* layoutRange, const Workload& workload,
                                    void* recvBuffer, void* dispatchRecvBuffer, const DeviceContext& context,
@@ -81,6 +86,10 @@ void rankMajorGatherReduceCombine(void* output, const void* input, const int64_t
                                   const int* srcInfo, const int64_t* layoutRange, const Workload& workload,
                                   void* recvBuffer, void* dispatchRecvBuffer, const DeviceContext& context,
                                   int numBlocks, cudaStream_t stream);
+
+void tokenMajorGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
+                                   const Workload& workload, void* recvBuffer, void* dispatchRecvBuffer,
+                                   const DeviceContext& context, int numBlocks, cudaStream_t stream);
 
 void rankMajorDirectSendCombine(void* output, const void* input, const int64_t* topkIdx, const Workload& workload,
                                 void* recvBuffer, void* dispatchRecvBuffer, const DeviceContext& context, int numBlocks,

--- a/src/ext/ep/include/kernels.hpp
+++ b/src/ext/ep/include/kernels.hpp
@@ -72,10 +72,11 @@ void rankMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int
                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
                        const DeviceContext& context, int numBlocks, cudaStream_t stream);
 
-void tokenMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
-                        float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
-                        const int64_t* topkIdx, const float* topkWeights, const Workload& workload, void* recvBuffer,
-                        const DeviceContext& context, int numBlocks, cudaStream_t stream);
+void rankMajorTopkExpandedDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
+                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount,
+                                   const void* input, const int64_t* topkIdx, const float* topkWeights,
+                                   const Workload& workload, void* recvBuffer, const DeviceContext& context,
+                                   int numBlocks, cudaStream_t stream);
 
 void expertMajorLocalReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
                                    const int* srcInfo, const int64_t* layoutRange, const Workload& workload,
@@ -87,9 +88,10 @@ void rankMajorGatherReduceCombine(void* output, const void* input, const int64_t
                                   void* recvBuffer, void* dispatchRecvBuffer, const DeviceContext& context,
                                   int numBlocks, cudaStream_t stream);
 
-void tokenMajorGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
-                                   const Workload& workload, void* recvBuffer, void* dispatchRecvBuffer,
-                                   const DeviceContext& context, int numBlocks, cudaStream_t stream);
+void rankMajorTopkExpandedGatherReduceCombine(void* output, const void* input, const int64_t* topkIdx,
+                                              const float* topkWeights, const Workload& workload, void* recvBuffer,
+                                              void* dispatchRecvBuffer, const DeviceContext& context, int numBlocks,
+                                              cudaStream_t stream);
 
 void rankMajorDirectSendCombine(void* output, const void* input, const int64_t* topkIdx, const Workload& workload,
                                 void* recvBuffer, void* dispatchRecvBuffer, const DeviceContext& context, int numBlocks,

--- a/src/ext/ep/include/kernels.hpp
+++ b/src/ext/ep/include/kernels.hpp
@@ -73,10 +73,9 @@ void rankMajorDispatch(void* output, void* outputScales, int* outputSrcInfo, int
                        const DeviceContext& context, int numBlocks, cudaStream_t stream);
 
 void rankMajorTopkExpandedDispatch(void* output, void* outputScales, int* outputSrcInfo, int* outputTopkIdx,
-                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount,
-                                   const void* input, const int64_t* topkIdx, const float* topkWeights,
-                                   const Workload& workload, void* recvBuffer, const DeviceContext& context,
-                                   int numBlocks, cudaStream_t stream);
+                                   float* outputTopkWeights, int64_t* outputLayout, int* outputCount, const void* input,
+                                   const int64_t* topkIdx, const float* topkWeights, const Workload& workload,
+                                   void* recvBuffer, const DeviceContext& context, int numBlocks, cudaStream_t stream);
 
 void expertMajorLocalReduceCombine(void* output, const void* input, const int64_t* topkIdx, const float* topkWeights,
                                    const int* srcInfo, const int64_t* layoutRange, const Workload& workload,

--- a/src/ext/ep/latency.cc
+++ b/src/ext/ep/latency.cc
@@ -36,7 +36,8 @@ LatencyContext::LatencyContext(mscclpp::Communicator& communicator, int rank, in
   EP_HOST_ASSERT(maxTokensPerRank > 0);
   EP_HOST_ASSERT(numExperts > 0 && numExperts % numRanks_ == 0);
   EP_HOST_ASSERT(numTopk > 0 && numTopk <= 32);
-  EP_HOST_ASSERT(outputLayout == DispatchLayout::EXPERT_MAJOR || outputLayout == DispatchLayout::RANK_MAJOR);
+  EP_HOST_ASSERT(outputLayout == DispatchLayout::EXPERT_MAJOR || outputLayout == DispatchLayout::RANK_MAJOR ||
+                 outputLayout == DispatchLayout::TOKEN_MAJOR);
 
   CUDA_CHECK(cudaGetDevice(&deviceId_));
   EP_HOST_ASSERT(numRanks_ % numNvlRanks == 0);
@@ -195,6 +196,10 @@ void MoERuntime::launchLatencyDispatch(const LatencyDispatchRequest& request) {
     EP_HOST_ASSERT(output == allocationLayout.dispatchOutputBuffer_);
     EP_HOST_ASSERT(outputTopkIdx == allocationLayout.rankMajorTopkIdsBuffer_);
     EP_HOST_ASSERT(outputTopkWeights == allocationLayout.rankMajorTopkWeightsBuffer_);
+  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+    EP_HOST_ASSERT(output == allocationLayout.dispatchOutputBuffer_);
+    EP_HOST_ASSERT(outputTopkIdx == allocationLayout.rankMajorTopkIdsBuffer_);
+    EP_HOST_ASSERT(outputTopkWeights == allocationLayout.rankMajorTopkWeightsBuffer_);
   }
 
   ++context.epoch_;
@@ -213,6 +218,10 @@ void MoERuntime::launchLatencyDispatch(const LatencyDispatchRequest& request) {
     rankMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount,
                       input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_, numBlocks,
                       stream);
+  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+    tokenMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount,
+                       input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_, numBlocks,
+                       stream);
   } else {
     expertMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout,
                         outputCount, input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_,
@@ -254,6 +263,8 @@ void MoERuntime::launchLatencyCombine(const LatencyCombineRequest& request) {
   void* dispatchRecvBuffer = allocationLayout.dispatchRecvBuffer_;
   if (dispatchLayout == DispatchLayout::RANK_MAJOR) {
     EP_HOST_ASSERT(input == allocationLayout.combineRecvBuffer_);
+  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+    EP_HOST_ASSERT(input == allocationLayout.dispatchOutputBuffer_);
   }
 
   const Workload workload{.epoch_ = context.epoch_,
@@ -276,6 +287,10 @@ void MoERuntime::launchLatencyCombine(const LatencyCombineRequest& request) {
       rankMajorGatherReduceCombine(output, input, topkIdx, topkWeights, srcInfo, layoutRange, workload,
                                    combineRecvBuffer, dispatchRecvBuffer, context.deviceContext_, numBlocks, stream);
     }
+  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+    EP_HOST_ASSERT(mode == CombineMode::RANK_LOCAL_REDUCE);
+    tokenMajorGatherReduceCombine(output, input, topkIdx, topkWeights, workload, combineRecvBuffer, dispatchRecvBuffer,
+                                  context.deviceContext_, numBlocks, stream);
   } else if (mode == CombineMode::DIRECT_SEND) {
     expertMajorDirectSendCombine(output, input, topkIdx, topkWeights, srcInfo, layoutRange, workload, combineRecvBuffer,
                                  dispatchRecvBuffer, context.deviceContext_, numBlocks, stream);

--- a/src/ext/ep/latency.cc
+++ b/src/ext/ep/latency.cc
@@ -37,7 +37,7 @@ LatencyContext::LatencyContext(mscclpp::Communicator& communicator, int rank, in
   EP_HOST_ASSERT(numExperts > 0 && numExperts % numRanks_ == 0);
   EP_HOST_ASSERT(numTopk > 0 && numTopk <= 32);
   EP_HOST_ASSERT(outputLayout == DispatchLayout::EXPERT_MAJOR || outputLayout == DispatchLayout::RANK_MAJOR ||
-                 outputLayout == DispatchLayout::TOKEN_MAJOR);
+                 outputLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED);
 
   CUDA_CHECK(cudaGetDevice(&deviceId_));
   EP_HOST_ASSERT(numRanks_ % numNvlRanks == 0);
@@ -196,7 +196,7 @@ void MoERuntime::launchLatencyDispatch(const LatencyDispatchRequest& request) {
     EP_HOST_ASSERT(output == allocationLayout.dispatchOutputBuffer_);
     EP_HOST_ASSERT(outputTopkIdx == allocationLayout.rankMajorTopkIdsBuffer_);
     EP_HOST_ASSERT(outputTopkWeights == allocationLayout.rankMajorTopkWeightsBuffer_);
-  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+  } else if (dispatchLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(output == allocationLayout.dispatchOutputBuffer_);
     EP_HOST_ASSERT(outputTopkIdx == allocationLayout.rankMajorTopkIdsBuffer_);
     EP_HOST_ASSERT(outputTopkWeights == allocationLayout.rankMajorTopkWeightsBuffer_);
@@ -218,10 +218,10 @@ void MoERuntime::launchLatencyDispatch(const LatencyDispatchRequest& request) {
     rankMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount,
                       input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_, numBlocks,
                       stream);
-  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
-    tokenMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout, outputCount,
-                       input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_, numBlocks,
-                       stream);
+  } else if (dispatchLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
+    rankMajorTopkExpandedDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout,
+                                  outputCount, input, topkIdx, topkWeights, workload, dispatchRecvBuffer,
+                                  context.deviceContext_, numBlocks, stream);
   } else {
     expertMajorDispatch(output, outputScales, outputSrcInfo, outputTopkIdx, outputTopkWeights, outputLayout,
                         outputCount, input, topkIdx, topkWeights, workload, dispatchRecvBuffer, context.deviceContext_,
@@ -263,7 +263,7 @@ void MoERuntime::launchLatencyCombine(const LatencyCombineRequest& request) {
   void* dispatchRecvBuffer = allocationLayout.dispatchRecvBuffer_;
   if (dispatchLayout == DispatchLayout::RANK_MAJOR) {
     EP_HOST_ASSERT(input == allocationLayout.combineRecvBuffer_);
-  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+  } else if (dispatchLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(input == allocationLayout.dispatchOutputBuffer_);
   }
 
@@ -287,10 +287,10 @@ void MoERuntime::launchLatencyCombine(const LatencyCombineRequest& request) {
       rankMajorGatherReduceCombine(output, input, topkIdx, topkWeights, srcInfo, layoutRange, workload,
                                    combineRecvBuffer, dispatchRecvBuffer, context.deviceContext_, numBlocks, stream);
     }
-  } else if (dispatchLayout == DispatchLayout::TOKEN_MAJOR) {
+  } else if (dispatchLayout == DispatchLayout::RANK_MAJOR_TOPK_EXPANDED) {
     EP_HOST_ASSERT(mode == CombineMode::RANK_LOCAL_REDUCE);
-    tokenMajorGatherReduceCombine(output, input, topkIdx, topkWeights, workload, combineRecvBuffer, dispatchRecvBuffer,
-                                  context.deviceContext_, numBlocks, stream);
+    rankMajorTopkExpandedGatherReduceCombine(output, input, topkIdx, topkWeights, workload, combineRecvBuffer,
+                                             dispatchRecvBuffer, context.deviceContext_, numBlocks, stream);
   } else if (mode == CombineMode::DIRECT_SEND) {
     expertMajorDirectSendCombine(output, input, topkIdx, topkWeights, srcInfo, layoutRange, workload, combineRecvBuffer,
                                  dispatchRecvBuffer, context.deviceContext_, numBlocks, stream);

--- a/test/python/ep/ep_bench_deepep.py
+++ b/test/python/ep/ep_bench_deepep.py
@@ -41,7 +41,7 @@ def setup_deepep(args, comm, rank, num_ranks, inputs):
     x, topk_idx, topk_weights, _ = inputs
     num_tokens, hidden = args.num_tokens, args.hidden
     num_experts, num_topk = args.num_experts, args.num_topk
-    if args.ep_layout == "token_major":
+    if args.ep_layout in ("token_major", "rank_major_topk_expanded"):
         raise ValueError("DeepEP ElasticBuffer supports rank_major or expert_major layout")
 
     if rank == 0:

--- a/test/python/ep/ep_bench_flashinfer.py
+++ b/test/python/ep/ep_bench_flashinfer.py
@@ -52,7 +52,7 @@ def setup_flashinfer(args, comm, rank, num_ranks, inputs):
             f"warmup={args.num_warmup} iters={args.num_iters}",
             flush=True,
         )
-        if args.ep_layout in ("expert_major", "token_major"):
+        if args.ep_layout in ("expert_major", "token_major", "rank_major_topk_expanded"):
             print(
                 f"[cfg] flashinfer ep_layout={args.ep_layout} requested but unsupported: "
                 "MoeAlltoAll dispatch is fixed rank-major [ep_size, tokens, hidden]; "

--- a/test/python/ep/ep_bench_mscclpp.py
+++ b/test/python/ep/ep_bench_mscclpp.py
@@ -59,15 +59,19 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
         "rank_local_reduce": ep.CombineMode.RANK_LOCAL_REDUCE,
         "direct_send": ep.CombineMode.DIRECT_SEND,
     }[args.combine_mode]
-    if args.ep_layout == "token_major":
-        raise ValueError("MSCCL++ latency mode supports expert_major or rank_major layout")
-    rank_major = args.ep_layout == "rank_major"
-    if rank_major and combine_mode != ep.CombineMode.RANK_LOCAL_REDUCE:
-        raise ValueError("rank-major output requires rank_local_reduce combine")
-    output_layout = ep.DispatchLayout.RANK_MAJOR if rank_major else ep.DispatchLayout.EXPERT_MAJOR
+    requested_layout = args.ep_layout or "expert_major"
+    rank_major = requested_layout == "rank_major"
+    token_major = requested_layout == "token_major"
+    if (rank_major or token_major) and combine_mode != ep.CombineMode.RANK_LOCAL_REDUCE:
+        raise ValueError(f"{requested_layout} output requires rank_local_reduce combine")
+    output_layout = {
+        "expert_major": ep.DispatchLayout.EXPERT_MAJOR,
+        "rank_major": ep.DispatchLayout.RANK_MAJOR,
+        "token_major": ep.DispatchLayout.TOKEN_MAJOR,
+    }[requested_layout]
     dispatch_quant = ep.QuantConfig(format=ep.DispatchDataType.FP8_E4M3) if args.dispatch_dtype == "fp8_e4m3" else None
-    if rank_major and dispatch_quant is not None:
-        raise ValueError("rank-major output supports BF16 dispatch only")
+    if (rank_major or token_major) and dispatch_quant is not None:
+        raise ValueError(f"{requested_layout} output supports BF16 dispatch only")
     dispatch_dtype = torch.float8_e4m3fn if dispatch_quant is not None else torch.bfloat16
     moe_comm = ep.MoECommunicator(
         comm=ep_group,
@@ -90,13 +94,13 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
             f"dispatch_dtype={args.dispatch_dtype} combine_mode={args.combine_mode} cuda_graph={args.cuda_graph}",
             flush=True,
         )
-        print(f"[cfg] mscclpp output_layout={args.ep_layout or 'expert_major'}", flush=True)
+        print(f"[cfg] mscclpp output_layout={requested_layout}", flush=True)
 
     # Hoist output tensors out of the timed loop (the communicator owns its
     # src_info/layout_range/count buffers internally).
     output_buffer = (
         None
-        if rank_major
+        if rank_major or token_major
         else torch.empty((num_local_experts, num_ranks * num_tokens, hidden), dtype=dispatch_dtype, device="cuda")
     )
     expert_output_initialized = False

--- a/test/python/ep/ep_bench_mscclpp.py
+++ b/test/python/ep/ep_bench_mscclpp.py
@@ -31,6 +31,12 @@ def _make_comm_group(comm):
     return CommGroup(torch_group=comm.torch_group) if hasattr(comm, "torch_group") else CommGroup(mpi_comm=comm)
 
 
+def _simulated_latency_expert_output(dispatch_out, ep):
+    if dispatch_out.layout.kind == ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
+        return dispatch_out.tokens
+    return simulated_gemm_output(dispatch_out)
+
+
 # ============================================================================
 # Backend: mscclpp EP (MoECommunicator).
 # ============================================================================
@@ -61,16 +67,18 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
     }[args.combine_mode]
     requested_layout = args.ep_layout or "expert_major"
     rank_major = requested_layout == "rank_major"
-    token_major = requested_layout == "token_major"
-    if (rank_major or token_major) and combine_mode != ep.CombineMode.RANK_LOCAL_REDUCE:
+    rank_major_topk_expanded = requested_layout == "rank_major_topk_expanded"
+    if requested_layout == "token_major":
+        raise ValueError("MSCCL++ latency TOKEN_MAJOR was renamed to rank_major_topk_expanded")
+    if (rank_major or rank_major_topk_expanded) and combine_mode != ep.CombineMode.RANK_LOCAL_REDUCE:
         raise ValueError(f"{requested_layout} output requires rank_local_reduce combine")
     output_layout = {
         "expert_major": ep.DispatchLayout.EXPERT_MAJOR,
         "rank_major": ep.DispatchLayout.RANK_MAJOR,
-        "token_major": ep.DispatchLayout.TOKEN_MAJOR,
+        "rank_major_topk_expanded": ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED,
     }[requested_layout]
     dispatch_quant = ep.QuantConfig(format=ep.DispatchDataType.FP8_E4M3) if args.dispatch_dtype == "fp8_e4m3" else None
-    if (rank_major or token_major) and dispatch_quant is not None:
+    if (rank_major or rank_major_topk_expanded) and dispatch_quant is not None:
         raise ValueError(f"{requested_layout} output supports BF16 dispatch only")
     dispatch_dtype = torch.float8_e4m3fn if dispatch_quant is not None else torch.bfloat16
     moe_comm = ep.MoECommunicator(
@@ -100,7 +108,7 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
     # src_info/layout_range/count buffers internally).
     output_buffer = (
         None
-        if rank_major or token_major
+        if rank_major or rank_major_topk_expanded
         else torch.empty((num_local_experts, num_ranks * num_tokens, hidden), dtype=dispatch_dtype, device="cuda")
     )
     expert_output_initialized = False
@@ -126,11 +134,12 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
     if args.validate:
         v_dispatch_out, v_handle = _dispatch()
         v_out = torch.empty_like(out)
-        validation_input = simulated_gemm_output(v_dispatch_out)
+        validation_input = _simulated_latency_expert_output(v_dispatch_out, ep)
         if v_dispatch_out.combine_input_buffer is not None:
             # Rank-major combine reads the runtime-owned registered buffer, so the
             # simulated expert output has to be staged into it first.
-            v_dispatch_out.combine_input_buffer.copy_(validation_input)
+            if v_dispatch_out.combine_input_buffer.data_ptr() != validation_input.data_ptr():
+                v_dispatch_out.combine_input_buffer.copy_(validation_input)
             validation_input = v_dispatch_out.combine_input_buffer
         moe_comm.combine(validation_input, v_handle, out=v_out)
         torch.cuda.synchronize()
@@ -193,7 +202,7 @@ def _setup_mscclpp_latency(args, comm, rank, num_ranks, inputs):
             _cap["out"], _cap["handle"] = moe_comm.dispatch(x, topk_idx, topk_weights, output_buffer=output_buffer)
 
         def _graph_combine():
-            moe_comm.combine(simulated_gemm_output(_cap["out"]), _cap["handle"], out=out)
+            moe_comm.combine(_simulated_latency_expert_output(_cap["out"], ep), _cap["handle"], out=out)
 
         graph_spec = {
             "dispatch": _graph_dispatch,

--- a/test/python/ep/ep_bench_nccl.py
+++ b/test/python/ep/ep_bench_nccl.py
@@ -30,7 +30,7 @@ def setup_nccl(args, comm, rank, num_ranks, inputs):
     num_tokens, hidden = args.num_tokens, args.hidden
     num_experts, num_topk = args.num_experts, args.num_topk
     num_local_experts = num_experts // num_ranks
-    if args.ep_layout == "token_major":
+    if args.ep_layout in ("token_major", "rank_major_topk_expanded"):
         raise ValueError("NCCL-EP supports expert_major or rank_major layout")
     if args.mode == "latency":
         algorithm = nccl_ep.Algorithm.LOW_LATENCY

--- a/test/python/ep/run_ep_bench_python.py
+++ b/test/python/ep/run_ep_bench_python.py
@@ -199,7 +199,7 @@ def parse_args() -> argparse.Namespace:
         "layout (NCCL-EP=expert_major, MSCCL++ latency=expert_major, MSCCL++ throughput=token_major, "
         "DeepEP=rank_major, FlashInfer=rank_major). "
         "The explicit value is applied where supported: NCCL-EP and DeepEP accept rank_major/expert_major; "
-        "MSCCL++ latency accepts rank_major/expert_major and throughput accepts rank_major/token_major. "
+        "MSCCL++ latency accepts expert_major/rank_major/token_major and throughput accepts rank_major/token_major. "
         "FlashInfer is rank-major only; unsupported requests are "
         "noted and the backend's default layout is kept.",
     )

--- a/test/python/ep/run_ep_bench_python.py
+++ b/test/python/ep/run_ep_bench_python.py
@@ -193,13 +193,14 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--ep-layout",
-        choices=["token_major", "rank_major", "expert_major"],
+        choices=["token_major", "rank_major", "rank_major_topk_expanded", "expert_major"],
         default=None,
         help="received-token dispatch layout. When omitted, each backend uses its own default "
         "layout (NCCL-EP=expert_major, MSCCL++ latency=expert_major, MSCCL++ throughput=token_major, "
         "DeepEP=rank_major, FlashInfer=rank_major). "
         "The explicit value is applied where supported: NCCL-EP and DeepEP accept rank_major/expert_major; "
-        "MSCCL++ latency accepts expert_major/rank_major/token_major and throughput accepts rank_major/token_major. "
+        "MSCCL++ latency accepts expert_major/rank_major/rank_major_topk_expanded and throughput accepts "
+        "rank_major/token_major. "
         "FlashInfer is rank-major only; unsupported requests are "
         "noted and the backend's default layout is kept.",
     )

--- a/test/python/ep/test_latency_multirank.py
+++ b/test/python/ep/test_latency_multirank.py
@@ -408,8 +408,8 @@ def validate_rank_major_topk_expanded_dispatch(
     local_expert_end = local_expert_begin + num_local_experts
 
     for source_rank in range(num_ranks):
-        expected_local_routes = (
-            (all_topk_idx[source_rank] >= local_expert_begin) & (all_topk_idx[source_rank] < local_expert_end)
+        expected_local_routes = (all_topk_idx[source_rank] >= local_expert_begin) & (
+            all_topk_idx[source_rank] < local_expert_end
         )
         assert int(packed_recv_count[source_rank].item()) == int(expected_local_routes.sum().item())
         row_base = source_rank * num_tokens * num_topk

--- a/test/python/ep/test_latency_multirank.py
+++ b/test/python/ep/test_latency_multirank.py
@@ -114,7 +114,7 @@ def parse_args():
     )
     parser.add_argument(
         "--output-layout",
-        choices=("expert_major", "rank_major"),
+        choices=("expert_major", "rank_major", "rank_major_topk_expanded"),
         default="expert_major",
         help="Low-latency dispatch output layout",
     )
@@ -209,6 +209,10 @@ def simulated_rank_major_route_output(dispatch_out):
 
 def stage_simulated_gemm_output(dispatch_out):
     """Build simulated GEMM output in the runtime-owned buffer when required."""
+    import mscclpp.ep as ep
+
+    if dispatch_out.layout.kind == ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED:
+        return dispatch_out.tokens
     combine_input = dispatch_out.combine_input_buffer
     if combine_input is None:
         return simulated_gemm_output(dispatch_out)
@@ -381,6 +385,48 @@ def validate_rank_major_dispatch(
         assert torch.all(dispatch_out.weights[row_end:block_end] == 0)
 
 
+def validate_rank_major_topk_expanded_dispatch(
+    *,
+    rank,
+    num_ranks,
+    num_tokens,
+    num_topk,
+    num_local_experts,
+    dispatch_out,
+    packed_recv_count,
+    all_topk_idx,
+    all_topk_weights,
+    all_x,
+    invalid_token_expert_id,
+):
+    assert all_x is not None
+    assert dispatch_out.topk_ids is not None
+    assert dispatch_out.weights is not None
+    assert dispatch_out.topk_ids.shape == (num_ranks * num_tokens, num_topk)
+    assert dispatch_out.weights.shape == (num_ranks * num_tokens, num_topk)
+    local_expert_begin = rank * num_local_experts
+    local_expert_end = local_expert_begin + num_local_experts
+
+    for source_rank in range(num_ranks):
+        expected_local_routes = (
+            (all_topk_idx[source_rank] >= local_expert_begin) & (all_topk_idx[source_rank] < local_expert_end)
+        )
+        assert int(packed_recv_count[source_rank].item()) == int(expected_local_routes.sum().item())
+        row_base = source_rank * num_tokens * num_topk
+        for token_idx in range(num_tokens):
+            metadata_row = source_rank * num_tokens + token_idx
+            for topk_slot in range(num_topk):
+                route_idx = row_base + token_idx * num_topk + topk_slot
+                expert = int(all_topk_idx[source_rank, token_idx, topk_slot].item())
+                expected_local = local_expert_begin <= expert < local_expert_end
+                expected_id = expert if expected_local else invalid_token_expert_id
+                expected_weight = all_topk_weights[source_rank, token_idx, topk_slot] if expected_local else 0.0
+                assert int(dispatch_out.topk_ids[metadata_row, topk_slot].item()) == expected_id
+                torch.testing.assert_close(dispatch_out.weights[metadata_row, topk_slot], expected_weight)
+                if expected_local:
+                    assert torch.equal(dispatch_out.tokens[route_idx], all_x[source_rank, token_idx])
+
+
 def reconstruct_expert_major_reference(
     *,
     rank,
@@ -513,6 +559,7 @@ def main():
     output_layout = {
         "expert_major": ep.DispatchLayout.EXPERT_MAJOR,
         "rank_major": ep.DispatchLayout.RANK_MAJOR,
+        "rank_major_topk_expanded": ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED,
     }[args.output_layout]
     if output_layout == ep.DispatchLayout.RANK_MAJOR:
         assert combine_mode in (
@@ -597,7 +644,11 @@ def main():
     dispatch_output_shape = (
         (num_local_experts, num_ranks * num_tokens, hidden)
         if output_layout == ep.DispatchLayout.EXPERT_MAJOR
-        else (num_ranks * num_tokens, hidden)
+        else (
+            (num_ranks * num_tokens * num_topk, hidden)
+            if output_layout == ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED
+            else (num_ranks * num_tokens, hidden)
+        )
     )
     assert moe_comm._context.dispatch_output_buffer is dispatch_output_buffer
     dispatch_out, handle = moe_comm.dispatch(
@@ -609,7 +660,7 @@ def main():
     assert dispatch_out.tokens.data_ptr() == dispatch_output_buffer.data_ptr()
     assert tuple(dispatch_out.tokens.shape) == dispatch_output_shape
     assert dispatch_out.tokens.dtype == dispatch_dtype
-    if output_layout == ep.DispatchLayout.RANK_MAJOR:
+    if output_layout in (ep.DispatchLayout.RANK_MAJOR, ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED):
         assert dispatch_out.combine_input_buffer is not None
         if combine_mode == ep.CombineMode.RANK_LOCAL_REDUCE:
             assert dispatch_out.combine_input_buffer.data_ptr() == dispatch_out.tokens.data_ptr()
@@ -636,7 +687,10 @@ def main():
     dist.all_gather_into_tensor(all_topk_weights, local_topk_weights, group=group)
     all_x = None
     expected_scales = None
-    if dispatch_quant is not None or output_layout == ep.DispatchLayout.RANK_MAJOR:
+    if dispatch_quant is not None or output_layout in (
+        ep.DispatchLayout.RANK_MAJOR,
+        ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED,
+    ):
         all_x = torch.empty((num_ranks, num_tokens, hidden), dtype=x.dtype, device="cuda")
         dist.all_gather_into_tensor(all_x, x, group=group)
     if dispatch_quant is not None:
@@ -671,20 +725,35 @@ def main():
             expected_scales=expected_scales,
         )
     else:
-        validate_rank_major_dispatch(
-            rank=rank,
-            num_ranks=num_ranks,
-            num_tokens=num_tokens,
-            num_topk=num_topk,
-            num_local_experts=num_local_experts,
-            dispatch_out=dispatch_out,
-            handle=handle,
-            packed_recv_count=packed_recv_count,
-            all_topk_idx=all_topk_idx,
-            all_topk_weights=all_topk_weights,
-            all_x=all_x,
-            invalid_token_expert_id=invalid_token_expert_id,
-        )
+        if output_layout == ep.DispatchLayout.RANK_MAJOR:
+            validate_rank_major_dispatch(
+                rank=rank,
+                num_ranks=num_ranks,
+                num_tokens=num_tokens,
+                num_topk=num_topk,
+                num_local_experts=num_local_experts,
+                dispatch_out=dispatch_out,
+                handle=handle,
+                packed_recv_count=packed_recv_count,
+                all_topk_idx=all_topk_idx,
+                all_topk_weights=all_topk_weights,
+                all_x=all_x,
+                invalid_token_expert_id=invalid_token_expert_id,
+            )
+        else:
+            validate_rank_major_topk_expanded_dispatch(
+                rank=rank,
+                num_ranks=num_ranks,
+                num_tokens=num_tokens,
+                num_topk=num_topk,
+                num_local_experts=num_local_experts,
+                dispatch_out=dispatch_out,
+                packed_recv_count=packed_recv_count,
+                all_topk_idx=all_topk_idx,
+                all_topk_weights=all_topk_weights,
+                all_x=all_x,
+                invalid_token_expert_id=invalid_token_expert_id,
+            )
 
     if rank == 0:
         print(f"[dispatch] OK (ranks={num_ranks})", flush=True)
@@ -774,7 +843,7 @@ def main():
     def _run_cuda_graph_correctness():
         graph_dispatch_output_buffer = (
             dispatch_output_buffer
-            if output_layout == ep.DispatchLayout.RANK_MAJOR
+            if output_layout in (ep.DispatchLayout.RANK_MAJOR, ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED)
             else (None if dispatch_output_buffer is None else torch.empty_like(dispatch_output_buffer))
         )
         graph_out = torch.empty_like(out)
@@ -808,7 +877,7 @@ def main():
     iters = args.bench_iters
     bench_dispatch_output_buffer = (
         dispatch_output_buffer
-        if output_layout == ep.DispatchLayout.RANK_MAJOR
+        if output_layout in (ep.DispatchLayout.RANK_MAJOR, ep.DispatchLayout.RANK_MAJOR_TOPK_EXPANDED)
         else (None if dispatch_output_buffer is None else torch.empty_like(dispatch_output_buffer))
     )
 


### PR DESCRIPTION
Enable latency-mode TOKEN_MAJOR dispatch/combine support and wire the unified Python EP benchmark to exercise the new layout.